### PR TITLE
Clarify initiative calculation

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -151,7 +151,7 @@ button:active{transform:translateY(1px)}
     <div class="grid grid-2">
       <div class="card">
         <label>Initiative</label>
-        <input id="initiative" type="number" inputmode="numeric" placeholder="auto from DEX + bonuses" readonly/>
+        <input id="initiative" type="number" inputmode="numeric" placeholder="auto from DEX" readonly/>
         <label>Speed (ft)</label>
         <input id="speed" type="number" inputmode="numeric" placeholder="30"/>
       </div>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Catalyst Core Character Tracker
 
 Hosted version of the mobile-optimized character sheet for GitHub Pages.
+
+Initiative is automatically calculated from the Dexterity modifier.


### PR DESCRIPTION
## Summary
- Remove reference to bonus fields in initiative placeholder
- Note in documentation that initiative is derived from Dexterity alone

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d2a08328832eac694bdf2268029a