### PR TITLE
Document serialization schema and add round-trip test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/Index.html
+++ b/Index.html
@@ -668,6 +668,23 @@ async function getRTDB(){
   const db=getDatabase(app);
   return { db, ref, get, set };
 }
+/*
+  Serialize current character sheet to a plain object.
+  Schema:
+  {
+    <input id>: value,
+    powers:      [{ name, sp, save, range, effect }],
+    signatures:  [{ name, sp, save, special, desc }],
+    weapons:     [{ name, damage, range }],
+    armor:       [{ name, slot, bonus, equipped }],
+    items:       [{ name, qty, notes }]
+  }
+  DOM expectations:
+  - All simple fields are standard inputs with unique ids.
+  - Repeating sections (powers, signatures, weapons, armor, items)
+    consist of cards marked with a `data-kind` attribute and
+    inputs within them labeled by `data-f` for each field.
+*/
 function serialize(){
   const data={};
   qsa('input,select,textarea').forEach(el=>{
@@ -706,6 +723,13 @@ function serialize(){
   }));
   return data;
 }
+/*
+  Populate the DOM from a serialized character object following the
+  schema described above. Expects container elements with ids
+  `powers`, `sigs`, `weapons`, `armors`, and `items` to hold the
+  repeating card entries. Each card is rebuilt using the corresponding
+  `card*` helper and simple fields are matched by element id.
+*/
 function deserialize(data){
   $('powers').innerHTML=''; $('sigs').innerHTML=''; $('weapons').innerHTML=''; $('armors').innerHTML=''; $('items').innerHTML='';
   Object.entries(data||{}).forEach(([k,v])=>{ const el=$(k); if (!el) return; if (el.type==='checkbox') el.checked=!!v; else el.value=v; });

--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # Catalyst Core Character Tracker
 
 Hosted version of the mobile-optimized character sheet for GitHub Pages.
+
+### Example serialized character
+
+```json
+{
+  "superhero": "Nova",
+  "player": "Alice",
+  "powers": [
+    { "name": "Fire Blast", "sp": "2", "save": "Dex", "range": "30ft", "effect": "2d6 fire" }
+  ],
+  "weapons": [
+    { "name": "Sword", "damage": "1d8", "range": "5ft" }
+  ],
+  "armor": [
+    { "name": "Leather", "slot": "Body", "bonus": 2, "equipped": true }
+  ],
+  "items": [
+    { "name": "Potion", "qty": 1, "notes": "" }
+  ]
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ccccg",
+  "version": "1.0.0",
+  "description": "Catalyst Core Character Tracker tests",
+  "devDependencies": {
+    "jsdom": "^24.0.0"
+  },
+  "scripts": {
+    "test": "node tests/roundtrip.test.js"
+  }
+}

--- a/tests/roundtrip.test.js
+++ b/tests/roundtrip.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const assert = require('assert');
+const { JSDOM, VirtualConsole } = require('jsdom');
+const vm = require('vm');
+
+const html = fs.readFileSync('Index.html', 'utf8');
+const vc = new VirtualConsole();
+vc.sendTo(console);
+const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://localhost', virtualConsole: vc });
+
+// Execute the module script in the DOM context so helper functions are attached to window
+const script = dom.window.document.querySelector('script[type="module"]').textContent;
+vm.runInContext(script, dom.getInternalVMContext());
+
+const sample = {
+  superhero: 'Nova',
+  powers: [
+    { name: 'Fire Blast', sp: '2', save: 'Dex', range: '30ft', effect: '2d6 fire' }
+  ],
+  weapons: [
+    { name: 'Sword', damage: '1d8', range: '5ft' }
+  ],
+  armor: [
+    { name: 'Leather', slot: 'Body', bonus: 2, equipped: true }
+  ],
+  items: [
+    { name: 'Potion', qty: 1, notes: '' }
+  ]
+};
+
+// Populate DOM with sample data, then serialize again and ensure it matches
+if (typeof dom.window.deserialize !== 'function' || typeof dom.window.serialize !== 'function') {
+  throw new Error('serialize/deserialize functions not found');
+}
+
+dom.window.deserialize(sample);
+const serialized = dom.window.serialize();
+
+const subset = JSON.parse(JSON.stringify({
+  superhero: serialized.superhero,
+  powers: serialized.powers,
+  weapons: serialized.weapons,
+  armor: serialized.armor,
+  items: serialized.items
+}));
+
+assert.deepStrictEqual(subset, sample);
+
+console.log('Round-trip serialization successful');


### PR DESCRIPTION
## Summary
- document serialization data schema and DOM expectations
- add example serialized character JSON to README
- add Node/JSDOM round-trip serialization test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2d3131934832e8a8ff9e52689d5b4