### PR TITLE
feat: externalize Firebase config

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -52,19 +52,7 @@ button:active{transform:translateY(1px)}
 </head>
 <body>
 
-<!-- Firebase config -->
-<script id="firebase-config" type="application/json">
-{
-  "apiKey": "AIzaSyAYENVrM2komgm2Nteg388YewLiVuUOlIw",
-  "authDomain": "catalyst-core-e458c.firebaseapp.com",
-  "databaseURL": "https://catalyst-core-e458c-default-rtdb.firebaseio.com",
-  "projectId": "catalyst-core-e458c",
-  "storageBucket": "catalyst-core-e458c.firebasestorage.app",
-  "messagingSenderId": "494771671712",
-  "appId": "1:494771671712:web:0587e669cd5f7d3be92fc5",
-  "measurementId": "G-R3JS5GWKFM"
-}
-</script>
+<!-- Firebase config is loaded from firebase-config.json -->
 
 <header>
   <div class="top">
@@ -652,9 +640,18 @@ $('enc-reset').addEventListener('click', ()=>{ if(!confirm('Reset encounter and 
 qsa('#modal-enc [data-close]').forEach(b=> b.addEventListener('click', ()=> hide('modal-enc')));
 
 /* ========= Save / Load (cloud-first, silent local mirror) ========= */
+let firebaseCfgPromise;
+async function loadFirebaseConfig(){
+  if(!firebaseCfgPromise){
+    const url = window.FIREBASE_CONFIG_URL || 'firebase-config.json';
+    firebaseCfgPromise = fetch(url).then(r=>r.ok?r.json():null).catch(()=>null);
+  }
+  let cfg = await firebaseCfgPromise;
+  if(window.FIREBASE_CONFIG) cfg = Object.assign({}, cfg, window.FIREBASE_CONFIG);
+  return cfg;
+}
 async function getRTDB(){
-  const cfgEl = $('firebase-config'); if(!cfgEl) return null;
-  let cfg=null; try{ cfg=JSON.parse(cfgEl.textContent) }catch(e){}
+  const cfg = await loadFirebaseConfig();
   if (!cfg || !cfg.apiKey || !cfg.databaseURL) return null;
   const [{ initializeApp }, { getAuth, signInAnonymously, onAuthStateChanged }, { getDatabase, ref, get, set }] = await Promise.all([
     import('https://www.gstatic.com/firebasejs/12.0.0/firebase-app.js'),

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # Catalyst Core Character Tracker
 
 Hosted version of the mobile-optimized character sheet for GitHub Pages.
+
+## Firebase Configuration
+
+Firebase settings are now stored in a standalone `firebase-config.json` file. The
+application fetches this file at runtime and initializes Firebase with the
+retrieved values.
+
+For different environments you can provide alternate configuration values in
+several ways:
+
+1. **Replace the file** – deploy a different `firebase-config.json` alongside
+   `Index.html`.
+2. **Point to another file** – set a global `FIREBASE_CONFIG_URL` before the
+   main script loads to fetch a different JSON file (e.g. `firebase-config.prod.json`).
+3. **Override individual fields** – define a global `FIREBASE_CONFIG` object to
+   merge/override values from the fetched JSON. This pattern works well with
+   environment variables injected by your hosting platform.
+
+Example:
+
+```html
+<script>
+  window.FIREBASE_CONFIG = {
+    apiKey: '$FIREBASE_API_KEY',
+    authDomain: '$FIREBASE_AUTH_DOMAIN'
+  };
+</script>
+```

--- a/firebase-config.json
+++ b/firebase-config.json
@@ -1,0 +1,10 @@
+{
+  "apiKey": "AIzaSyAYENVrM2komgm2Nteg388YewLiVuUOlIw",
+  "authDomain": "catalyst-core-e458c.firebaseapp.com",
+  "databaseURL": "https://catalyst-core-e458c-default-rtdb.firebaseio.com",
+  "projectId": "catalyst-core-e458c",
+  "storageBucket": "catalyst-core-e458c.firebasestorage.app",
+  "messagingSenderId": "494771671712",
+  "appId": "1:494771671712:web:0587e669cd5f7d3be92fc5",
+  "measurementId": "G-R3JS5GWKFM"
+}


### PR DESCRIPTION
## Summary
- move Firebase credentials from inline `<script>` into standalone `firebase-config.json`
- fetch and merge configuration at runtime, allowing overrides via `FIREBASE_CONFIG_URL` or `FIREBASE_CONFIG`
- document configuration override strategies for deployments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d939347c832e91b97497d0578fe4