### PR TITLE
Improve form semantics with labelled inputs and fieldsets

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -56,53 +56,60 @@
   <section data-tab="combat">
     <h2>Tools</h2>
     <div class="grid grid-2">
-      <div class="card">
-        <label>Dice Roller</label>
+      <fieldset class="card">
+        <legend>Dice Roller</legend>
         <div class="inline">
+          <label for="dice-sides" class="sr-only">Sides</label>
           <select id="dice-sides"><option>4</option><option>6</option><option>8</option><option>10</option><option>12</option><option selected>20</option><option>100</option></select>
+          <label for="dice-count" class="sr-only">Count</label>
           <input id="dice-count" type="number" inputmode="numeric" min="1" value="1" style="max-width:120px"/>
           <button id="roll-dice" style="max-width:160px">Roll</button>
         </div>
         <div class="small" id="dice-out"></div>
-      </div>
-      <div class="card">
-        <label>Coin Flip</label>
+      </fieldset>
+      <fieldset class="card">
+        <legend>Coin Flip</legend>
         <div class="inline">
           <button id="flip">Flip</button>
           <span class="pill" id="flip-out"></span>
         </div>
-      </div>
+      </fieldset>
     </div>
   </section>
 
   <section data-tab="combat">
     <h2>Combat Stats</h2>
     <div class="grid grid-2">
-      <div class="card">
-        <label>HP</label>
+      <fieldset class="card">
+        <legend>HP</legend>
         <div class="inline">
           <progress id="hp-bar" max="10" value="10" style="width:100%"></progress>
           <span class="pill" id="hp-pill">10/10</span>
         </div>
         <div class="inline">
+          <label for="hp-roll" class="sr-only">Tier Roll</label>
           <input id="hp-roll" type="number" inputmode="numeric" placeholder="Tier Roll"/>
+          <label for="hp-bonus" class="sr-only">Bonus HP</label>
           <input id="hp-bonus" type="number" inputmode="numeric" placeholder="Bonus HP"/>
         </div>
         <div class="inline">
+          <label for="hp-temp" class="sr-only">Temp HP</label>
           <input id="hp-temp" type="number" inputmode="numeric" placeholder="Temp HP"/>
+          <label for="hp-amt" class="sr-only">Amount</label>
           <input id="hp-amt" type="number" inputmode="numeric" placeholder="Amount"/>
           <button id="hp-dmg" class="btn-sm">Damage</button>
           <button id="hp-heal" class="btn-sm">Heal</button>
           <button id="hp-full" class="btn-sm">Reset HP</button>
         </div>
-      </div>
-      <div class="card">
-        <label>SP</label>
+      </fieldset>
+      <fieldset class="card">
+        <legend>SP</legend>
         <div class="inline">
           <progress id="sp-bar" max="5" value="5" style="width:100%"></progress>
           <span class="pill" id="sp-pill">5/5</span>
         </div>
         <div class="inline">
+          <label for="sp-temp" class="sr-only">Temp SP</label>
           <input id="sp-temp" type="number" inputmode="numeric" placeholder="Temp SP"/>
           <button class="btn-sm" data-sp="-1">-1 SP</button>
           <button class="btn-sm" data-sp="-2">-2 SP</button>
@@ -110,26 +117,28 @@
           <button id="sp-full" class="btn-sm">Reset SP</button>
         </div>
         <div class="inline"><button id="long-rest" class="btn-sm">Long Rest</button></div>
-      </div>
+      </fieldset>
     </div>
 
     <div class="grid grid-2">
-      <div class="card">
-        <label>Initiative</label>
+      <fieldset class="card">
+        <legend>Initiative &amp; Speed</legend>
+        <label for="initiative">Initiative</label>
         <input id="initiative" type="number" inputmode="numeric" placeholder="auto from DEX + bonuses" readonly/>
-        <label>Speed (ft)</label>
+        <label for="speed">Speed (ft)</label>
         <input id="speed" type="number" inputmode="numeric" placeholder="30"/>
-      </div>
-      <div class="card">
-        <label>Passive Perception</label>
+      </fieldset>
+      <fieldset class="card">
+        <legend>Defense Stats</legend>
+        <label for="pp">Passive Perception</label>
         <input id="pp" type="number" readonly/>
-        <label>Armor/Shield Bonus (auto)</label>
+        <label for="armor-bonus">Armor/Shield Bonus (auto)</label>
         <input id="armor-bonus" type="number" readonly/>
-        <label>Power/Origin Bonus</label>
+        <label for="origin-bonus">Power/Origin Bonus</label>
         <input id="origin-bonus" type="number" inputmode="numeric" value="0"/>
-        <label>TC</label>
+        <label for="tc">TC</label>
         <input id="tc" type="number" readonly/>
-      </div>
+      </fieldset>
     </div>
   </section>
 
@@ -137,25 +146,26 @@
   <section data-tab="abilities">
     <h2>Ability Scores</h2>
     <div class="grid grid-3" id="abil-grid"></div>
-    <div class="card">
+    <fieldset class="card">
+      <legend>Proficiency &amp; Power</legend>
       <div class="inline">
         <div style="flex:1">
-          <label>Proficiency Bonus</label>
+          <label for="prof-bonus">Proficiency Bonus</label>
           <input id="prof-bonus" type="number" inputmode="numeric" value="2"/>
         </div>
         <div style="flex:1">
-          <label>Power Save Ability</label>
+          <label for="power-save-ability">Power Save Ability</label>
           <select id="power-save-ability">
             <option value="str">STR</option><option value="dex">DEX</option><option value="con">CON</option>
             <option value="int">INT</option><option value="wis" selected>WIS</option><option value="cha">CHA</option>
           </select>
         </div>
         <div style="flex:1">
-          <label>Power Save DC</label>
+          <label for="power-save-dc">Power Save DC</label>
           <input id="power-save-dc" type="number" readonly/>
         </div>
       </div>
-    </div>
+    </fieldset>
   </section>
 
   <!-- POWERS -->
@@ -179,19 +189,19 @@
     <div class="grid grid-2">
       <div class="card">
         <div class="inline" style="justify-content:space-between">
-          <label>Weapons</label><button id="add-weapon" class="btn-sm" style="max-width:140px">Add Weapon</button>
+          <h3 style="margin:0">Weapons</h3><button id="add-weapon" class="btn-sm" style="max-width:140px">Add Weapon</button>
         </div>
         <div id="weapons" class="grid grid-1"></div>
       </div>
       <div class="card">
         <div class="inline" style="justify-content:space-between">
-          <label>Armor & Protection</label><button id="add-armor" class="btn-sm" style="max-width:160px">Add Armor</button>
+          <h3 style="margin:0">Armor &amp; Protection</h3><button id="add-armor" class="btn-sm" style="max-width:160px">Add Armor</button>
         </div>
         <div id="armors" class="grid grid-1"></div>
       </div>
       <div class="card" style="grid-column:1/-1">
         <div class="inline" style="justify-content:space-between">
-          <label>Gear & Items</label>
+          <h3 style="margin:0">Gear &amp; Items</h3>
           <div class="inline">
             <button id="add-item" class="btn-sm" style="max-width:140px">Add Item</button>
             <button id="open-catalog" class="btn-sm" style="max-width:160px">Open Gear Catalog</button>
@@ -206,14 +216,14 @@
   <section data-tab="story">
     <h2>Character & Story</h2>
     <div class="grid grid-2">
-      <div class="card"><label>Superhero Identity</label><input id="superhero" placeholder="Vigil name"/></div>
-      <div class="card"><label>Secret Identity</label><input id="secret" placeholder="Real name"/></div>
+      <div class="card"><label for="superhero">Superhero Identity</label><input id="superhero" placeholder="Vigil name"/></div>
+      <div class="card"><label for="secret">Secret Identity</label><input id="secret" placeholder="Real name"/></div>
       <div class="card">
-        <label>Public Identity</label>
+        <label for="publicIdentity">Public Identity</label>
         <select id="publicIdentity"><option value="Public">Public</option><option value="Secret" selected>Secret</option></select>
       </div>
       <div class="card">
-        <label>Tier</label>
+        <label for="tier">Tier</label>
         <select id="tier">
           <option>Tier 5 – Rookie</option>
           <option>Tier 4 – Emerging Vigilante</option>
@@ -224,7 +234,7 @@
         </select>
       </div>
       <div class="card">
-        <label>Alignment</label>
+        <label for="alignment">Alignment</label>
         <select id="alignment">
           <option>Paragon (Lawful Light)</option>
           <option>Guardian (Neutral Light)</option>
@@ -238,20 +248,20 @@
         </select>
       </div>
       <div class="card">
-        <label>Classification</label>
+        <label for="classification">Classification</label>
         <select id="classification">
           <option>Mutant</option><option>Enhanced Human</option><option>Magic User</option><option>Alien/Extraterrestrial</option><option>Mystical Being</option>
         </select>
       </div>
       <div class="card">
-        <label>Primary Power Style</label>
+        <label for="power-style">Primary Power Style</label>
         <select id="power-style">
           <option>Physical Powerhouse</option><option>Energy Manipulator</option><option>Speedster</option>
           <option>Telekinetic/Psychic</option><option>Illusionist</option><option>Shape-shifter</option><option>Elemental Controller</option>
         </select>
       </div>
       <div class="card">
-        <label>Secondary Power Style</label>
+        <label for="power-style-2">Secondary Power Style</label>
         <select id="power-style-2">
           <option>None</option>
           <option>Physical Powerhouse</option><option>Energy Manipulator</option><option>Speedster</option>
@@ -261,7 +271,7 @@
     </div>
 
     <div class="card">
-      <label>Backstory / Notes</label>
+      <label for="story-notes">Backstory / Notes</label>
       <textarea id="story-notes" rows="6" placeholder="Key events, allies, vulnerabilities, research/training notes, etc."></textarea>
     </div>
   </section>
@@ -277,11 +287,14 @@
     </button>
     <h3>Encounter Tracker</h3>
     <div class="inline" style="margin-bottom:6px"><span class="pill" id="round-pill">Round 1</span></div>
-    <div class="inline">
+    <fieldset class="inline">
+      <legend class="sr-only">Add Combatant</legend>
+      <label for="enc-name" class="sr-only">Name</label>
       <input id="enc-name" placeholder="Name"/>
+      <label for="enc-init" class="sr-only">Init</label>
       <input id="enc-init" type="number" inputmode="numeric" placeholder="Init"/>
       <button id="enc-add" class="btn-sm">Add</button>
-    </div>
+    </fieldset>
     <div id="enc-list" class="catalog" style="margin-top:8px"></div>
     <div class="actions">
       <button id="enc-next" class="btn-sm">Next Round</button>
@@ -300,8 +313,8 @@
     </button>
     <h3>Recent Log</h3>
     <div class="grid grid-2">
-      <div><label>Dice</label><div id="log-dice" class="catalog"></div></div>
-      <div><label>Coins</label><div id="log-coin" class="catalog"></div></div>
+      <div><h4 style="margin:0">Dice</h4><div id="log-dice" class="catalog"></div></div>
+      <div><h4 style="margin:0">Coins</h4><div id="log-coin" class="catalog"></div></div>
     </div>
     <div class="actions"><button class="btn-sm" data-close>Close</button></div>
   </div>
@@ -316,7 +329,7 @@
       </svg>
     </button>
     <h3>Save Character</h3>
-    <label>Save name</label>
+    <label for="save-key">Save name</label>
     <input id="save-key" placeholder="e.g., Shawn"/>
     <div class="actions"><button id="do-save">Save</button></div>
   </div>
@@ -329,7 +342,7 @@
       </svg>
     </button>
     <h3>Load Character</h3>
-    <label>Save name</label>
+    <label for="load-key">Save name</label>
     <input id="load-key" placeholder="Enter save name"/>
     <div class="actions"><button id="do-load">Load</button></div>
   </div>
@@ -344,12 +357,17 @@
       </svg>
     </button>
     <h3>Gear Catalog</h3>
-    <div class="inline" style="margin:6px 0">
+    <fieldset class="inline" style="margin:6px 0">
+      <legend class="sr-only">Filters</legend>
+      <label for="catalog-filter-style" class="sr-only">Style</label>
       <select id="catalog-filter-style" style="max-width:260px"></select>
+      <label for="catalog-filter-type" class="sr-only">Type</label>
       <select id="catalog-filter-type" style="max-width:180px"><option value="">All Types</option><option>Armor</option><option>Shield</option><option>Utility</option></select>
+      <label for="catalog-filter-rarity" class="sr-only">Rarity</label>
       <select id="catalog-filter-rarity" style="max-width:160px"><option value="">All Rarities</option><option>Common</option><option>Uncommon</option><option>Rare</option><option>Elite</option><option>Legendary</option></select>
+      <label for="catalog-search" class="sr-only">Search</label>
       <input id="catalog-search" placeholder="Search..."/>
-    </div>
+    </fieldset>
     <div id="catalog-list" class="catalog"></div>
   </div>
 </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -26,6 +26,7 @@ input,select,textarea,button{width:100%;border-radius:12px;border:1px solid var(
 button{background:var(--accent);color:#041319;border:none;font-weight:700;min-height:44px;cursor:pointer}
 button:active{transform:translateY(1px)}
 .btn-sm{min-height:36px;padding:8px 10px;border-radius:10px}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .inline{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
 .card{border:1px solid var(--line);border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:10px}


### PR DESCRIPTION
## Summary
- add `fieldset`/`legend` and id-linked labels for combat tools and stats
- label story, modal, and catalog inputs for better accessibility
- introduce `.sr-only` utility class for non-visual labels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e87bc3c4832e85e97b1e3b9511e2