### PR TITLE
feat: add light theme with toggle

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -40,6 +40,14 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
         </svg>
       </button>
+      <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme">
+        <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 3V5.25M18.364 5.63604L16.773 7.22703M21 12H18.75M18.364 18.364L16.773 16.773M12 18.75V21M7.22703 16.773L5.63604 18.364M5.25 12H3M7.22703 7.22703L5.63604 5.63604M15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z"/>
+        </svg>
+        <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" style="display:none">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/>
+        </svg>
+      </button>
     </div>
   </div>
   <div class="tabs">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -30,6 +30,23 @@ function toast(msg, type='info'){
   setTimeout(()=>t.classList.remove('show'),1200);
 }
 
+/* ========= theme ========= */
+const root = document.documentElement;
+const btnTheme = $('btn-theme');
+function applyTheme(t){
+  root.classList.toggle('theme-light', t==='light');
+  if(btnTheme){
+    qs('#icon-sun', btnTheme).style.display = t==='light' ? 'none' : 'block';
+    qs('#icon-moon', btnTheme).style.display = t==='light' ? 'block' : 'none';
+  }
+}
+applyTheme(localStorage.getItem('theme')==='light'?'light':'dark');
+btnTheme?.addEventListener('click', ()=>{
+  const next = root.classList.contains('theme-light') ? 'dark' : 'light';
+  localStorage.setItem('theme', next);
+  applyTheme(next);
+});
+
 /* ========= tabs ========= */
 function setTab(name){
   qsa('section[data-tab]').forEach(s=> s.style.display = s.getAttribute('data-tab')===name ? 'block':'none');

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,4 +1,5 @@
-:root{--bg:#0e1117;--surface:#151a23;--text:#e5e7eb;--muted:#9aa3af;--accent:#3cc6ff;--accent-2:#2563eb;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35)}
+:root{--bg:#0e1117;--surface:#151a23;--surface-2:#0b0f16;--text:#e5e7eb;--muted:#9aa3af;--accent:#3cc6ff;--accent-2:#2563eb;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#041319}
+:root.theme-light{--bg:#f9fafb;--surface:#fff;--surface-2:#f3f4f6;--text:#111827;--muted:#6b7280;--accent:#2563eb;--accent-2:#1e3a8a;--line:rgba(0,0,0,.1);--shadow:0 8px 28px rgba(0,0,0,.2);--text-on-accent:#fff}
 *{box-sizing:border-box}
 html,body{height:100%}
 body{margin:0;background:var(--bg);color:var(--text);font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased}
@@ -6,13 +7,13 @@ header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var
 .top{display:flex;align-items:center;justify-content:space-between;gap:10px}
 h1{margin:0;font-size:1.1rem;color:var(--accent);font-weight:700}
 .actions{display:flex;gap:8px}
-.icon{width:40px;height:40px;border-radius:10px;background:#0b0f16;border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center}
+.icon{width:40px;height:40px;border-radius:10px;background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center}
 .icon svg,.modal .x svg{width:24px;height:24px}
 .icon:active{transform:translateY(1px)}
 .icon:focus-visible,.modal .x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .tabs{margin-top:10px;display:flex;gap:8px;flex-wrap:wrap}
-.tab{flex:1 0 110px;padding:10px 12px;border-radius:10px;border:1px solid var(--accent);background:#0b0f16;color:var(--text);font-weight:700;text-align:center}
-.tab.active{background:var(--accent);color:#041319}
+.tab{flex:1 0 110px;padding:10px 12px;border-radius:10px;border:1px solid var(--accent);background:var(--surface-2);color:var(--text);font-weight:700;text-align:center}
+.tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{max-width:980px;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}
 section{background:var(--surface);border:1px solid var(--line);border-radius:16px;padding:14px;margin-bottom:14px;box-shadow:var(--shadow)}
 section h2{margin:0 0 10px;color:var(--accent);font-size:1.05rem}
@@ -22,8 +23,8 @@ section h2{margin:0 0 10px;color:var(--accent);font-size:1.05rem}
 .grid-3{grid-template-columns:1fr}
 @media(min-width:820px){.grid-2{grid-template-columns:repeat(2,1fr)}.grid-3{grid-template-columns:repeat(3,1fr)}}
 label{display:block;font-weight:700;margin-bottom:6px}
-input,select,textarea,button{width:100%;border-radius:12px;border:1px solid var(--accent);background:#0b0f16;color:var(--text);padding:12px}
-button{background:var(--accent);color:#041319;border:none;font-weight:700;min-height:44px;cursor:pointer}
+input,select,textarea,button{width:100%;border-radius:12px;border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:12px}
+button{background:var(--accent);color:var(--text-on-accent);border:none;font-weight:700;min-height:44px;cursor:pointer}
 button:active{transform:translateY(1px)}
 .btn-sm{min-height:36px;padding:8px 10px;border-radius:10px}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}


### PR DESCRIPTION
## Summary
- add parallel light theme variables and use a `.theme-light` root class
- add theme toggle button with sun/moon icon and persist preference in localStorage
- update controls to inherit surface colors for both themes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ee9f45ec832e8bfe039f146cad74