### PR TITLE
Handle log parsing errors

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -105,8 +105,15 @@ qsa('[data-sp]').forEach(b=> b.addEventListener('click', ()=> setSP(num($('sp-ba
 $('long-rest').addEventListener('click', ()=>{ setHP(num($('hp-bar').max)); setSP(num($('sp-bar').max)); });
 
 /* ========= Dice/Coin + Logs ========= */
-const diceLog = JSON.parse(localStorage.getItem('dice-log')||'[]');
-const coinLog = JSON.parse(localStorage.getItem('coin-log')||'[]');
+function safeParse(key){
+  try{
+    return JSON.parse(localStorage.getItem(key)||'[]');
+  }catch(e){
+    return [];
+  }
+}
+const diceLog = safeParse('dice-log');
+const coinLog = safeParse('coin-log');
 const fmt = (ts)=>new Date(ts).toLocaleTimeString();
 function pushLog(arr, entry, key){ arr.push(entry); if (arr.length>30) arr.splice(0, arr.length-30); localStorage.setItem(key, JSON.stringify(arr)); }
 function renderLogs(){


### PR DESCRIPTION
## Summary
- avoid crashes when loading dice/coin logs by safely parsing localStorage data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f4e71cac832eba11849a2df97b16