### PR TITLE
Handle missing Firebase config gracefully

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -385,11 +385,19 @@ async function loadFirebaseConfig(){
   }
   let cfg = await firebaseCfgPromise;
   if(window.FIREBASE_CONFIG) cfg = Object.assign({}, cfg, window.FIREBASE_CONFIG);
+  if(!cfg || !cfg.apiKey || !cfg.databaseURL){
+    console.warn('Cloud config missing required fields', cfg);
+    toast('Cloud config missing.','error');
+    return null;
+  }
   return cfg;
 }
 async function getRTDB(){
   const cfg = await loadFirebaseConfig();
-  if (!cfg || !cfg.apiKey || !cfg.databaseURL) return null;
+  if (!cfg){
+    console.warn('RTDB init skipped: no cloud config');
+    return null;
+  }
   try{
     const [{ initializeApp }, { getAuth, signInAnonymously, onAuthStateChanged }, { getDatabase, ref, get, set }] = await Promise.all([
       import('https://www.gstatic.com/firebasejs/12.0.0/firebase-app.js'),


### PR DESCRIPTION
## Summary
- Warn and show toast when Firebase config lacks `apiKey` or `databaseURL`
- Skip RTDB initialization when cloud config is missing to avoid silent failures

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f4e8e894832e9fa57fea5bcc912c