### PR TITLE
Expand CCCCG support with classification perks and downtime tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Hosted version of the mobile-optimized character sheet for GitHub Pages.
 
+## CCCCG Features
+
+- Auto-fills classification perks along with matching resistances and vulnerabilities and displays power-style and origin perks
+- Offers origin story options and extensive character questions for backstory building
+- Provides skill proficiency tracking with auto-calculated modifiers
+- Tracks cinematic points and resistances in the combat tab
+- Logs downtime activities like Research, Training, and Media Control for campaign bookkeeping
+
 ## Firebase Configuration
 
 Firebase settings are now stored in a standalone `firebase-config.json` file. The

--- a/index.html
+++ b/index.html
@@ -148,6 +148,29 @@
         <input id="tc" type="number" readonly/>
       </fieldset>
     </div>
+
+    <div class="grid grid-2">
+      <fieldset class="card">
+        <legend>Cinematic Points</legend>
+        <div class="inline">
+          <progress id="cp-bar" max="1" value="1" style="width:100%"></progress>
+          <span class="pill" id="cp-pill">1/1</span>
+        </div>
+        <div class="inline">
+          <label for="cp-amt" class="sr-only">Amount</label>
+          <input id="cp-amt" type="number" inputmode="numeric" placeholder="Amount"/>
+          <button id="cp-use" class="btn-sm">Use</button>
+          <button id="cp-reset" class="btn-sm">Reset</button>
+        </div>
+      </fieldset>
+      <fieldset class="card">
+        <legend>Resistances &amp; Vulnerabilities</legend>
+        <label for="resist">Resistances</label>
+        <input id="resist" placeholder="e.g., Fire, Psychic"/>
+        <label for="vuln">Vulnerabilities</label>
+        <input id="vuln" placeholder="e.g., Cold, Force"/>
+      </fieldset>
+    </div>
   </section>
 
   <!-- ABILITIES -->
@@ -173,6 +196,14 @@
           <input id="power-save-dc" type="number" readonly/>
         </div>
       </div>
+    </fieldset>
+    <fieldset class="card">
+      <legend>Saving Throws</legend>
+      <div class="grid grid-3" id="saves"></div>
+    </fieldset>
+    <fieldset class="card">
+      <legend>Skills</legend>
+      <div class="grid grid-3" id="skills"></div>
     </fieldset>
   </section>
 
@@ -261,6 +292,7 @@
           <option>Mutant</option><option>Enhanced Human</option><option>Magic User</option><option>Alien/Extraterrestrial</option><option>Mystical Being</option>
         </select>
       </div>
+      <div class="card"><label for="class-perk">Classification Perk</label><input id="class-perk" readonly placeholder="Perk"/></div>
       <div class="card">
         <label for="power-style">Primary Power Style</label>
         <select id="power-style">
@@ -268,6 +300,7 @@
           <option>Telekinetic/Psychic</option><option>Illusionist</option><option>Shape-shifter</option><option>Elemental Controller</option>
         </select>
       </div>
+      <div class="card"><label for="style-perk">Primary Style Perk</label><input id="style-perk" readonly placeholder="Perk"/></div>
       <div class="card">
         <label for="power-style-2">Secondary Power Style</label>
         <select id="power-style-2">
@@ -276,11 +309,57 @@
           <option>Telekinetic/Psychic</option><option>Illusionist</option><option>Shape-shifter</option><option>Elemental Controller</option>
         </select>
       </div>
+      <div class="card"><label for="style2-perk">Secondary Style Perk</label><input id="style2-perk" readonly placeholder="Perk"/></div>
+      <div class="card">
+        <label for="origin">Origin Story</label>
+        <select id="origin">
+          <option>The Accident</option>
+          <option>The Experiment</option>
+          <option>The Legacy</option>
+          <option>The Awakening</option>
+          <option>The Pact</option>
+          <option>The Lost Time</option>
+          <option>The Exposure</option>
+          <option>The Rebirth</option>
+          <option>The Vigil</option>
+          <option>The Redemption</option>
+        </select>
+      </div>
+      <div class="card"><label for="origin-perk">Origin Perk</label><input id="origin-perk" readonly placeholder="Perk"/></div>
     </div>
 
     <div class="card">
       <label for="story-notes">Backstory / Notes</label>
       <textarea id="story-notes" rows="6" placeholder="Key events, allies, vulnerabilities, research/training notes, etc."></textarea>
+    </div>
+    <h3>Character Questions</h3>
+    <div class="grid grid-1">
+      <div class="card"><label for="q-mask">Who are you behind the mask?</label><textarea id="q-mask" rows="2"></textarea></div>
+      <div class="card"><label for="q-justice">What does justice mean to you?</label><textarea id="q-justice" rows="2"></textarea></div>
+      <div class="card"><label for="q-fear">What is your biggest fear or unresolved trauma?</label><textarea id="q-fear" rows="2"></textarea></div>
+      <div class="card"><label for="q-first-power">What moment first defined your sense of power—was it thrilling, terrifying, or tragic?</label><textarea id="q-first-power" rows="2"></textarea></div>
+      <div class="card"><label for="q-origin-meaning">What does your Origin Story mean to you now?</label><textarea id="q-origin-meaning" rows="2"></textarea></div>
+      <div class="card"><label for="q-before-powers">What was your life like before you had powers or before you remembered having them?</label><textarea id="q-before-powers" rows="2"></textarea></div>
+      <div class="card"><label for="q-power-scare">What is one way your powers scare even you?</label><textarea id="q-power-scare" rows="2"></textarea></div>
+      <div class="card"><label for="q-signature-move">What is your signature move or ability, and how does it reflect who you are?</label><textarea id="q-signature-move" rows="2"></textarea></div>
+      <div class="card"><label for="q-emotional">What happens to your powers when you are emotionally compromised?</label><textarea id="q-emotional" rows="2"></textarea></div>
+      <div class="card"><label for="q-no-line">What line will you never cross even if the world burns around you?</label><textarea id="q-no-line" rows="2"></textarea></div>
+      <div class="card"><label for="q-alignment-fear">Which Alignment do you identify with, and which do you fear becoming?</label><textarea id="q-alignment-fear" rows="2"></textarea></div>
+      <div class="card"><label for="q-opinion">Whose opinion matters more to you—civilians, teammates, or your faction superiors? Why?</label><textarea id="q-opinion" rows="2"></textarea></div>
+      <div class="card"><label for="q-drive">What drives you to fight—justice, guilt, revenge, legacy, redemption, or something else?</label><textarea id="q-drive" rows="2"></textarea></div>
+      <div class="card"><label for="q-walk-away">What would make you walk away from this life for good?</label><textarea id="q-walk-away" rows="2"></textarea></div>
+      <div class="card"><label for="q-secret">What is one major secret you are keeping from the rest of the team?</label><textarea id="q-secret" rows="2"></textarea></div>
+      <div class="card"><label for="q-vulnerable">What situation leaves you the most vulnerable—physically, emotionally, or strategically?</label><textarea id="q-vulnerable" rows="2"></textarea></div>
+      <div class="card"><label for="q-admire">Which teammate do you admire the most and what do they have that you lack?</label><textarea id="q-admire" rows="2"></textarea></div>
+      <div class="card"><label for="q-if-lost">If you lost your powers tomorrow, who would you still be?</label><textarea id="q-if-lost" rows="2"></textarea></div>
+    </div>
+    <h3>Downtime Activities</h3>
+    <div class="grid grid-1">
+      <div class="card"><label for="dt-media">Media Control</label><textarea id="dt-media" rows="2"></textarea></div>
+      <div class="card"><label for="dt-research">Research</label><textarea id="dt-research" rows="2"></textarea></div>
+      <div class="card"><label for="dt-train">Train or Tinker</label><textarea id="dt-train" rows="2"></textarea></div>
+      <div class="card"><label for="dt-intel">Gather Intel</label><textarea id="dt-intel" rows="2"></textarea></div>
+      <div class="card"><label for="dt-personal">Personal Time</label><textarea id="dt-personal" rows="2"></textarea></div>
     </div>
   </section>
 </main>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -62,6 +62,40 @@ abilGrid.innerHTML = ABILS.map(a=>`
   </div>`).join('');
 ABILS.forEach(a=>{ const sel=$(a); for(let v=10; v<=24; v++) sel.add(new Option(v,v)); sel.value='10'; });
 
+const saveGrid = $('saves');
+saveGrid.innerHTML = ABILS.map(a=>`
+  <div class="card">
+    <label>${a.toUpperCase()}</label>
+    <div class="inline"><input type="checkbox" id="save-${a}-prof"/><span class="pill" id="save-${a}">+0</span></div>
+  </div>`).join('');
+
+const SKILLS = [
+  { name: 'Acrobatics', abil: 'dex' },
+  { name: 'Animal Handling', abil: 'wis' },
+  { name: 'Arcana', abil: 'int' },
+  { name: 'Athletics', abil: 'str' },
+  { name: 'Deception', abil: 'cha' },
+  { name: 'History', abil: 'int' },
+  { name: 'Insight', abil: 'wis' },
+  { name: 'Intimidation', abil: 'cha' },
+  { name: 'Investigation', abil: 'int' },
+  { name: 'Medicine', abil: 'wis' },
+  { name: 'Nature', abil: 'int' },
+  { name: 'Perception', abil: 'wis' },
+  { name: 'Performance', abil: 'cha' },
+  { name: 'Persuasion', abil: 'cha' },
+  { name: 'Religion', abil: 'int' },
+  { name: 'Sleight of Hand', abil: 'dex' },
+  { name: 'Stealth', abil: 'dex' },
+  { name: 'Survival', abil: 'wis' }
+];
+const skillGrid = $('skills');
+skillGrid.innerHTML = SKILLS.map((s,i)=>`
+  <div class="card">
+    <label>${s.name}</label>
+    <div class="inline"><input type="checkbox" id="skill-${i}-prof"/><span class="pill" id="skill-${i}">+0</span></div>
+  </div>`).join('');
+
 /* ========= cached elements ========= */
 const elPP = $('pp');
 const elTC = $('tc');
@@ -81,6 +115,18 @@ const elInitiative = $('initiative');
 const elProfBonus = $('prof-bonus');
 const elPowerSaveAbility = $('power-save-ability');
 const elPowerSaveDC = $('power-save-dc');
+const elClass = $('classification');
+const elClassPerk = $('class-perk');
+const elResist = $('resist');
+const elVuln = $('vuln');
+const elCPBar = $('cp-bar');
+const elCPPill = $('cp-pill');
+const elStyle = $('power-style');
+const elStyle2 = $('power-style-2');
+const elStylePerk = $('style-perk');
+const elStyle2Perk = $('style2-perk');
+const elOrigin = $('origin');
+const elOriginPerk = $('origin-perk');
 
 /* ========= derived helpers ========= */
 function updateSP(){
@@ -107,9 +153,72 @@ function updateDerived(){
   elInitiative.value = mod(elDex.value);
   const pb = num(elProfBonus.value)||2;
   elPowerSaveDC.value = 8 + pb + mod($( elPowerSaveAbility.value ).value);
+  ABILS.forEach(a=>{
+    const val = mod($(a).value) + ($('save-'+a+'-prof')?.checked ? pb : 0);
+    $('save-'+a).textContent = (val>=0?'+':'') + val;
+  });
+  SKILLS.forEach((s,i)=>{
+    const val = mod($(s.abil).value) + ($('skill-'+i+'-prof')?.checked ? pb : 0);
+    $('skill-'+i).textContent = (val>=0?'+':'') + val;
+  });
 }
 ABILS.forEach(a=> $(a).addEventListener('change', updateDerived));
 ['hp-roll','hp-bonus','hp-temp','origin-bonus','prof-bonus','power-save-ability'].forEach(id=> $(id).addEventListener('input', updateDerived));
+ABILS.forEach(a=> $('save-'+a+'-prof').addEventListener('change', updateDerived));
+SKILLS.forEach((s,i)=> $('skill-'+i+'-prof').addEventListener('change', updateDerived));
+
+const CLASS_DATA = {
+  'Mutant': { perk: 'Reroll one failed saving throw per long rest.', res: 'Radiation, Psychic', vuln: 'Necrotic, Force' },
+  'Enhanced Human': { perk: 'Advantage on all Technology-related checks.', res: 'Piercing, Fire', vuln: 'Psychic, Radiation' },
+  'Magic User': { perk: 'Cast one minor magical effect (prestidigitation) per long rest.', res: 'Force, Necrotic', vuln: 'Confusion, Radiation' },
+  'Alien/Extraterrestrial': { perk: 'Immune to environmental hazard and no penalty to movement in rough terrain.', res: 'Cold, Acid, Lightning', vuln: 'Radiant, Emotion' },
+  'Mystical Being': { perk: '+2 to Persuasion or Intimidation checks.', res: 'Corruption, Radiation', vuln: 'Radiant, Psychic' }
+};
+
+const STYLE_DATA = {
+  'Physical Powerhouse': 'Cut one attack by half once per combat encounter.',
+  'Energy Manipulator': 'Reroll 1s once per turn.',
+  'Speedster': '+10 ft movement and +1 AC while moving 20+ ft.',
+  'Telekinetic/Psychic': 'Force enemies to reroll all rolls above a 17 once per rest.',
+  'Illusionist': 'Create a 1-min decoy illusion once per combat encounter.',
+  'Shape-shifter': 'Advantage on Deception, disguise freely.',
+  'Elemental Controller': '+2 to hit and +5 to damage once per turn when using elemental powers.'
+};
+
+const ORIGIN_DATA = {
+  'The Accident': 'Resistance to one damage type.',
+  'The Experiment': 'Reroll a failed CON or INT save once per long rest.',
+  'The Legacy': 'Use the powers of one other character you’ve met or are related to once per long rest.',
+  'The Awakening': '+5 to hit and +10 to damage when below ½ HP.',
+  'The Pact': 'Auto-success on one save or +10 to any roll once per long rest.',
+  'The Lost Time': 'Once per combat when using a power, roll a d20 (DC17); on success it costs no SP and gains +1d6 bonus.',
+  'The Exposure': '+5 elemental damage once per round.',
+  'The Rebirth': 'If knocked out, stand up with 1 HP and resistance to all damage for 1 round.',
+  'The Vigil': 'Create a shield once per combat reducing ally damage to 0 for one turn.',
+  'The Redemption': 'Once per day take damage for an ally to heal them 1d6 and give advantage; after combat you gain advantage on all saves till dawn.'
+};
+function updateClassDetails(){
+  const d = CLASS_DATA[elClass.value] || {};
+  elClassPerk.value = d.perk || '';
+  elResist.value = d.res || '';
+  elVuln.value = d.vuln || '';
+}
+elClass.addEventListener('change', updateClassDetails);
+updateClassDetails();
+
+function updateStyleDetails(){
+  elStylePerk.value = STYLE_DATA[elStyle.value] || '';
+  elStyle2Perk.value = STYLE_DATA[elStyle2.value] || '';
+}
+elStyle.addEventListener('change', updateStyleDetails);
+elStyle2.addEventListener('change', updateStyleDetails);
+updateStyleDetails();
+
+function updateOriginDetails(){
+  elOriginPerk.value = ORIGIN_DATA[elOrigin.value] || '';
+}
+elOrigin.addEventListener('change', updateOriginDetails);
+updateOriginDetails();
 
 /* ========= HP/SP controls ========= */
 function setHP(v){
@@ -126,6 +235,14 @@ $('hp-full').addEventListener('click', ()=> setHP(num(elHPBar.max)));
 $('sp-full').addEventListener('click', ()=> setSP(num(elSPBar.max)));
 qsa('[data-sp]').forEach(b=> b.addEventListener('click', ()=> setSP(num(elSPBar.value) + num(b.dataset.sp)||0) ));
 $('long-rest').addEventListener('click', ()=>{ setHP(num(elHPBar.max)); setSP(num(elSPBar.max)); });
+
+function setCP(v){
+  elCPBar.value = Math.max(0, Math.min(num(elCPBar.max), v));
+  elCPPill.textContent = `${num(elCPBar.value)}/${num(elCPBar.max)}`;
+}
+$('cp-use').addEventListener('click', ()=>{ const d=num($('cp-amt').value)||0; setCP(num(elCPBar.value)-d); });
+$('cp-reset').addEventListener('click', ()=> setCP(num(elCPBar.max)));
+setCP(num(elCPBar.value)||num(elCPBar.max));
 
 /* ========= Dice/Coin + Logs ========= */
 function safeParse(key){


### PR DESCRIPTION
## Summary
- auto-fill classification perks plus resistances and vulnerabilities
- show power-style and origin perks in the Story tab
- track cinematic points and resistances in the combat tab
- add downtime activity notes for campaign bookkeeping
- expose origin story options and detailed character questions
- provide skill proficiency tracking with auto-calculated modifiers
- document these CCCCG enhancements in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f997a104832eaea62d50fcfec204