### PR TITLE
Add offline autosave and undo history

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,10 @@
         <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 3V5.25M18.364 5.63604L16.773 7.22703M21 12H18.75M18.364 18.364L16.773 16.773M12 18.75V21M7.22703 16.773L5.63604 18.364M5.25 12H3M7.22703 7.22703L5.63604 5.63604M15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z"/>
         </svg>
+        <svg id="icon-contrast" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" style="display:none">
+          <circle cx="12" cy="12" r="9"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v18"/>
+        </svg>
         <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" style="display:none">
           <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/>
         </svg>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -27,19 +27,37 @@ function toast(msg, type='info'){
   setTimeout(()=>t.classList.remove('show'),1200);
 }
 
+function debounce(fn, ms=300){
+  let t;
+  return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn(...args), ms); };
+}
+
+// prevent negative numbers in numeric inputs
+document.addEventListener('input', e=>{
+  const el = e.target;
+  if(el.matches('input[type="number"]') && el.value !== '' && Number(el.value) < 0){
+    el.value = 0;
+  }
+});
+
 /* ========= theme ========= */
 const root = document.documentElement;
 const btnTheme = $('btn-theme');
 function applyTheme(t){
-  root.classList.toggle('theme-light', t==='light');
+  root.classList.remove('theme-light','theme-high');
+  if(t==='light') root.classList.add('theme-light');
+  if(t==='high') root.classList.add('theme-high');
   if(btnTheme){
-    qs('#icon-sun', btnTheme).style.display = t==='light' ? 'none' : 'block';
-    qs('#icon-moon', btnTheme).style.display = t==='light' ? 'block' : 'none';
+    qs('#icon-sun', btnTheme).style.display = t==='dark' ? 'block' : 'none';
+    qs('#icon-contrast', btnTheme).style.display = t==='light' ? 'block' : 'none';
+    qs('#icon-moon', btnTheme).style.display = t==='high' ? 'block' : 'none';
   }
 }
-applyTheme(localStorage.getItem('theme')==='light'?'light':'dark');
+applyTheme(localStorage.getItem('theme') || 'dark');
 btnTheme?.addEventListener('click', ()=>{
-  const next = root.classList.contains('theme-light') ? 'dark' : 'light';
+  const themes=['dark','light','high'];
+  const curr=localStorage.getItem('theme')||'dark';
+  const next=themes[(themes.indexOf(curr)+1)%themes.length];
   localStorage.setItem('theme', next);
   applyTheme(next);
 });
@@ -317,6 +335,7 @@ function createCard(kind, pref = {}) {
   delBtn.addEventListener('click', () => {
     card.remove();
     if (cfg.onDelete) cfg.onDelete();
+    pushHistory();
   });
   delWrap.appendChild(delBtn);
   card.appendChild(delWrap);
@@ -326,13 +345,13 @@ function createCard(kind, pref = {}) {
   return card;
 }
 
-$('add-power').addEventListener('click', () => $('powers').appendChild(createCard('power')));
-$('add-sig').addEventListener('click', () => $('sigs').appendChild(createCard('sig')));
+$('add-power').addEventListener('click', () => { $('powers').appendChild(createCard('power')); pushHistory(); });
+$('add-sig').addEventListener('click', () => { $('sigs').appendChild(createCard('sig')); pushHistory(); });
 
 /* ========= Gear ========= */
-$('add-weapon').addEventListener('click', () => $('weapons').appendChild(createCard('weapon')));
-$('add-armor').addEventListener('click', () => $('armors').appendChild(createCard('armor')));
-$('add-item').addEventListener('click', () => $('items').appendChild(createCard('item')));
+$('add-weapon').addEventListener('click', () => { $('weapons').appendChild(createCard('weapon')); pushHistory(); });
+$('add-armor').addEventListener('click', () => { $('armors').appendChild(createCard('armor')); pushHistory(); });
+$('add-item').addEventListener('click', () => { $('items').appendChild(createCard('item')); pushHistory(); });
 
 /* ========= Gear Catalog (seeded; extend as needed) ========= */
 const CATALOG = (()=>{ const mk=(style,type,rarity,name,tc,notes)=>({style,type,rarity,name,tc,notes}); const out=[];
@@ -547,6 +566,44 @@ function deserialize(data){
   (data?.items||[]).forEach(i=> $('items').appendChild(createCard('item', i)));
   updateDerived();
 }
+
+/* ========= autosave + history ========= */
+const AUTO_KEY = 'autosave';
+let history = [];
+let histIdx = -1;
+const pushHistory = debounce(()=>{
+  const snap = serialize();
+  history = history.slice(0, histIdx + 1);
+  history.push(snap);
+  if(history.length > 20){ history.shift(); }
+  histIdx = history.length - 1;
+  try{ localStorage.setItem(AUTO_KEY, JSON.stringify(snap)); }catch(e){ console.error('Autosave failed', e); }
+}, 500);
+
+document.addEventListener('input', pushHistory);
+document.addEventListener('change', pushHistory);
+
+function undo(){
+  if(histIdx > 0){ histIdx--; deserialize(history[histIdx]); }
+}
+function redo(){
+  if(histIdx < history.length - 1){ histIdx++; deserialize(history[histIdx]); }
+}
+
+document.addEventListener('keydown', e=>{
+  if(e.ctrlKey && e.key==='z'){ e.preventDefault(); undo(); }
+  else if(e.ctrlKey && (e.key==='y' || (e.shiftKey && e.key==='Z'))){ e.preventDefault(); redo(); }
+  else if(e.ctrlKey && e.key==='s'){ e.preventDefault(); $('btn-save')?.click(); }
+});
+
+(function(){
+  const raw = localStorage.getItem(AUTO_KEY);
+  if(raw){
+    try{ const data = JSON.parse(raw); deserialize(data); history=[data]; histIdx=0; }
+    catch(e){ console.error('Auto-load failed', e); }
+  }
+  pushHistory();
+})();
 const ENCODE = (s)=>encodeURIComponent(String(s||''));
 async function saveCloud(name, payload){
   const r = await getRTDB().catch(err=>{ console.error('RTDB init failed', err); return null; });
@@ -616,3 +673,6 @@ qsa('.overlay').forEach(ov=> ov.addEventListener('click', (e)=>{ if (e.target===
 
 /* ========= boot ========= */
 updateDerived();
+if('serviceWorker' in navigator){
+  navigator.serviceWorker.register('sw.js').catch(e=>console.error('SW reg failed', e));
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,12 +1,17 @@
 :root{--bg:#0e1117;--surface:#151a23;--surface-2:#0b0f16;--text:#e5e7eb;--muted:#9aa3af;--accent:#3cc6ff;--accent-2:#2563eb;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#041319}
 :root.theme-light{--bg:#f9fafb;--surface:#fff;--surface-2:#f3f4f6;--text:#111827;--muted:#6b7280;--accent:#2563eb;--accent-2:#1e3a8a;--line:rgba(0,0,0,.1);--shadow:0 8px 28px rgba(0,0,0,.2);--text-on-accent:#fff}
+:root.theme-high{--bg:#000;--surface:#000;--surface-2:#000;--text:#fff;--muted:#fff;--accent:#ff0;--accent-2:#0ff;--line:#fff;--shadow:none;--text-on-accent:#000}
 *{box-sizing:border-box}
 html,body{height:100%}
-body{margin:0;background:var(--bg);color:var(--text);font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+body{margin:0;background:var(--bg);color:var(--text);font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased;overflow-x:hidden}
 header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(12px + env(safe-area-inset-top)) 14px 12px}
 .top{display:flex;align-items:center;justify-content:space-between;gap:10px}
 h1{margin:0;font-size:1.1rem;color:var(--accent);font-weight:700}
 .actions{display:flex;gap:8px}
+@media(max-width:600px){
+  .top{flex-direction:column;align-items:flex-start}
+  .actions{flex-wrap:wrap}
+}
 .icon{width:40px;height:40px;border-radius:10px;background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center}
 .icon svg,.modal .x svg{width:24px;height:24px}
 .icon:active{transform:translateY(1px)}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,21 @@
+const CACHE = 'cccg-cache-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './styles/main.css',
+  './scripts/main.js',
+  './scripts/helpers.js'
+];
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
+});
+self.addEventListener('activate', e => {
+  e.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k))))
+  );
+});
+self.addEventListener('fetch', e => {
+  e.respondWith(
+    caches.match(e.request).then(res => res || fetch(e.request))
+  );
+});


### PR DESCRIPTION
## Summary
- Add high contrast theme and cycle theme toggle through dark, light, and high contrast
- Prevent negative values in numeric inputs
- Wrap header actions on small screens to reduce horizontal scrolling
- Cache core assets with a service worker and autosave state locally for offline use
- Track state history with undo/redo and keyboard shortcuts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a32a9420ec832eb7886afae25a0414