### PR TITLE
Remove PDF export and streamline encounter tracker; revamp XP tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,11 +40,6 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
         </svg>
       </button>
-      <button id="btn-pdf" class="icon" aria-label="Export PDF" title="Export PDF">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75V3h-10.5v3.75m10.5 0h1.5a2.25 2.25 0 0 1 2.25 2.25v7.5a2.25 2.25 0 0 1-2.25 2.25h-1.5m0-12H6.75m10.5 0v12m-10.5-12h-1.5A2.25 2.25 0 0 0 3 9v7.5A2.25 2.25 0 0 0 5.25 18.75h1.5m0 0V21h10.5v-2.25m-10.5 0h10.5"/>
-        </svg>
-      </button>
       <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme">
         <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 3V5.25M18.364 5.63604L16.773 7.22703M21 12H18.75M18.364 18.364L16.773 16.773M12 18.75V21M7.22703 16.773L5.63604 18.364M5.25 12H3M7.22703 7.22703L5.63604 5.63604M15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z"/>
@@ -251,12 +246,12 @@
       <div class="card">
         <label for="tier">Tier</label>
         <select id="tier">
-          <option>Tier 5 – Rookie</option>
-          <option>Tier 4 – Emerging Vigilante</option>
-          <option>Tier 3 – Field-Tested Operative</option>
-          <option>Tier 2 – Respected Force</option>
-          <option>Tier 1 – Heroic Figure</option>
-          <option>Tier 0 – Transcendent</option>
+          <option value="0">Tier 5 – Rookie (Starting)</option>
+          <option value="2000">Tier 4 – Emerging Vigilante (2,000 XP)</option>
+          <option value="6000">Tier 3 – Field-Tested Operative (6,000 XP)</option>
+          <option value="18000">Tier 2 – Respected Force (18,000 XP)</option>
+          <option value="54000">Tier 1 – Heroic Figure (54,000 XP)</option>
+          <option value="162000">Tier 0 – Transcendent / Legendary (162,000 XP)</option>
         </select>
       </div>
       <div class="card" style="grid-column:1/-1">
@@ -265,6 +260,12 @@
           <input id="xp" type="number" inputmode="numeric" value="0" min="0" style="max-width:120px"/>
           <progress id="xp-bar" max="100" value="0" style="flex:1"></progress>
           <span id="xp-pill" class="pill">0/100</span>
+        </div>
+        <div class="inline">
+          <label for="xp-amt" class="sr-only">Amount</label>
+          <input id="xp-amt" type="number" inputmode="numeric" placeholder="Amount"/>
+          <button id="xp-add" class="btn-sm">Add XP</button>
+          <button id="xp-remove" class="btn-sm">Remove XP</button>
         </div>
       </div>
       <div class="card">
@@ -373,7 +374,7 @@
       </svg>
     </button>
     <h3>Encounter Tracker</h3>
-    <div class="inline" style="margin-bottom:6px"><span class="pill" id="round-pill">Round 1</span></div>
+    <div class="inline" style="margin-bottom:6px"><span class="pill" id="round-pill">Round 1</span><span class="pill" id="turn-pill"></span></div>
     <fieldset class="inline">
       <legend class="sr-only">Add Combatant</legend>
       <label for="enc-name" class="sr-only">Name</label>
@@ -384,7 +385,7 @@
     </fieldset>
     <div id="enc-list" class="catalog" style="margin-top:8px"></div>
     <div class="actions">
-      <button id="enc-next" class="btn-sm">Next Round</button>
+      <button id="enc-next" class="btn-sm">Next Turn</button>
       <button id="enc-reset" class="btn-sm">Reset</button>
     </div>
   </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -146,6 +146,9 @@ const elPowerSaveDC = $('power-save-dc');
 const elXP = $('xp');
 const elXPBar = $('xp-bar');
 const elXPPill = $('xp-pill');
+const elTier = $('tier');
+
+const XP_TIERS = [0, 2000, 6000, 18000, 54000, 162000];
 
 /* ========= derived helpers ========= */
 function updateSP(){
@@ -163,11 +166,26 @@ function updateHP(){
 }
 
 function updateXP(){
-  const next = 100;
-  const val = Math.max(0, num(elXP.value)) % next;
-  elXPBar.max = next;
-  elXPBar.value = val;
-  elXPPill.textContent = `${val}/${next}`;
+  const xp = Math.max(0, num(elXP.value));
+  let idx = 0;
+  for(let i=XP_TIERS.length-1;i>=0;i--){
+    if(xp >= XP_TIERS[i]){ idx = i; break; }
+  }
+  if(elTier) elTier.selectedIndex = idx;
+  const nextXP = XP_TIERS[idx+1];
+  const prevXP = XP_TIERS[idx];
+  if(nextXP){
+    const val = xp - prevXP;
+    const diff = nextXP - prevXP;
+    elXPBar.max = diff;
+    elXPBar.value = val;
+    elXPPill.textContent = `${val}/${diff}`;
+  }else{
+    const val = xp - prevXP;
+    elXPBar.max = 1;
+    elXPBar.value = 1;
+    elXPPill.textContent = `${val}+`;
+  }
 }
 
 function updateDerived(){
@@ -195,6 +213,24 @@ ABILS.forEach(a=> $(a).addEventListener('change', updateDerived));
 ABILS.forEach(a=> $('save-'+a+'-prof').addEventListener('change', updateDerived));
 SKILLS.forEach((s,i)=> $('skill-'+i+'-prof').addEventListener('change', updateDerived));
 elXP?.addEventListener('input', updateXP);
+
+function setXP(v){
+  elXP.value = Math.max(0, v);
+  updateXP();
+}
+$('xp-add').addEventListener('click', ()=>{
+  const inp = $('xp-amt');
+  const d = Math.abs(num(inp.value)) || 0;
+  if(d) setXP(num(elXP.value) + d);
+  inp.value = '';
+});
+$('xp-remove').addEventListener('click', ()=>{
+  const inp = $('xp-amt');
+  const d = Math.abs(num(inp.value)) || 0;
+  if(d) setXP(num(elXP.value) - d);
+  inp.value = '';
+});
+elTier?.addEventListener('change', ()=> setXP(num(elTier.value)));
 
 /* ========= HP/SP controls ========= */
 function setHP(v){
@@ -392,7 +428,6 @@ $('add-sig').addEventListener('click', () => { $('sigs').appendChild(createCard(
 $('add-weapon').addEventListener('click', () => { $('weapons').appendChild(createCard('weapon')); pushHistory(); });
 $('add-armor').addEventListener('click', () => { $('armors').appendChild(createCard('armor')); pushHistory(); });
 $('add-item').addEventListener('click', () => { $('items').appendChild(createCard('item')); pushHistory(); });
-$('btn-pdf').addEventListener('click', () => window.print());
 
 /* ========= Drag & Drop ========= */
 function enableDragReorder(id){
@@ -532,31 +567,64 @@ $('open-catalog').addEventListener('click', ()=>{ renderCatalog(); show('modal-c
 
 /* ========= Encounter / Initiative ========= */
 let round = Number(localStorage.getItem('enc-round')||'1')||1;
+let turn = Number(localStorage.getItem('enc-turn')||'0')||0;
 const roster = JSON.parse(localStorage.getItem('enc-roster')||'[]');
-function saveEnc(){ localStorage.setItem('enc-roster', JSON.stringify(roster)); localStorage.setItem('enc-round', String(round)); }
+function saveEnc(){
+  localStorage.setItem('enc-roster', JSON.stringify(roster));
+  localStorage.setItem('enc-round', String(round));
+  localStorage.setItem('enc-turn', String(turn));
+}
 function renderEnc(){
   $('round-pill').textContent='Round '+round;
   const list=$('enc-list'); list.innerHTML='';
-  roster.sort((a,b)=>(b.init||0)-(a.init||0) || String(a.name).localeCompare(String(b.name)));
   roster.forEach((r,idx)=>{
-    const row=document.createElement('div'); row.className='catalog-item';
-    row.innerHTML = `<div class="pill">${r.init}</div><div><b>${r.name}</b></div>
-      <div class="inline" style="gap:6px">
-        <button class="btn-sm" data-up="${idx}">▲</button>
-        <button class="btn-sm" data-down="${idx}">▼</button>
-        <button class="btn-sm" data-del="${idx}">Delete</button>
-      </div>`;
+    const row=document.createElement('div');
+    row.className='catalog-item'+(idx===turn?' active':'');
+    row.innerHTML = `<div class="pill">${r.init}</div><div><b>${r.name}</b></div><div><button class="btn-sm" data-del="${idx}">Delete</button></div>`;
     list.appendChild(row);
   });
-  qsa('[data-del]', $('enc-list')).forEach(b=> b.addEventListener('click', ()=>{ roster.splice(Number(b.dataset.del),1); renderEnc(); saveEnc(); }));
-  qsa('[data-up]', $('enc-list')).forEach(b=> b.addEventListener('click', ()=>{ const i=Number(b.dataset.up); if(i>0){ const t=roster[i-1]; roster[i-1]=roster[i]; roster[i]=t; renderEnc(); saveEnc(); }}));
-  qsa('[data-down]', $('enc-list')).forEach(b=> b.addEventListener('click', ()=>{ const i=Number(b.dataset.down); if(i<roster.length-1){ const t=roster[i+1]; roster[i+1]=roster[i]; roster[i]=t; renderEnc(); saveEnc(); }}));
+  const turnName = roster[turn]?.name || '';
+  const turnEl = $('turn-pill');
+  if(turnEl){
+    turnEl.textContent = turnName ? `Turn: ${turnName}` : '';
+    turnEl.style.display = turnName ? '' : 'none';
+  }
+  qsa('[data-del]', list).forEach(b=> b.addEventListener('click', ()=>{
+    const i=Number(b.dataset.del);
+    roster.splice(i,1);
+    if(turn>=roster.length) turn=0;
+    renderEnc();
+    saveEnc();
+  }));
 }
 $('btn-enc').addEventListener('click', ()=>{ renderEnc(); show('modal-enc'); });
-$('enc-add').addEventListener('click', ()=>{ const name=$('enc-name').value.trim(); const init=Number($('enc-init').value||0);
-  if(!name) return toast('Enter a name','error'); roster.push({name, init}); $('enc-name').value=''; $('enc-init').value=''; renderEnc(); saveEnc(); });
-$('enc-next').addEventListener('click', ()=>{ round+=1; renderEnc(); saveEnc(); });
-$('enc-reset').addEventListener('click', ()=>{ if(!confirm('Reset encounter and round?')) return; round=1; roster.length=0; renderEnc(); saveEnc(); });
+$('enc-add').addEventListener('click', ()=>{
+  const name=$('enc-name').value.trim();
+  const init=Number($('enc-init').value||0);
+  if(!name) return toast('Enter a name','error');
+  roster.push({name, init});
+  roster.sort((a,b)=>(b.init||0)-(a.init||0) || String(a.name).localeCompare(String(b.name)));
+  $('enc-name').value='';
+  $('enc-init').value='';
+  turn=0;
+  renderEnc();
+  saveEnc();
+});
+$('enc-next').addEventListener('click', ()=>{
+  if(!roster.length) return;
+  turn = (turn + 1) % roster.length;
+  if(turn===0) round+=1;
+  renderEnc();
+  saveEnc();
+});
+$('enc-reset').addEventListener('click', ()=>{
+  if(!confirm('Reset encounter and round?')) return;
+  round=1;
+  turn=0;
+  roster.length=0;
+  renderEnc();
+  saveEnc();
+});
 qsa('#modal-enc [data-close]').forEach(b=> b.addEventListener('click', ()=> hide('modal-enc')));
 
 /* ========= Save / Load (cloud-first, silent local mirror) ========= */
@@ -757,7 +825,7 @@ $('do-load').addEventListener('click', async ()=>{
 });
 
 /* ========= Rules ========= */
-$('btn-rules').addEventListener('click', ()=> show('modal-rules'));
+$('btn-rules')?.addEventListener('click', ()=> show('modal-rules'));
 
 /* ========= Close + click-outside ========= */
 $('btn-log').addEventListener('click', ()=> show('modal-log'));

--- a/styles/main.css
+++ b/styles/main.css
@@ -40,6 +40,8 @@ button:active{transform:translateY(1px)}
 .catalog{max-height:360px;overflow:auto;border:1px dashed var(--line);border-radius:10px;padding:6px}
 .catalog-item{display:grid;grid-template-columns:auto 1fr auto;gap:10px;align-items:center;padding:8px;border-bottom:1px solid var(--line)}
 .catalog-item:last-child{border-bottom:none}
+.catalog-item.active{background:var(--accent);color:var(--text-on-accent)}
+.catalog-item.active .pill{border-color:var(--text-on-accent);color:var(--text-on-accent)}
 .small{font-size:.9rem;color:var(--muted)}
 .overlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:1000;padding:16px}
 .overlay.hidden{display:none!important}
@@ -51,4 +53,3 @@ button:active{transform:translateY(1px)}
 .toast.show{opacity:1;transform:translateY(0)}
 .toast.success{border-color:#16a34a;color:#16a34a}
 .toast.error{border-color:#dc2626;color:#dc2626}
-@media print{header,.tabs,.actions,.overlay{display:none!important} body{background:#fff;color:#000} section{box-shadow:none;border:1px solid #ccc} .pill{border-color:#000;color:#000}}


### PR DESCRIPTION
## Summary
- drop outdated PDF export button and related print code
- harden CCCCG rules button so missing element no longer breaks script
- rework encounter tracker with turn highlighting, next-turn flow, and persistent state
- revamp XP tracker with tier thresholds and add/remove controls
- clear XP amount after adjustments and enforce positive values for add/remove
- sync tier selection with corresponding XP thresholds for accurate progress

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a33944d4cc832e8f4a0ce947692bc7