### PR TITLE
Add tier-based XP tracker with submit controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,14 +245,7 @@
       </div>
       <div class="card">
         <label for="tier">Tier</label>
-        <select id="tier">
-          <option>Tier 5 – Rookie</option>
-          <option>Tier 4 – Emerging Vigilante</option>
-          <option>Tier 3 – Field-Tested Operative</option>
-          <option>Tier 2 – Respected Force</option>
-          <option>Tier 1 – Heroic Figure</option>
-          <option>Tier 0 – Transcendent / Legendary</option>
-        </select>
+        <select id="tier"></select>
       </div>
       <div class="card" style="grid-column:1/-1">
         <label for="xp">Experience</label>
@@ -264,8 +257,11 @@
         <div class="inline">
           <label for="xp-amt" class="sr-only">Amount</label>
           <input id="xp-amt" type="number" inputmode="numeric" placeholder="Amount"/>
-          <button id="xp-add" class="btn-sm">Add XP</button>
-          <button id="xp-remove" class="btn-sm">Remove XP</button>
+          <select id="xp-mode" style="max-width:160px">
+            <option value="add">Add XP</option>
+            <option value="remove">Remove XP</option>
+          </select>
+          <button id="xp-submit" class="btn-sm">Submit</button>
         </div>
       </div>
       <div class="card">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -148,7 +148,19 @@ const elXPBar = $('xp-bar');
 const elXPPill = $('xp-pill');
 const elTier = $('tier');
 
-const XP_TIERS = [0, 2000, 6000, 18000, 54000, 162000];
+const XP_TIERS = [
+  { xp: 0, label: 'Tier 5 – Rookie' },
+  { xp: 2000, label: 'Tier 4 – Emerging Vigilante' },
+  { xp: 6000, label: 'Tier 3 – Field-Tested Operative' },
+  { xp: 18000, label: 'Tier 2 – Respected Force' },
+  { xp: 54000, label: 'Tier 1 – Heroic Figure' },
+  { xp: 162000, label: 'Tier 0 – Transcendent / Legendary' }
+];
+
+// populate tier options
+if(elTier){
+  elTier.innerHTML = XP_TIERS.map(t=>`<option>${t.label}</option>`).join('');
+}
 
 /* ========= derived helpers ========= */
 function updateSP(){
@@ -169,14 +181,14 @@ function updateXP(){
   const xp = Math.max(0, num(elXP.value));
   let idx = 0;
   for(let i=XP_TIERS.length-1;i>=0;i--){
-    if(xp >= XP_TIERS[i]){ idx = i; break; }
+    if(xp >= XP_TIERS[i].xp){ idx = i; break; }
   }
   if(elTier) elTier.selectedIndex = idx;
-  const nextXP = XP_TIERS[idx+1];
-  const prevXP = XP_TIERS[idx];
-  if(nextXP){
+  const nextTier = XP_TIERS[idx+1];
+  const prevXP = XP_TIERS[idx].xp;
+  if(nextTier){
     const val = xp - prevXP;
-    const diff = nextXP - prevXP;
+    const diff = nextTier.xp - prevXP;
     elXPBar.max = diff;
     elXPBar.value = val;
     elXPPill.textContent = `${val}/${diff}`;
@@ -218,8 +230,12 @@ function setXP(v){
   elXP.value = Math.max(0, v);
   updateXP();
 }
-$('xp-add').addEventListener('click', ()=>{ const d=num($('xp-amt').value)||0; if(d) setXP(num(elXP.value)+d); });
-$('xp-remove').addEventListener('click', ()=>{ const d=num($('xp-amt').value)||0; if(d) setXP(num(elXP.value)-d); });
+$('xp-submit').addEventListener('click', ()=>{
+  const amt = num($('xp-amt').value)||0;
+  if(!amt) return;
+  const mode = $('xp-mode').value;
+  setXP(num(elXP.value) + (mode==='add'? amt : -amt));
+});
 
 /* ========= HP/SP controls ========= */
 function setHP(v){


### PR DESCRIPTION
## Summary
- Generate XP tier options dynamically with their experience thresholds
- Track XP changes via a single submit action for adding or removing points
- Automatically update tier selection and progress toward next tier

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3558c6d08832e8a88827fef6bf376