### PR TITLE
Add tier-based XP tracker with submit controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,28 +244,24 @@
         <select id="publicIdentity"><option value="Public">Public</option><option value="Secret" selected>Secret</option></select>
       </div>
       <div class="card">
-        <label for="tier">Tier</label>
-        <select id="tier">
-          <option>Tier 5 – Rookie</option>
-          <option>Tier 4 – Emerging Vigilante</option>
-          <option>Tier 3 – Field-Tested Operative</option>
-          <option>Tier 2 – Respected Force</option>
-          <option>Tier 1 – Heroic Figure</option>
-          <option>Tier 0 – Transcendent / Legendary</option>
-        </select>
+        <label>Tier</label>
+        <span id="tier" class="pill">Tier 4 – Emerging Vigilante</span>
       </div>
       <div class="card" style="grid-column:1/-1">
         <label for="xp">Experience</label>
         <div class="inline">
-          <input id="xp" type="number" inputmode="numeric" value="0" min="0" style="max-width:120px"/>
-          <progress id="xp-bar" max="100" value="0" style="flex:1"></progress>
-          <span id="xp-pill" class="pill">0/100</span>
+          <input id="xp" type="number" inputmode="numeric" value="2000" min="0" style="max-width:120px" readonly/>
+          <progress id="xp-bar" max="4000" value="0" style="flex:1"></progress>
+          <span id="xp-pill" class="pill">0/4000</span>
         </div>
         <div class="inline">
           <label for="xp-amt" class="sr-only">Amount</label>
           <input id="xp-amt" type="number" inputmode="numeric" placeholder="Amount"/>
-          <button id="xp-add" class="btn-sm">Add XP</button>
-          <button id="xp-remove" class="btn-sm">Remove XP</button>
+          <select id="xp-mode" style="max-width:160px">
+            <option value="add">Add XP</option>
+            <option value="remove">Remove XP</option>
+          </select>
+          <button id="xp-submit" class="btn-sm">Submit</button>
         </div>
       </div>
       <div class="card">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -148,7 +148,16 @@ const elXPBar = $('xp-bar');
 const elXPPill = $('xp-pill');
 const elTier = $('tier');
 
-const XP_TIERS = [0, 2000, 6000, 18000, 54000, 162000];
+const XP_TIERS = [
+  { xp: 0, label: 'Tier 5 – Rookie' },
+  { xp: 2000, label: 'Tier 4 – Emerging Vigilante' },
+  { xp: 6000, label: 'Tier 3 – Field-Tested Operative' },
+  { xp: 18000, label: 'Tier 2 – Respected Force' },
+  { xp: 54000, label: 'Tier 1 – Heroic Figure' },
+  { xp: 162000, label: 'Tier 0 – Transcendent / Legendary' }
+];
+
+// tier select removed; tier will display current label
 
 /* ========= derived helpers ========= */
 function updateSP(){
@@ -169,14 +178,14 @@ function updateXP(){
   const xp = Math.max(0, num(elXP.value));
   let idx = 0;
   for(let i=XP_TIERS.length-1;i>=0;i--){
-    if(xp >= XP_TIERS[i]){ idx = i; break; }
+    if(xp >= XP_TIERS[i].xp){ idx = i; break; }
   }
-  if(elTier) elTier.selectedIndex = idx;
-  const nextXP = XP_TIERS[idx+1];
-  const prevXP = XP_TIERS[idx];
-  if(nextXP){
+  if(elTier) elTier.textContent = XP_TIERS[idx].label;
+  const nextTier = XP_TIERS[idx+1];
+  const prevXP = XP_TIERS[idx].xp;
+  if(nextTier){
     const val = xp - prevXP;
-    const diff = nextXP - prevXP;
+    const diff = nextTier.xp - prevXP;
     elXPBar.max = diff;
     elXPBar.value = val;
     elXPPill.textContent = `${val}/${diff}`;
@@ -212,14 +221,17 @@ ABILS.forEach(a=> $(a).addEventListener('change', updateDerived));
 ['hp-roll','hp-bonus','hp-temp','origin-bonus','prof-bonus','power-save-ability'].forEach(id=> $(id).addEventListener('input', updateDerived));
 ABILS.forEach(a=> $('save-'+a+'-prof').addEventListener('change', updateDerived));
 SKILLS.forEach((s,i)=> $('skill-'+i+'-prof').addEventListener('change', updateDerived));
-elXP?.addEventListener('input', updateXP);
 
 function setXP(v){
   elXP.value = Math.max(0, v);
   updateXP();
 }
-$('xp-add').addEventListener('click', ()=>{ const d=num($('xp-amt').value)||0; if(d) setXP(num(elXP.value)+d); });
-$('xp-remove').addEventListener('click', ()=>{ const d=num($('xp-amt').value)||0; if(d) setXP(num(elXP.value)-d); });
+$('xp-submit').addEventListener('click', ()=>{
+  const amt = num($('xp-amt').value)||0;
+  if(!amt) return;
+  const mode = $('xp-mode').value;
+  setXP(num(elXP.value) + (mode==='add'? amt : -amt));
+});
 
 /* ========= HP/SP controls ========= */
 function setHP(v){


### PR DESCRIPTION
## Summary
- Lock experience total to prevent manual edits and start at 2,000 XP
- Replace tier dropdown with auto-updating label based on XP thresholds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3558c6d08832e8a88827fef6bf376