### PR TITLE
Auto-calculate tier and lock XP input

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,14 +245,14 @@
       </div>
       <div class="card">
         <label for="tier">Tier</label>
-        <select id="tier"></select>
+        <input id="tier" type="text" readonly/>
       </div>
       <div class="card" style="grid-column:1/-1">
         <label for="xp">Experience</label>
         <div class="inline">
-          <input id="xp" type="number" inputmode="numeric" value="0" min="0" style="max-width:120px"/>
-          <progress id="xp-bar" max="100" value="0" style="flex:1"></progress>
-          <span id="xp-pill" class="pill">0/100</span>
+          <input id="xp" type="number" inputmode="numeric" value="0" min="0" style="max-width:120px" readonly/>
+          <progress id="xp-bar" max="2000" value="0" style="flex:1"></progress>
+          <span id="xp-pill" class="pill">0/2000</span>
         </div>
         <div class="inline">
           <label for="xp-amt" class="sr-only">Amount</label>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -157,9 +157,9 @@ const XP_TIERS = [
   { xp: 162000, label: 'Tier 0 – Transcendent / Legendary' }
 ];
 
-// populate tier options
+// set initial tier display
 if(elTier){
-  elTier.innerHTML = XP_TIERS.map(t=>`<option>${t.label}</option>`).join('');
+  elTier.value = XP_TIERS[0].label;
 }
 
 /* ========= derived helpers ========= */
@@ -183,7 +183,7 @@ function updateXP(){
   for(let i=XP_TIERS.length-1;i>=0;i--){
     if(xp >= XP_TIERS[i].xp){ idx = i; break; }
   }
-  if(elTier) elTier.selectedIndex = idx;
+  if(elTier) elTier.value = XP_TIERS[idx].label;
   const nextTier = XP_TIERS[idx+1];
   const prevXP = XP_TIERS[idx].xp;
   if(nextTier){


### PR DESCRIPTION
## Summary
- Display tier as read-only text that updates with XP
- Make XP total read-only and start progress at 2,000 XP to next tier

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a362374800832e9e4fddb14605a09f