### PR TITLE
Add perk display for character categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,6 +272,7 @@
       <div class="card">
         <label for="alignment">Alignment</label>
         <select id="alignment">
+          <option value="">Select one</option>
           <option>Paragon (Lawful Light)</option>
           <option>Guardian (Neutral Light)</option>
           <option>Vigilante (Chaotic Light)</option>
@@ -282,23 +283,27 @@
           <option>Anti-Hero (Neutral Shadow)</option>
           <option>Renegade (Chaotic Shadow)</option>
         </select>
+        <ul id="alignment-perks" class="perk-list"></ul>
       </div>
       <div class="card">
         <label for="classification">Classification</label>
         <select id="classification">
-          <option>Mutant</option><option>Enhanced Human</option><option>Magic User</option><option>Alien/Extraterrestrial</option><option>Mystical Being</option>
+          <option value="">Select one</option><option>Mutant</option><option>Enhanced Human</option><option>Magic User</option><option>Alien/Extraterrestrial</option><option>Mystical Being</option>
         </select>
+        <ul id="classification-perks" class="perk-list"></ul>
       </div>
       <div class="card">
         <label for="power-style">Primary Power Style</label>
         <select id="power-style">
-          <option>Physical Powerhouse</option><option>Energy Manipulator</option><option>Speedster</option>
+          <option value="">Select one</option><option>Physical Powerhouse</option><option>Energy Manipulator</option><option>Speedster</option>
           <option>Telekinetic/Psychic</option><option>Illusionist</option><option>Shape-shifter</option><option>Elemental Controller</option>
         </select>
+        <ul id="power-style-perks" class="perk-list"></ul>
       </div>
       <div class="card">
         <label for="power-style-2">Secondary Power Style</label>
         <select id="power-style-2">
+          <option value="">Select one</option>
           <option>None</option>
           <option>Physical Powerhouse</option><option>Energy Manipulator</option><option>Speedster</option>
           <option>Telekinetic/Psychic</option><option>Illusionist</option><option>Shape-shifter</option><option>Elemental Controller</option>
@@ -307,6 +312,7 @@
       <div class="card">
         <label for="origin">Origin Story</label>
         <select id="origin">
+          <option value="">Select one</option>
           <option>The Accident</option>
           <option>The Experiment</option>
           <option>The Legacy</option>
@@ -318,6 +324,7 @@
           <option>The Vigil</option>
           <option>The Redemption</option>
         </select>
+        <ul id="origin-perks" class="perk-list"></ul>
       </div>
     </div>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -124,6 +124,62 @@ skillGrid.innerHTML = SKILLS.map((s,i)=>`
     <div class="inline"><input type="checkbox" id="skill-${i}-prof"/><span class="pill" id="skill-${i}">+0</span></div>
   </div>`).join('');
 
+const ALIGNMENT_PERKS = {
+  'Paragon (Lawful Light)': ['Inspire allies with unwavering justice.'],
+  'Guardian (Neutral Light)': ['Protect an ally once per encounter.'],
+  'Vigilante (Chaotic Light)': ['Advantage on stealth checks in urban areas.'],
+  'Sentinel (Lawful Neutral)': ['+1 to saves against coercion.'],
+  'Outsider (True Neutral)': ['Reroll one failed check per day.'],
+  'Wildcard (Chaotic Neutral)': ['Add your Wisdom modifier to initiative.'],
+  'Inquisitor (Lawful Shadow)': ['Bonus to Insight checks to detect lies.'],
+  'Anti-Hero (Neutral Shadow)': ['Gain temporary hit points when you drop a foe.'],
+  'Renegade (Chaotic Shadow)': ['Once per encounter, add +2 damage to a hit.']
+};
+
+const CLASSIFICATION_PERKS = {
+  'Mutant': ['Begin with an extra minor power related to your mutation.'],
+  'Enhanced Human': ['Increase one ability score by 1.'],
+  'Magic User': ['Learn a basic spell from any school.'],
+  'Alien/Extraterrestrial': ['Gain resistance to one damage type of your choice.'],
+  'Mystical Being': ['Communicate with spirits for guidance.']
+};
+
+const POWER_STYLE_PERKS = {
+  'Physical Powerhouse': ['Melee attacks deal +1 damage.'],
+  'Energy Manipulator': ['Gain a ranged energy attack.'],
+  'Speedster': ['Dash as a bonus action.'],
+  'Telekinetic/Psychic': ['Move small objects with your mind.'],
+  'Illusionist': ['Create minor illusions at will.'],
+  'Shape-shifter': ['Alter your appearance slightly.'],
+  'Elemental Controller': ['Resist environmental hazards of your element.']
+};
+
+const ORIGIN_PERKS = {
+  'The Accident': ['Resistance to the damage type that created you.'],
+  'The Experiment': ['Reroll a failed save once per long rest.'],
+  'The Legacy': ['Start with an heirloom item.'],
+  'The Awakening': ['Gain proficiency in one skill.'],
+  'The Pact': ['Call upon your patron for minor aid.'],
+  'The Lost Time': ['Possess knowledge from a bygone era.'],
+  'The Exposure': ['Sense the presence of similar energies.'],
+  'The Rebirth': ['+1 to death saving throws.'],
+  'The Vigil': ['Remain alert without sleep for 24 hours.'],
+  'The Redemption': ['Advantage on persuasion checks for second chances.']
+};
+
+function setupPerkSelect(selId, perkId, data){
+  const sel = $(selId);
+  const perkEl = $(perkId);
+  if(!sel || !perkEl) return;
+  function render(){
+    const perks = data[sel.value] || [];
+    perkEl.innerHTML = perks.map(p=>`<li>${p}</li>`).join('');
+    perkEl.style.display = perks.length ? 'block' : 'none';
+  }
+  sel.addEventListener('change', render);
+  render();
+}
+
 /* ========= cached elements ========= */
 const elPP = $('pp');
 const elTC = $('tc');
@@ -852,6 +908,10 @@ $('tour-ok')?.addEventListener('click', ()=>{ hide('modal-tour'); localStorage.s
 if(!localStorage.getItem('tour-done')) show('modal-tour');
 
 /* ========= boot ========= */
+setupPerkSelect('alignment','alignment-perks', ALIGNMENT_PERKS);
+setupPerkSelect('classification','classification-perks', CLASSIFICATION_PERKS);
+setupPerkSelect('power-style','power-style-perks', POWER_STYLE_PERKS);
+setupPerkSelect('origin','origin-perks', ORIGIN_PERKS);
 updateDerived();
 if('serviceWorker' in navigator){
   navigator.serviceWorker.register('sw.js').catch(e=>console.error('SW reg failed', e));

--- a/styles/main.css
+++ b/styles/main.css
@@ -38,6 +38,7 @@ button:active{transform:translateY(1px)}
 .card{border:1px solid var(--line);border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab}
 .card.dragging{opacity:.5}
 .catalog{max-height:360px;overflow:auto;border:1px dashed var(--line);border-radius:10px;padding:6px}
+.perk-list{margin:0;padding-left:20px;list-style:disc}
 .catalog-item{display:grid;grid-template-columns:auto 1fr auto;gap:10px;align-items:center;padding:8px;border-bottom:1px solid var(--line)}
 .catalog-item:last-child{border-bottom:none}
 .catalog-item.active{background:var(--accent);color:var(--text-on-accent)}


### PR DESCRIPTION
## Summary
- add 'Select one' placeholder to alignment, classification, power style, and origin choices
- show perk lists for alignment, classification, primary power style, and origin selections
- style perk lists for consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a36d5f8274832e926fc259c233a798