### PR TITLE
Fix top buttons by defining missing debounce helper

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -42,6 +42,14 @@ function toast(msg, type='info'){
   setTimeout(()=>t.classList.remove('show'),1200);
 }
 
+function debounce(fn, delay){
+  let t;
+  return (...args)=>{
+    clearTimeout(t);
+    t = setTimeout(()=>fn(...args), delay);
+  };
+}
+
 // prevent negative numbers in numeric inputs
 document.addEventListener('input', e=>{
   const el = e.target;


### PR DESCRIPTION
## Summary
- Add a simple `debounce` utility to prevent ReferenceError during initialization
- Ensures remaining startup code runs so header buttons like Save/Load work again

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a36b21d22c832e93cab4ce42172caf