### PR TITLE
Refactor save/load logic and add save/load test

### DIFF
--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+import { saveCloud, loadCloud } from '../scripts/storage.js';
+
+describe('saveCloud/loadCloud', () => {
+  const mockGetRTDB = async () => null; // force localStorage path
+  const mockToast = jest.fn();
+
+  beforeEach(() => {
+    localStorage.clear();
+    mockToast.mockClear();
+    Object.defineProperty(global.navigator, 'onLine', { value: true, configurable: true });
+  });
+
+  test('saves data and loads it back', async () => {
+    const payload = { foo: 'bar', num: 42 };
+    await saveCloud('test', payload, { getRTDB: mockGetRTDB, toast: mockToast });
+    const loaded = await loadCloud('test', { getRTDB: mockGetRTDB, toast: mockToast });
+    expect(loaded).toEqual(payload);
+  });
+});

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -1,0 +1,61 @@
+const ENCODE = (s) => encodeURIComponent(String(s || ''));
+
+export async function saveCloud(name, payload, { getRTDB, toast } = {}) {
+  const r = getRTDB ? await getRTDB().catch(err => { console.error('RTDB init failed', err); return null; }) : null;
+  if (r) {
+    const { db, ref, set } = r;
+    let tries = 2;
+    while (tries--) {
+      try {
+        await set(ref(db, '/saves/' + ENCODE(name)), { updatedAt: Date.now(), data: payload });
+        break;
+      } catch (e) {
+        console.error('Firebase set failed', e);
+        if (!tries) toast?.('Cloud save failed. Data saved locally.', 'error');
+        else await new Promise(res => setTimeout(res, 1000));
+      }
+    }
+  } else {
+    if (!navigator.onLine) toast?.('Offline: saved locally only', 'error');
+    else toast?.('Cloud unavailable; saved locally', 'error');
+  }
+  try {
+    localStorage.setItem('save:' + name, JSON.stringify(payload));
+    localStorage.setItem('last-save', name);
+  } catch (e) {
+    console.error('Local save failed', e);
+  }
+}
+
+export async function loadCloud(name, { getRTDB, toast } = {}) {
+  const r = getRTDB ? await getRTDB().catch(err => { console.error('RTDB init failed', err); return null; }) : null;
+  if (r) {
+    const { db, ref, get } = r;
+    let snap = null, tries = 2;
+    while (tries--) {
+      try {
+        snap = await get(ref(db, '/saves/' + ENCODE(name)));
+        if (!snap.exists()) snap = await get(ref(db, '/saves/' + name));
+        break;
+      } catch (e) {
+        console.error('Firebase get failed', e);
+        if (!tries) toast?.('Cloud load failed. Trying local save.', 'error');
+        else await new Promise(res => setTimeout(res, 1000));
+      }
+    }
+    if (snap && snap.exists()) {
+      const v = snap.val();
+      return v?.data || v?.character || v?.sheet || v;
+    }
+  } else {
+    if (!navigator.onLine) toast?.('Offline: using local save', 'error');
+    else toast?.('Cloud unavailable; using local save', 'error');
+  }
+  try {
+    const raw = localStorage.getItem('save:' + name);
+    if (raw) return JSON.parse(raw);
+  } catch (e) {
+    console.error('Local load failed', e);
+  }
+  throw new Error('No save found');
+}


### PR DESCRIPTION
## Summary
- Extract save/load functionality into a dedicated `storage` module with cloud fallback and local persistence
- Update main script to use injected `saveCloud`/`loadCloud` helpers
- Mirror encounter saves to the cloud and add periodic cloud backups every 10 minutes
- Add Jest test to verify saving and loading via localStorage when cloud is unavailable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a376c7abd4832e9d1dfa1f44ab2cf9