### PR TITLE
feat: add proficiency and save deletion utilities

### DIFF
--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -1,4 +1,4 @@
-import { num, mod, calculateArmorBonus } from '../scripts/helpers.js';
+import { num, mod, calculateArmorBonus, proficiencyBonus } from '../scripts/helpers.js';
 
 describe('num', () => {
   test('converts strings to numbers and defaults to 0', () => {
@@ -11,6 +11,14 @@ describe('mod', () => {
   test('calculates ability modifiers', () => {
     expect(mod(10)).toBe(0);
     expect(mod(15)).toBe(2);
+  });
+});
+
+describe('proficiencyBonus', () => {
+  test('computes proficiency bonus from level', () => {
+    expect(proficiencyBonus(1)).toBe(2);
+    expect(proficiencyBonus(5)).toBe(3);
+    expect(proficiencyBonus('12')).toBe(4);
   });
 });
 

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { saveCloud, loadCloud } from '../scripts/storage.js';
+import { saveCloud, loadCloud, deleteSave } from '../scripts/storage.js';
 
 describe('saveCloud/loadCloud', () => {
   const mockGetRTDB = async () => null; // force localStorage path
@@ -16,5 +16,14 @@ describe('saveCloud/loadCloud', () => {
     await saveCloud('test', payload, { getRTDB: mockGetRTDB, toast: mockToast });
     const loaded = await loadCloud('test', { getRTDB: mockGetRTDB, toast: mockToast });
     expect(loaded).toEqual(payload);
+  });
+
+  test('deletes saved data', async () => {
+    const payload = { foo: 'baz' };
+    await saveCloud('remove', payload, { getRTDB: mockGetRTDB, toast: mockToast });
+    await deleteSave('remove', { getRTDB: mockGetRTDB, toast: mockToast });
+    await expect(loadCloud('remove', { getRTDB: mockGetRTDB, toast: mockToast })).rejects.toThrow('No save found');
+    expect(localStorage.getItem('save:remove')).toBeNull();
+    expect(localStorage.getItem('last-save')).toBeNull();
   });
 });

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -3,6 +3,7 @@ export const qs = (s, r=document) => r.querySelector(s);
 export const qsa = (s, r=document) => Array.from(r.querySelectorAll(s));
 export const num = (v) => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
 export const mod = (score) => Math.floor((num(score) - 10) / 2);
+export const proficiencyBonus = (level) => Math.floor((num(level) - 1) / 4) + 2;
 export function calculateArmorBonus(){
   let body=[], head=[], shield=0, misc=0;
   qsa("[data-kind='armor']").forEach(card=>{


### PR DESCRIPTION
## Summary
- add proficiencyBonus helper for level-based proficiency calculation
- add deleteSave storage utility for removing local/cloud saves
- expand tests for new helpers and storage deletion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a37f899008832ebbeb7456caa69de3