### PR TITLE
feat: modernize UI styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"/>
+<meta name="theme-color" content="#0e1117"/>
+<meta name="color-scheme" content="dark light"/>
 <title>Catalyst Core: Character Tracker (Clean)</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"/>
 <link rel="stylesheet" href="styles/main.css"/>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,10 +1,10 @@
-:root{--bg:#0e1117;--surface:#151a23;--surface-2:#0b0f16;--text:#e5e7eb;--muted:#9aa3af;--accent:#3cc6ff;--accent-2:#2563eb;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#041319}
+:root{--bg:#0e1117;--surface:#151a23;--surface-2:#0b0f16;--text:#e5e7eb;--muted:#9aa3af;--accent:#3cc6ff;--accent-2:#2563eb;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#041319;--radius:12px;--transition:all .2s ease}
 :root.theme-light{--bg:#f9fafb;--surface:#fff;--surface-2:#f3f4f6;--text:#111827;--muted:#6b7280;--accent:#2563eb;--accent-2:#1e3a8a;--line:rgba(0,0,0,.1);--shadow:0 8px 28px rgba(0,0,0,.2);--text-on-accent:#fff}
 :root.theme-high{--bg:#000;--surface:#000;--surface-2:#000;--text:#fff;--muted:#fff;--accent:#ff0;--accent-2:#0ff;--line:#fff;--shadow:none;--text-on-accent:#000}
 *{box-sizing:border-box}
 html,body{height:100%}
-body{margin:0;background:var(--bg);color:var(--text);font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased;overflow-x:hidden}
-header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(12px + env(safe-area-inset-top)) 14px 12px}
+body{margin:0;background:var(--bg);color:var(--text);font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased;overflow-x:hidden;line-height:1.6;font-size:16px}
+header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(12px + env(safe-area-inset-top)) 14px 12px;backdrop-filter:blur(8px)}
 .top{display:flex;align-items:center;justify-content:space-between;gap:10px}
 h1{margin:0;font-size:1.1rem;color:var(--accent);font-weight:700}
 .actions{display:flex;gap:8px}
@@ -12,12 +12,14 @@ h1{margin:0;font-size:1.1rem;color:var(--accent);font-weight:700}
   .top{flex-direction:column;align-items:flex-start}
   .actions{flex-wrap:wrap}
 }
-.icon{width:40px;height:40px;border-radius:10px;background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center}
+.icon{width:40px;height:40px;border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition)}
 .icon svg,.modal .x svg{width:24px;height:24px}
+.icon:hover{background:var(--accent);color:var(--text-on-accent)}
 .icon:active{transform:translateY(1px)}
 .icon:focus-visible,.modal .x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .tabs{margin-top:10px;display:flex;gap:8px;flex-wrap:wrap}
-.tab{flex:1 0 110px;padding:10px 12px;border-radius:10px;border:1px solid var(--accent);background:var(--surface-2);color:var(--text);font-weight:700;text-align:center}
+.tab{flex:1 0 110px;padding:10px 12px;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);font-weight:700;text-align:center;transition:var(--transition)}
+.tab:hover{background:var(--accent);color:var(--text-on-accent)}
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{max-width:980px;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}
 section{background:var(--surface);border:1px solid var(--line);border-radius:16px;padding:14px;margin-bottom:14px;box-shadow:var(--shadow)}
@@ -28,14 +30,16 @@ section h2{margin:0 0 10px;color:var(--accent);font-size:1.05rem}
 .grid-3{grid-template-columns:1fr}
 @media(min-width:820px){.grid-2{grid-template-columns:repeat(2,1fr)}.grid-3{grid-template-columns:repeat(3,1fr)}}
 label{display:block;font-weight:700;margin-bottom:6px}
-input,select,textarea,button{width:100%;border-radius:12px;border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:12px}
-button{background:var(--accent);color:var(--text-on-accent);border:none;font-weight:700;min-height:44px;cursor:pointer}
-button:active{transform:translateY(1px)}
-.btn-sm{min-height:36px;padding:8px 10px;border-radius:10px}
+input,select,textarea,button{width:100%;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:12px;transition:var(--transition)}
+button{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:var(--text-on-accent);border:none;font-weight:700;min-height:44px;cursor:pointer}
+button:hover{filter:brightness(1.1);transform:translateY(-1px)}
+button:active{transform:translateY(0)}
+.btn-sm{min-height:36px;padding:8px 10px;border-radius:var(--radius)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .inline{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
-.card{border:1px solid var(--line);border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab}
+.card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}
+.card:hover{box-shadow:0 12px 28px rgba(0,0,0,.45);transform:translateY(-2px)}
 .card.dragging{opacity:.5}
 .catalog{max-height:360px;overflow:auto;border:1px dashed var(--line);border-radius:10px;padding:6px}
 .perk-list{margin:0;padding-left:20px;list-style:disc}
@@ -48,9 +52,10 @@ button:active{transform:translateY(1px)}
 .overlay.hidden{display:none!important}
 .modal{background:var(--surface);border:1px solid var(--accent);border-radius:16px;max-width:720px;width:100%;padding:16px;box-shadow:var(--shadow);position:relative}
 .modal h3{margin:0 0 8px;color:var(--accent)}
-.modal .x{position:absolute;top:8px;right:10px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px}
+.modal .x{position:absolute;top:8px;right:10px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition)}
+.modal .x:hover{color:var(--accent)}
 .modal .actions{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}
-.toast{position:fixed;bottom:18px;right:18px;background:var(--surface);border:1px solid var(--accent);padding:10px 12px;border-radius:10px;opacity:0;transform:translateY(8px);transition:opacity .2s,transform .2s;z-index:2000}
+.toast{position:fixed;bottom:18px;right:18px;background:var(--surface);border:1px solid var(--accent);padding:10px 12px;border-radius:var(--radius);opacity:0;transform:translateY(8px);transition:opacity .2s,transform .2s;z-index:2000}
 .toast.show{opacity:1;transform:translateY(0)}
 .toast.success{border-color:#16a34a;color:#16a34a}
 .toast.error{border-color:#dc2626;color:#dc2626}


### PR DESCRIPTION
## Summary
- polish head meta with theme-color and color-scheme hints
- refresh layout with transitions, gradients and soft hover effects
- introduce shared radius/transition vars for a cohesive modern feel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3947032e0832ea9580906b7df2a21