### PR TITLE
Add death save tool to combat section

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
   <!-- COMBAT -->
   <section data-tab="combat">
     <h2 data-rule="8">Tools</h2>
-    <div class="grid grid-2">
+    <div class="grid grid-3">
       <fieldset class="card">
         <legend>Dice Roller</legend>
         <div class="inline">
@@ -92,6 +92,13 @@
         <div class="inline">
           <button id="flip">Flip</button>
           <span class="pill" id="flip-out"></span>
+        </div>
+      </fieldset>
+      <fieldset class="card">
+        <legend>Death Save</legend>
+        <div class="inline">
+          <button id="death-save">Roll</button>
+          <span class="pill" id="death-out"></span>
         </div>
       </fieldset>
     </div>
@@ -402,9 +409,10 @@
       </svg>
     </button>
     <h3>Recent Log</h3>
-    <div class="grid grid-2">
+    <div class="grid grid-3">
       <div><h4 style="margin:0">Dice</h4><div id="log-dice" class="catalog"></div></div>
       <div><h4 style="margin:0">Coins</h4><div id="log-coin" class="catalog"></div></div>
+      <div><h4 style="margin:0">Death Saves</h4><div id="log-death" class="catalog"></div></div>
     </div>
     <div class="actions"><button class="btn-sm" data-close>Close</button></div>
 </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -328,12 +328,14 @@ function safeParse(key){
 }
 const diceLog = safeParse('dice-log');
 const coinLog = safeParse('coin-log');
+const deathLog = safeParse('death-log');
 const campaignLog = safeParse('campaign-log');
 const fmt = (ts)=>new Date(ts).toLocaleTimeString();
 function pushLog(arr, entry, key){ arr.push(entry); if (arr.length>30) arr.splice(0, arr.length-30); localStorage.setItem(key, JSON.stringify(arr)); }
 function renderLogs(){
   $('log-dice').innerHTML = diceLog.slice(-10).reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
   $('log-coin').innerHTML = coinLog.slice(-10).reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
+  $('log-death').innerHTML = deathLog.slice(-10).reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
 }
 $('roll-dice').addEventListener('click', ()=>{
   const s = num($('dice-sides').value), c=num($('dice-count').value)||1;
@@ -349,6 +351,12 @@ $('flip').addEventListener('click', ()=>{
   const v = Math.random()<.5 ? 'Heads' : 'Tails';
   $('flip-out').textContent = v;
   pushLog(coinLog, {t:Date.now(), text:v}, 'coin-log');
+});
+$('death-save').addEventListener('click', ()=>{
+  const roll = 1 + Math.floor(Math.random()*20);
+  const result = roll >= 10 ? 'Success' : 'Failure';
+  $('death-out').textContent = `${roll} (${result})`;
+  pushLog(deathLog, {t:Date.now(), text:`${roll} (${result})`}, 'death-log');
 });
 $('campaign-add')?.addEventListener('click', ()=>{
   const text = $('campaign-entry').value.trim();


### PR DESCRIPTION
## Summary
- Add death save roll option to combat tools
- Log death save results alongside dice and coin logs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39c5077c4832ebe2d40baad01aa46