### PR TITLE
Ensure inline elements align uniformly

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -37,6 +37,13 @@ button:active{transform:translateY(0)}
 .btn-sm{min-height:36px;padding:8px 10px;border-radius:var(--radius)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .inline{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.inline>input,
+.inline>select,
+.inline>textarea,
+.inline>button,
+.inline>progress{flex:1;width:auto}
+.inline>.pill,
+.inline>.sr-only{flex:0;width:auto}
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}
 .card:hover{box-shadow:0 12px 28px rgba(0,0,0,.45);transform:translateY(-2px)}


### PR DESCRIPTION
## Summary
- Use flexbox to allow inputs, buttons, and selects in inline groups to share space equally
- Prevent pills and screen-reader labels from stretching inside inline forms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39cafdf94832eb6b256664bc19fc0