### PR TITLE
Organize ability scores into 2x3 grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
   <!-- ABILITIES -->
   <section data-tab="abilities">
     <h2 data-rule="2">Ability Scores</h2>
-    <div class="grid grid-3" id="abil-grid"></div>
+    <div id="abil-grid" class="grid ability-grid"></div>
     <fieldset class="card">
       <legend>Proficiency &amp; Power</legend>
       <div class="inline">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -93,9 +93,12 @@ setTab('combat');
 const ABILS = ['str','dex','con','int','wis','cha'];
 const abilGrid = $('abil-grid');
 abilGrid.innerHTML = ABILS.map(a=>`
-  <div class="card">
+  <div class="ability-box">
     <label>${a.toUpperCase()}</label>
-    <div class="inline"><select id="${a}"></select><span class="pill" id="${a}-mod">+0</span></div>
+    <div class="score">
+      <select id="${a}"></select>
+      <span class="mod" id="${a}-mod">+0</span>
+    </div>
   </div>`).join('');
 ABILS.forEach(a=>{ const sel=$(a); for(let v=10; v<=24; v++) sel.add(new Option(v,v)); sel.value='10'; });
 
@@ -272,7 +275,9 @@ function updateDerived(){
   const pb = num(elProfBonus.value)||2;
   elPowerSaveDC.value = 8 + pb + mod($( elPowerSaveAbility.value ).value);
   ABILS.forEach(a=>{
-    const val = mod($(a).value) + ($('save-'+a+'-prof')?.checked ? pb : 0);
+    const m = mod($(a).value);
+    $(a+'-mod').textContent = (m>=0?'+':'') + m;
+    const val = m + ($('save-'+a+'-prof')?.checked ? pb : 0);
     $('save-'+a).textContent = (val>=0?'+':'') + val;
   });
   SKILLS.forEach((s,i)=>{

--- a/styles/main.css
+++ b/styles/main.css
@@ -66,3 +66,44 @@ button:active{transform:translateY(0)}
 .toast.show{opacity:1;transform:translateY(0)}
 .toast.success{border-color:#16a34a;color:#16a34a}
 .toast.error{border-color:#dc2626;color:#dc2626}
+
+/* ability grid */
+.ability-grid{grid-template-columns:repeat(2,1fr)}
+
+.ability-box{
+  border:1px solid var(--line);
+  border-radius:var(--radius);
+  padding:8px;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:6px;
+}
+
+.ability-box label{
+  margin-bottom:0;
+}
+
+.ability-box .score{
+  position:relative;
+  width:100%;
+}
+
+.ability-box select{
+  width:100%;
+  height:72px;
+  font-size:1.8rem;
+  text-align:center;
+}
+
+.ability-box .mod{
+  position:absolute;
+  bottom:4px;
+  right:4px;
+  padding:4px 6px;
+  border:1px solid var(--accent);
+  border-radius:var(--radius);
+  background:var(--surface-2);
+  color:var(--accent);
+  font-size:.85rem;
+}


### PR DESCRIPTION
## Summary
- Display ability scores in a fixed 2x3 grid
- Show ability modifiers in small in-card boxes
- Update derived calculations to refresh displayed modifiers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39ea16014832e8dda416c933380f4