### PR TITLE
Organize ability stats into compact grids

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
   <!-- ABILITIES -->
   <section data-tab="abilities">
     <h2 data-rule="2">Ability Scores</h2>
-    <div class="grid grid-3" id="abil-grid"></div>
+    <div id="abil-grid" class="grid ability-grid"></div>
     <fieldset class="card">
       <legend>Proficiency &amp; Power</legend>
       <div class="inline">
@@ -195,11 +195,11 @@
     </fieldset>
     <fieldset class="card">
       <legend>Saving Throws</legend>
-      <div class="grid grid-3" id="saves"></div>
+      <div id="saves" class="grid ability-grid"></div>
     </fieldset>
     <fieldset class="card">
       <legend>Skills</legend>
-      <div class="grid grid-3" id="skills"></div>
+      <div id="skills" class="grid ability-grid"></div>
     </fieldset>
   </section>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -93,17 +93,24 @@ setTab('combat');
 const ABILS = ['str','dex','con','int','wis','cha'];
 const abilGrid = $('abil-grid');
 abilGrid.innerHTML = ABILS.map(a=>`
-  <div class="card">
+  <div class="ability-box">
     <label>${a.toUpperCase()}</label>
-    <div class="inline"><select id="${a}"></select><span class="pill" id="${a}-mod">+0</span></div>
+    <div class="score">
+      <select id="${a}"></select>
+      <span class="mod" id="${a}-mod">+0</span>
+    </div>
   </div>`).join('');
 ABILS.forEach(a=>{ const sel=$(a); for(let v=10; v<=24; v++) sel.add(new Option(v,v)); sel.value='10'; });
 
 const saveGrid = $('saves');
 saveGrid.innerHTML = ABILS.map(a=>`
-  <div class="card">
+  <div class="ability-box">
     <label>${a.toUpperCase()}</label>
-    <div class="inline"><input type="checkbox" id="save-${a}-prof"/><span class="pill" id="save-${a}">+0</span></div>
+    <div class="score">
+      <span class="value" id="save-${a}">+0</span>
+      <span class="mod" id="save-${a}-base">+0</span>
+      <input type="checkbox" id="save-${a}-prof" class="prof"/>
+    </div>
   </div>`).join('');
 
 const SKILLS = [
@@ -128,9 +135,13 @@ const SKILLS = [
 ];
 const skillGrid = $('skills');
 skillGrid.innerHTML = SKILLS.map((s,i)=>`
-  <div class="card">
+  <div class="ability-box">
     <label>${s.name}</label>
-    <div class="inline"><input type="checkbox" id="skill-${i}-prof"/><span class="pill" id="skill-${i}">+0</span></div>
+    <div class="score">
+      <span class="value" id="skill-${i}">+0</span>
+      <span class="mod" id="skill-${i}-base">+0</span>
+      <input type="checkbox" id="skill-${i}-prof" class="prof"/>
+    </div>
   </div>`).join('');
 
 const ALIGNMENT_PERKS = {
@@ -272,12 +283,19 @@ function updateDerived(){
   const pb = num(elProfBonus.value)||2;
   elPowerSaveDC.value = 8 + pb + mod($( elPowerSaveAbility.value ).value);
   ABILS.forEach(a=>{
-    const val = mod($(a).value) + ($('save-'+a+'-prof')?.checked ? pb : 0);
+    const m = mod($(a).value);
+    $(a+'-mod').textContent = (m>=0?'+':'') + m;
+    const prof = $('save-'+a+'-prof')?.checked ? pb : 0;
+    const val = m + prof;
     $('save-'+a).textContent = (val>=0?'+':'') + val;
+    $('save-'+a+'-base').textContent = (m>=0?'+':'') + m;
   });
   SKILLS.forEach((s,i)=>{
-    const val = mod($(s.abil).value) + ($('skill-'+i+'-prof')?.checked ? pb : 0);
+    const m = mod($(s.abil).value);
+    const prof = $('skill-'+i+'-prof')?.checked ? pb : 0;
+    const val = m + prof;
     $('skill-'+i).textContent = (val>=0?'+':'') + val;
+    $('skill-'+i+'-base').textContent = (m>=0?'+':'') + m;
   });
   updateXP();
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -66,3 +66,61 @@ button:active{transform:translateY(0)}
 .toast.show{opacity:1;transform:translateY(0)}
 .toast.success{border-color:#16a34a;color:#16a34a}
 .toast.error{border-color:#dc2626;color:#dc2626}
+
+/* ability grid */
+.ability-grid{grid-template-columns:repeat(2,1fr)}
+
+.ability-box{
+  border:1px solid var(--line);
+  border-radius:var(--radius);
+  padding:8px;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:6px;
+}
+
+.ability-box label{
+  margin-bottom:0;
+}
+
+.ability-box .score{
+  position:relative;
+  width:100%;
+}
+
+.ability-box select{
+  width:100%;
+  height:72px;
+  font-size:1.8rem;
+  text-align:center;
+}
+
+.ability-box .value{
+  width:100%;
+  height:72px;
+  font-size:1.8rem;
+  border:1px solid var(--accent);
+  border-radius:var(--radius);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+
+.ability-box .prof{
+  position:absolute;
+  top:4px;
+  left:4px;
+}
+
+.ability-box .mod{
+  position:absolute;
+  bottom:4px;
+  right:4px;
+  padding:4px 6px;
+  border:1px solid var(--accent);
+  border-radius:var(--radius);
+  background:var(--surface-2);
+  color:var(--accent);
+  font-size:.85rem;
+}


### PR DESCRIPTION
## Summary
- Display saving throws and skills in two-column ability-style grids
- Show totals prominently with base modifiers in mini boxes
- Add styles for value fields and in-card proficiency toggles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39ea16014832e8dda416c933380f4