### PR TITLE
Improve mobile layout alignment

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -9,8 +9,9 @@ header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var
 h1{margin:0;font-size:1.1rem;color:var(--accent);font-weight:700}
 .actions{display:flex;gap:8px}
 @media(max-width:600px){
-  .top{flex-direction:column;align-items:flex-start}
-  .actions{flex-wrap:wrap}
+  .top{flex-direction:column;align-items:center;text-align:center}
+  .actions{flex-wrap:wrap;justify-content:center}
+  .tabs{justify-content:center}
 }
 .icon{width:40px;height:40px;border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition)}
 .icon svg,.modal .x svg{width:24px;height:24px}
@@ -44,6 +45,16 @@ button:active{transform:translateY(0)}
 .inline>progress{flex:1;width:auto}
 .inline>.pill,
 .inline>.sr-only{flex:0;width:auto}
+@media(max-width:480px){
+  .inline{flex-direction:column;align-items:stretch}
+  .inline>input,
+  .inline>select,
+  .inline>textarea,
+  .inline>button,
+  .inline>progress{flex:none;width:100%;max-width:none!important}
+  .tabs{flex-direction:column;align-items:stretch}
+  .tab{flex:none;width:100%}
+}
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}
 .card:hover{box-shadow:0 12px 28px rgba(0,0,0,.45);transform:translateY(-2px)}


### PR DESCRIPTION
## Summary
- center header actions and tabs on small screens for better symmetry
- stack inline form elements vertically on narrow devices for consistent widths
- let stacked controls and tabs span the full width on very small screens for uniform layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a23571e0832eb47b57b9f9791992