### PR TITLE
Open CCCCG PDF full-screen with close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,16 +489,13 @@
 
 <!-- RULES (CCCG PDF) -->
 <div class="overlay hidden" id="modal-rules" aria-hidden="true">
-  <div class="modal" role="dialog" aria-modal="true" tabindex="-1" style="max-width:960px;height:80vh">
+  <div class="modal modal-rules" role="dialog" aria-modal="true" aria-label="CCCG — Character Creation Guide" tabindex="-1">
     <button class="x" data-close aria-label="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
-    <h3>CCCG — Character Creation Guide</h3>
-    <div style="height:calc(100% - 40px)">
-      <iframe src="./CCCCG - Catalyst Core Character Creation Guide.pdf" title="CCCG PDF" style="width:100%;height:100%;border:1px solid var(--line);border-radius:8px"></iframe>
-    </div>
+    <iframe src="./CCCCG - Catalyst Core Character Creation Guide.pdf" title="CCCG PDF"></iframe>
   </div>
 </div>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -71,6 +71,9 @@ button:active{transform:translateY(0)}
 .modal .x{position:absolute;top:8px;right:10px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition)}
 .modal .x:hover{color:var(--accent)}
 .modal .actions{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}
+#modal-rules{align-items:stretch;padding:0}
+#modal-rules .modal-rules{max-width:none;width:100%;height:100%;border-radius:0;border:none;padding:0}
+#modal-rules .modal-rules iframe{width:100%;height:100%;border:none}
 .toast{position:fixed;bottom:18px;right:18px;background:var(--surface);border:1px solid var(--accent);padding:10px 12px;border-radius:var(--radius);opacity:0;transform:translateY(8px);transition:opacity .2s,transform .2s;z-index:2000}
 .toast.show{opacity:1;transform:translateY(0)}
 .toast.success{border-color:#16a34a;color:#16a34a}


### PR DESCRIPTION
## Summary
- Expand CCCCG rules modal to full-screen so the PDF scrolls properly on mobile
- Add dedicated styles and markup for a full-screen PDF viewer with close button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3a4c501c0832ea2ec18f55c3f4301