### PR TITLE
Convert death save roll to checkboxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,10 +94,14 @@
         </div>
       </fieldset>
       <fieldset class="card">
-        <legend>Death Save</legend>
+        <legend>Death Saves</legend>
         <div class="inline">
-          <button id="death-save">Roll</button>
-          <span class="pill" id="death-out"></span>
+          <label for="death-save-1" class="sr-only">Death Save 1</label>
+          <input type="checkbox" id="death-save-1"/>
+          <label for="death-save-2" class="sr-only">Death Save 2</label>
+          <input type="checkbox" id="death-save-2"/>
+          <label for="death-save-3" class="sr-only">Death Save 3</label>
+          <input type="checkbox" id="death-save-3"/>
         </div>
       </fieldset>
     </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -371,11 +371,16 @@ $('flip').addEventListener('click', ()=>{
   $('flip-out').textContent = v;
   pushLog(coinLog, {t:Date.now(), text:v}, 'coin-log');
 });
-$('death-save').addEventListener('click', ()=>{
-  const roll = 1 + Math.floor(Math.random()*20);
-  const result = roll >= 10 ? 'Success' : 'Failure';
-  $('death-out').textContent = `${roll} (${result})`;
-  pushLog(deathLog, {t:Date.now(), text:`${roll} (${result})`}, 'death-log');
+const deathBoxes = ['death-save-1','death-save-2','death-save-3'].map(id => $(id));
+deathBoxes.forEach((box, idx) => {
+  box.addEventListener('change', () => {
+    if (box.checked) {
+      pushLog(deathLog, {t: Date.now(), text: `Failure ${idx + 1}`}, 'death-log');
+    }
+    if (deathBoxes.every(b => b.checked)) {
+      alert('Your character has fallen and their sacrifice will be remembered.');
+    }
+  });
 });
 const btnCampaignAdd = $('campaign-add');
 if (btnCampaignAdd) {


### PR DESCRIPTION
## Summary
- replace death save roller with three checkboxes
- alert when all death save boxes are checked and log failures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ac673394832e9f0ecb82b4de96c3