### PR TITLE
Limit log previews to 5 entries with full log option

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,9 +413,10 @@
       <div><h4 style="margin:0">Coins</h4><div id="log-coin" class="catalog"></div></div>
       <div><h4 style="margin:0">Death Saves</h4><div id="log-death" class="catalog"></div></div>
     </div>
-    <div class="actions"><button class="btn-sm" data-close>Close</button></div>
+    <div class="actions"><button id="log-full" class="btn-sm">Full Log</button><button class="btn-sm" data-close>Close</button></div>
+  </div>
 </div>
-</div>
+
 
 <div class="overlay hidden" id="modal-campaign" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
@@ -431,6 +432,23 @@
       <button id="campaign-add" class="btn-sm" style="max-width:140px">Add Entry</button>
     </div>
     <div id="campaign-log" class="catalog"></div>
+    <div class="actions"><button class="btn-sm" data-close>Close</button></div>
+  </div>
+</div>
+
+<div class="overlay hidden" id="modal-log-full" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Full Log</h3>
+    <div class="grid grid-3">
+      <div><h4 style="margin:0">Dice</h4><div id="full-log-dice" class="catalog"></div></div>
+      <div><h4 style="margin:0">Coins</h4><div id="full-log-coin" class="catalog"></div></div>
+      <div><h4 style="margin:0">Death Saves</h4><div id="full-log-death" class="catalog"></div></div>
+    </div>
     <div class="actions"><button class="btn-sm" data-close>Close</button></div>
   </div>
 </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -352,9 +352,14 @@ const campaignLog = safeParse('campaign-log');
 const fmt = (ts)=>new Date(ts).toLocaleTimeString();
 function pushLog(arr, entry, key){ arr.push(entry); if (arr.length>30) arr.splice(0, arr.length-30); localStorage.setItem(key, JSON.stringify(arr)); }
 function renderLogs(){
-  $('log-dice').innerHTML = diceLog.slice(-10).reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
-  $('log-coin').innerHTML = coinLog.slice(-10).reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
-  $('log-death').innerHTML = deathLog.slice(-10).reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
+  $('log-dice').innerHTML = diceLog.slice(-5).reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
+  $('log-coin').innerHTML = coinLog.slice(-5).reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
+  $('log-death').innerHTML = deathLog.slice(-5).reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
+}
+function renderFullLogs(){
+  $('full-log-dice').innerHTML = diceLog.slice().reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
+  $('full-log-coin').innerHTML = coinLog.slice().reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
+  $('full-log-death').innerHTML = deathLog.slice().reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div><b>${e.text}</b></div></div>`).join('');
 }
 $('roll-dice').addEventListener('click', ()=>{
   const s = num($('dice-sides').value), c=num($('dice-count').value)||1;
@@ -411,6 +416,10 @@ $('campaign-log').addEventListener('click', e=>{
 const btnLog = $('btn-log');
 if (btnLog) {
   btnLog.addEventListener('click', ()=>{ renderLogs(); show('modal-log'); });
+}
+const btnLogFull = $('log-full');
+if (btnLogFull) {
+  btnLogFull.addEventListener('click', ()=>{ renderFullLogs(); hide('modal-log'); show('modal-log-full'); });
 }
 const btnCampaign = $('btn-campaign');
 if (btnCampaign) {


### PR DESCRIPTION
## Summary
- Show only the five most recent dice, coin and death save results in the log modal
- Add a "Full Log" button that opens a full history modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ad4b1cb0832eaa91ec946cf414d1