### PR TITLE
Improve roll and flip tool UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,23 +74,20 @@
   <!-- COMBAT -->
   <section data-tab="combat">
     <h2 data-rule="8">Tools</h2>
-    <div class="grid grid-3">
+    <div class="grid grid-2">
       <fieldset class="card">
-        <legend>Dice Roller</legend>
-        <div class="inline">
+        <legend>Roll &amp; Flip</legend>
+        <div class="inline roll-flip">
           <label for="dice-sides" class="sr-only">Sides</label>
-          <select id="dice-sides"><option>4</option><option>6</option><option>8</option><option>10</option><option>12</option><option selected>20</option><option>100</option></select>
+          <select id="dice-sides">
+            <option>4</option><option>6</option><option>8</option><option>10</option><option>12</option><option selected>20</option><option>100</option>
+          </select>
           <label for="dice-count" class="sr-only">Count</label>
-          <input id="dice-count" type="number" inputmode="numeric" min="1" value="1" style="max-width:120px"/>
-          <button id="roll-dice" style="max-width:160px">Roll</button>
-        </div>
-        <div class="small" id="dice-out"></div>
-      </fieldset>
-      <fieldset class="card">
-        <legend>Coin Flip</legend>
-        <div class="inline">
-          <button id="flip">Flip</button>
-          <span class="pill" id="flip-out"></span>
+          <input id="dice-count" type="number" inputmode="numeric" min="1" value="1"/>
+          <button id="roll-dice" class="btn-sm">Roll</button>
+          <span class="pill result" id="dice-out"></span>
+          <button id="flip" class="btn-sm">Flip</button>
+          <span class="pill result" id="flip-out"></span>
         </div>
       </fieldset>
       <fieldset class="card">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -362,7 +362,7 @@ $('roll-dice').addEventListener('click', ()=>{
   out.classList.remove('rolling');
   const rolls = Array.from({length:c}, ()=> 1+Math.floor(Math.random()*s));
   const sum = rolls.reduce((a,b)=>a+b,0);
-  out.textContent = `Rolls: ${rolls.join(', ')} (Sum: ${sum})`;
+  out.textContent = sum;
   void out.offsetWidth; out.classList.add('rolling');
   pushLog(diceLog, {t:Date.now(), text:`${c}×d${s}: ${rolls.join(', ')} = ${sum}`}, 'dice-log');
 });

--- a/styles/main.css
+++ b/styles/main.css
@@ -56,6 +56,13 @@ button:active{transform:translateY(0)}
   .inline>progress{flex:none;width:100%}
 }
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
+.pill.result{font-size:1rem;font-weight:700;}
+.roll-flip>*{flex:0;}
+.roll-flip select{width:80px;}
+.roll-flip input{width:60px;}
+@media(max-width:480px){
+  .roll-flip{flex-direction:row;}
+}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}
 .card:hover{box-shadow:0 12px 28px rgba(0,0,0,.45);transform:translateY(-2px)}
 .card.dragging{opacity:.5}


### PR DESCRIPTION
## Summary
- Combine dice rolling and coin flip into a single compact card
- Show roll sums and flip results in highlighted pills for clarity
- Support tighter layout with new styles for roll/flip controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3af881de8832eb4f1f64bc682a5d3