### PR TITLE
Enlarge death save checkboxes and update alert

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -383,7 +383,7 @@ deathBoxes.forEach((box, idx) => {
       pushLog(deathLog, {t: Date.now(), text: `Failure ${idx + 1}`}, 'death-log');
     }
     if (deathBoxes.every(b => b.checked)) {
-      alert('Your character has fallen and their sacrifice will be remembered.');
+      alert('You have fallen, your sacrifice will be remembered.');
     }
   });
 });

--- a/styles/main.css
+++ b/styles/main.css
@@ -65,7 +65,7 @@ button:active{transform:translateY(0)}
   .roll-flip{flex-direction:row;}
 }
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:8px;}
-.death-saves input[type="checkbox"]{width:32px;height:32px;margin:0;}
+.death-saves input[type="checkbox"]{width:96px;height:96px;margin:0;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}
 .card:hover{box-shadow:0 12px 28px rgba(0,0,0,.45);transform:translateY(-2px)}
 .card.dragging{opacity:.5}


### PR DESCRIPTION
## Summary
- enlarge death save checkboxes to triple size
- update fallen alert message for death saves

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c2bf4a10832ebc5e093bf8de0b3e