### PR TITLE
Default HP to 30 and modal tier bonus entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,12 +110,12 @@
       <fieldset class="card">
         <legend data-rule="3">HP</legend>
         <div class="inline">
-          <progress id="hp-bar" max="10" value="10" style="width:100%"></progress>
-          <span class="pill" id="hp-pill">10/10</span>
+          <progress id="hp-bar" max="30" value="30" style="width:100%"></progress>
+          <span class="pill" id="hp-pill">30/30</span>
         </div>
         <div class="inline">
-          <label for="hp-roll" class="sr-only">Tier Roll</label>
-          <input id="hp-roll" type="number" inputmode="numeric" placeholder="Tier Roll"/>
+          <input id="hp-roll" type="hidden" value="0"/>
+          <button id="hp-roll-add" class="btn-sm">Add Tier HP</button>
           <label for="hp-bonus" class="sr-only">Bonus HP</label>
           <input id="hp-bonus" type="number" inputmode="numeric" placeholder="Bonus HP"/>
         </div>
@@ -404,6 +404,23 @@
     <div class="actions">
       <button id="enc-next" class="btn-sm">Next Turn</button>
       <button id="enc-reset" class="btn-sm">Reset</button>
+    </div>
+  </div>
+</div>
+
+<div class="overlay hidden" id="modal-hp-roll" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Add Tier HP</h3>
+    <label for="hp-roll-input" class="sr-only">Tier HP Bonus</label>
+    <input id="hp-roll-input" type="number" inputmode="numeric" placeholder="Tier HP Bonus"/>
+    <div class="actions">
+      <button id="hp-roll-save" class="btn-sm">Add</button>
+      <button class="btn-sm" data-close>Cancel</button>
     </div>
   </div>
 </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -261,6 +261,8 @@ const elHPPill = $('hp-pill');
 const elHPRoll = $('hp-roll');
 const elHPBonus = $('hp-bonus');
 const elHPTemp = $('hp-temp');
+const elHPRollAdd = $('hp-roll-add');
+const elHPRollInput = $('hp-roll-input');
 const elInitiative = $('initiative');
 const elProfBonus = $('prof-bonus');
 const elPowerSaveAbility = $('power-save-ability');
@@ -293,9 +295,12 @@ function updateSP(){
 }
 
 function updateHP(){
-  const total = 30 + mod(elCon.value) + num(elHPRoll.value||0) + num(elHPBonus.value||0);
+  const base = 30;
+  const conMod = elCon.value === '' ? 0 : mod(elCon.value);
+  const total = base + conMod + num(elHPRoll.value||0) + num(elHPBonus.value||0);
+  const prevMax = num(elHPBar.max);
   elHPBar.max = Math.max(0, total);
-  if (!num(elHPBar.value)) elHPBar.value = elHPBar.max;
+  if (!num(elHPBar.value) || num(elHPBar.value) === prevMax) elHPBar.value = elHPBar.max;
   elHPPill.textContent = `${num(elHPBar.value)}/${num(elHPBar.max)}` + (num(elHPTemp.value)?` (+${num(elHPTemp.value)})`:``);
 }
 
@@ -343,7 +348,7 @@ function updateDerived(){
   updateXP();
 }
 ABILS.forEach(a=> $(a).addEventListener('change', updateDerived));
-['hp-roll','hp-bonus','hp-temp','origin-bonus','prof-bonus','power-save-ability'].forEach(id=> $(id).addEventListener('input', updateDerived));
+['hp-bonus','hp-temp','origin-bonus','prof-bonus','power-save-ability'].forEach(id=> $(id).addEventListener('input', updateDerived));
 ABILS.forEach(a=> $('save-'+a+'-prof').addEventListener('change', updateDerived));
 SKILLS.forEach((s,i)=> $('skill-'+i+'-prof').addEventListener('change', updateDerived));
 if (elXP) {
@@ -380,6 +385,9 @@ $('hp-full').addEventListener('click', ()=> setHP(num(elHPBar.max)));
 $('sp-full').addEventListener('click', ()=> setSP(num(elSPBar.max)));
 qsa('[data-sp]').forEach(b=> b.addEventListener('click', ()=> setSP(num(elSPBar.value) + num(b.dataset.sp)||0) ));
 $('long-rest').addEventListener('click', ()=>{ setHP(num(elHPBar.max)); setSP(num(elSPBar.max)); });
+elHPRollAdd.addEventListener('click', ()=>{ elHPRollInput.value=''; show('modal-hp-roll'); });
+$('hp-roll-save').addEventListener('click', ()=>{ const v=num(elHPRollInput.value); if(!v) return hide('modal-hp-roll'); elHPRoll.value = num(elHPRoll.value)+v; updateHP(); hide('modal-hp-roll'); });
+qsa('#modal-hp-roll [data-close]').forEach(b=> b.addEventListener('click', ()=> hide('modal-hp-roll')));
 
 /* ========= Dice/Coin + Logs ========= */
 function safeParse(key){


### PR DESCRIPTION
## Summary
- Default HP display to 30/30 until stats are supplied and then recalc with new scores
- Replace tier roll input with "Add Tier HP" button and modal to capture bonuses
- Update HP logic and handlers to support new modal-based tier bonuses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c495786c832eae360678d4076b4f