### PR TITLE
Ignore status checkboxes when showing status reminders

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -185,7 +185,9 @@ if (statusGrid) {
 }
 
 document.addEventListener('click', e => {
-  if (activeStatuses.size && !e.target.closest('header .top')) {
+  if (activeStatuses.size &&
+      !e.target.closest('header .top') &&
+      !e.target.closest('#statuses')) {
     alert('Afflicted by: ' + Array.from(activeStatuses).join(', '));
   }
 }, true);


### PR DESCRIPTION
## Summary
- prevent status effect checkboxes from triggering the active status reminder popup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c7ea4090832eb26eeeaf1e3d675d