### PR TITLE
Lock death save checkboxes to 50px

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -65,7 +65,7 @@ button:active{transform:translateY(0)}
   .roll-flip{flex-direction:row;}
 }
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:8px;}
-.death-saves input[type="checkbox"]{width:96px;height:96px;margin:0;}
+.death-saves input[type="checkbox"]{width:50px;height:50px;max-width:50px;max-height:50px;margin:0;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}
 .card:hover{box-shadow:0 12px 28px rgba(0,0,0,.45);transform:translateY(-2px)}
 .card.dragging{opacity:.5}


### PR DESCRIPTION
## Summary
- shrink death save checkboxes to 50x50px to keep them compact

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c77f7894832ea4dc5bbfa8f92dc6