### PR TITLE
fix: robust encounter tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,6 +402,7 @@
     </fieldset>
     <div id="enc-list" class="catalog" style="margin-top:8px"></div>
     <div class="actions">
+      <button id="enc-prev" class="btn-sm">Prev Turn</button>
       <button id="enc-next" class="btn-sm">Next Turn</button>
       <button id="enc-reset" class="btn-sm">Reset</button>
     </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -806,7 +806,7 @@ $('open-catalog').addEventListener('click', ()=>{ renderCatalog(); show('modal-c
 /* ========= Encounter / Initiative ========= */
 let round = Number(localStorage.getItem('enc-round')||'1')||1;
 let turn = Number(localStorage.getItem('enc-turn')||'0')||0;
-const roster = JSON.parse(localStorage.getItem('enc-roster')||'[]');
+const roster = safeParse('enc-roster');
 function saveEnc(){
   localStorage.setItem('enc-roster', JSON.stringify(roster));
   localStorage.setItem('enc-round', String(round));
@@ -859,6 +859,13 @@ $('enc-next').addEventListener('click', ()=>{
   if(!roster.length) return;
   turn = (turn + 1) % roster.length;
   if(turn===0) round+=1;
+  renderEnc();
+  saveEnc();
+});
+$('enc-prev').addEventListener('click', ()=>{
+  if(!roster.length) return;
+  turn = (turn - 1 + roster.length) % roster.length;
+  if(turn===roster.length-1 && round>1) round-=1;
   renderEnc();
   saveEnc();
 });


### PR DESCRIPTION
## Summary
- avoid corrupt local data crashing encounter tracker
- allow stepping back to previous combatant in initiative order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c8b2ca3c832eba2a7ea36d60f7ea