### PR TITLE
Separate dice roll and coin flip into grid cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,32 +76,37 @@
     <h2 data-rule="8">Tools</h2>
     <div class="grid grid-2">
       <fieldset class="card">
-        <legend>Roll &amp; Flip</legend>
-        <div class="inline roll-flip">
+        <legend>Dice Roll</legend>
+        <div class="inline">
           <label for="dice-sides" class="sr-only">Sides</label>
           <select id="dice-sides">
-            <option>4</option><option>6</option><option>8</option><option>10</option><option>12</option><option selected>20</option><option>100</option>
+            <option value="4">d4</option><option value="6">d6</option><option value="8">d8</option><option value="10">d10</option><option value="12">d12</option><option value="20" selected>d20</option><option value="100">d100</option>
           </select>
           <label for="dice-count" class="sr-only">Count</label>
           <input id="dice-count" type="number" inputmode="numeric" min="1" value="1"/>
           <button id="roll-dice" class="btn-sm">Roll</button>
-          <span class="pill result" id="dice-out"></span>
-          <button id="flip" class="btn-sm">Flip</button>
-          <span class="pill result" id="flip-out"></span>
         </div>
+        <span class="pill result" id="dice-out"></span>
       </fieldset>
       <fieldset class="card">
-        <legend>Death Saves</legend>
-        <div class="death-saves">
-          <label for="death-save-1" class="sr-only">Death Save 1</label>
-          <input type="checkbox" id="death-save-1"/>
-          <label for="death-save-2" class="sr-only">Death Save 2</label>
-          <input type="checkbox" id="death-save-2"/>
-          <label for="death-save-3" class="sr-only">Death Save 3</label>
-          <input type="checkbox" id="death-save-3"/>
+        <legend>Coin Flip</legend>
+        <div class="inline">
+          <button id="flip" class="btn-sm">Flip</button>
         </div>
+        <span class="pill result" id="flip-out"></span>
       </fieldset>
     </div>
+    <fieldset class="card">
+      <legend>Death Saves</legend>
+      <div class="death-saves">
+        <label for="death-save-1" class="sr-only">Death Save 1</label>
+        <input type="checkbox" id="death-save-1"/>
+        <label for="death-save-2" class="sr-only">Death Save 2</label>
+        <input type="checkbox" id="death-save-2"/>
+        <label for="death-save-3" class="sr-only">Death Save 3</label>
+        <input type="checkbox" id="death-save-3"/>
+      </div>
+    </fieldset>
   </section>
 
   <section data-tab="combat">

--- a/styles/main.css
+++ b/styles/main.css
@@ -58,12 +58,6 @@ button:active{transform:translateY(0)}
 }
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
 .pill.result{font-size:1rem;font-weight:700;}
-.roll-flip>*{flex:0;}
-.roll-flip select{width:80px;}
-.roll-flip input{width:60px;}
-@media(max-width:480px){
-  .roll-flip{flex-direction:row;}
-}
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:8px;}
 .death-saves input[type="checkbox"]{width:50px;height:50px;max-width:50px;max-height:50px;margin:0;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}


### PR DESCRIPTION
## Summary
- Split dice roll and coin flip into individual cards in a 1x2 grid with results at the bottom
- Prefix dice side options with "d" to match standard dice notation
- Remove unused roll-flip CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3cb9426f4832eb888cf906b6cc314