### PR TITLE
Adjust death save checkbox size

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -65,7 +65,7 @@ button:active{transform:translateY(0)}
   .roll-flip{flex-direction:row;}
 }
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:8px;}
-.death-saves input[type="checkbox"]{width:96px;height:96px;max-width:96px;max-height:96px;margin:0;}
+.death-saves input[type="checkbox"]{width:25px;height:25px;max-width:25px;max-height:25px;margin:0;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}
 .card:hover{box-shadow:0 12px 28px rgba(0,0,0,.45);transform:translateY(-2px)}
 .card.dragging{opacity:.5}


### PR DESCRIPTION
## Summary
- resize death save checkboxes to 25x25 pixels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c9eec914832e8f2864f31d13ea56