### PR TITLE
Reduce death save checkbox size to 25px

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -60,7 +60,7 @@ button:active{transform:translateY(0)}
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
 .pill.result{font-size:1rem;font-weight:700;}
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:8px;}
-.death-saves input[type="checkbox"]{width:50px;height:50px;max-width:50px;max-height:50px;margin:0;}
+.death-saves input[type="checkbox"]{width:25px;height:25px;max-width:25px;max-height:25px;margin:0;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}
 .card:hover{box-shadow:0 12px 28px rgba(0,0,0,.45);transform:translateY(-2px)}
 .card.dragging{opacity:.5}


### PR DESCRIPTION
## Summary
- shrink death save checkboxes from 50px to 25px for a more compact layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3cdf3e11c832ea12592913ceb872a