### PR TITLE
Keep modal close buttons visible and add CCCCG page navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -542,6 +542,18 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
+    <div class="pdf-controls">
+      <button id="cccg-page-up" class="icon" aria-label="Previous Page">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 19V5m0 0-7 7m7-7 7 7"/>
+        </svg>
+      </button>
+      <button id="cccg-page-down" class="icon" aria-label="Next Page">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m0 0 7-7m-7 7-7-7"/>
+        </svg>
+      </button>
+    </div>
     <iframe src="./CCCCG - Catalyst Core Character Creation Guide.pdf" title="CCCG PDF"></iframe>
   </div>
 </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2,6 +2,8 @@
 import { $, qs, qsa, num, mod, calculateArmorBonus } from './helpers.js';
 import { saveCloud, loadCloud } from './storage.js';
 let lastFocus = null;
+let cccgPage = 1;
+const ruleFrame = qs('#modal-rules iframe');
 function show(id){
   const el = $(id);
   if(!el) return;
@@ -747,11 +749,11 @@ function enableDragReorder(id){
 
 /* ========= Rule Tooltips ========= */
 qsa('[data-rule]').forEach(el=>{
-  const page = el.dataset.rule;
+  const page = Number(el.dataset.rule);
   el.title = `See CCCCG p.${page}`;
   el.addEventListener('click', ()=>{
-    const frame = qs('#modal-rules iframe');
-    if(frame) frame.src = `./CCCCG - Catalyst Core Character Creation Guide.pdf#page=${page}`;
+    cccgPage = page;
+    if(ruleFrame) ruleFrame.src = `./CCCCG - Catalyst Core Character Creation Guide.pdf#page=${cccgPage}`;
     show('modal-rules');
   });
 });
@@ -1087,8 +1089,25 @@ setInterval(async ()=>{
 
 /* ========= Rules ========= */
 const btnRules = $('btn-rules');
+const btnPageUp = $('cccg-page-up');
+const btnPageDown = $('cccg-page-down');
 if (btnRules) {
-  btnRules.addEventListener('click', ()=> show('modal-rules'));
+  btnRules.addEventListener('click', ()=>{
+    if(ruleFrame) ruleFrame.src = `./CCCCG - Catalyst Core Character Creation Guide.pdf#page=${cccgPage}`;
+    show('modal-rules');
+  });
+}
+if (btnPageUp) {
+  btnPageUp.addEventListener('click', ()=>{
+    if(cccgPage>1) cccgPage--;
+    if(ruleFrame) ruleFrame.src = `./CCCCG - Catalyst Core Character Creation Guide.pdf#page=${cccgPage}`;
+  });
+}
+if (btnPageDown) {
+  btnPageDown.addEventListener('click', ()=>{
+    cccgPage++;
+    if(ruleFrame) ruleFrame.src = `./CCCCG - Catalyst Core Character Creation Guide.pdf#page=${cccgPage}`;
+  });
 }
 
 /* ========= Close + click-outside ========= */

--- a/styles/main.css
+++ b/styles/main.css
@@ -71,15 +71,16 @@ button:active{transform:translateY(0)}
 .catalog-item.active{background:var(--accent);color:var(--text-on-accent)}
 .catalog-item.active .pill{border-color:var(--text-on-accent);color:var(--text-on-accent)}
 .small{font-size:.9rem;color:var(--muted)}
+#modal-rules .pdf-controls{position:absolute;bottom:16px;right:16px;display:flex;flex-direction:column;gap:8px;z-index:1}
 .overlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:1000;padding:16px}
 .overlay.hidden{display:none!important}
-.modal{background:var(--surface);border:1px solid var(--accent);border-radius:16px;max-width:720px;width:100%;padding:16px;box-shadow:var(--shadow);position:relative}
+.modal{background:var(--surface);border:1px solid var(--accent);border-radius:16px;max-width:720px;width:100%;padding:16px;box-shadow:var(--shadow);position:relative;max-height:calc(100vh - 32px);overflow:auto}
 .modal h3{margin:0 0 8px;color:var(--accent)}
-.modal .x{position:absolute;top:8px;right:10px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition)}
+.modal .x{position:sticky;top:8px;margin-left:auto;margin-right:8px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition);z-index:2}
 .modal .x:hover{color:var(--accent)}
 .modal .actions{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}
 #modal-rules{align-items:stretch;padding:0}
-#modal-rules .modal-rules{max-width:none;width:100%;height:100%;border-radius:0;border:none;padding:0}
+#modal-rules .modal-rules{max-width:none;width:100%;height:100%;border-radius:0;border:none;padding:0;max-height:none}
 #modal-rules .modal-rules iframe{width:100%;height:100%;border:none}
 .toast{position:fixed;bottom:18px;right:18px;background:var(--surface);border:1px solid var(--accent);padding:10px 12px;border-radius:var(--radius);opacity:0;transform:translateY(8px);transition:opacity .2s,transform .2s;z-index:2000}
 .toast.show{opacity:1;transform:translateY(0)}


### PR DESCRIPTION
## Summary
- Make modal close buttons sticky so they remain visible while scrolling
- Add page up/down controls to the CCCCG rules modal
- Track current rules page and update navigation logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3cd8d3e78832e89b8c88f946c2c51