### PR TITLE
Add SP controls and improve long rest reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,9 +141,13 @@
         <div class="inline">
           <label for="sp-temp" class="sr-only">Temp SP</label>
           <input id="sp-temp" type="number" inputmode="numeric" placeholder="Temp SP"/>
-          <button class="btn-sm" data-sp="-1">-1 SP</button>
-          <button class="btn-sm" data-sp="-2">-2 SP</button>
-          <button class="btn-sm" data-sp="-3">-3 SP</button>
+          <div class="sp-grid">
+            <button class="btn-sm" data-sp="-1">-1 SP</button>
+            <button class="btn-sm" data-sp="-2">-2 SP</button>
+            <button class="btn-sm" data-sp="-3">-3 SP</button>
+            <button class="btn-sm" data-sp="-4">-4 SP</button>
+          </div>
+          <button class="btn-sm" data-sp="-5">-5 SP</button>
           <button id="sp-full" class="btn-sm">Reset SP</button>
         </div>
         <div class="inline"><button id="long-rest" class="btn-sm">Long Rest</button></div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -450,7 +450,15 @@ $('hp-heal').addEventListener('click', ()=>{ const d=num($('hp-amt').value)||0; 
 $('hp-full').addEventListener('click', ()=> setHP(num(elHPBar.max)));
 $('sp-full').addEventListener('click', ()=> setSP(num(elSPBar.max)));
 qsa('[data-sp]').forEach(b=> b.addEventListener('click', ()=> setSP(num(elSPBar.value) + num(b.dataset.sp)||0) ));
-$('long-rest').addEventListener('click', ()=>{ setHP(num(elHPBar.max)); setSP(num(elSPBar.max)); });
+$('long-rest').addEventListener('click', ()=>{
+  setHP(num(elHPBar.max));
+  setSP(num(elSPBar.max));
+  elHPTemp.value='';
+  const spTemp=$('sp-temp'); if(spTemp) spTemp.value='';
+  qsa('#death-save-1,#death-save-2,#death-save-3').forEach(cb=> cb.checked=false);
+  qsa('#statuses input[type="checkbox"]').forEach(cb=> cb.checked=false);
+  activeStatuses.clear();
+});
 function renderHPRollList(){
   if(!elHPRollList) return;
   elHPRollList.innerHTML='';

--- a/styles/main.css
+++ b/styles/main.css
@@ -61,6 +61,8 @@ button:active{transform:translateY(0)}
 .pill.result{font-size:1rem;font-weight:700;}
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:8px;}
 .death-saves input[type="checkbox"]{width:25px;height:25px;max-width:25px;max-height:25px;margin:0;}
+.sp-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;flex:1;}
+.sp-grid .btn-sm{width:100%;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}
 .card:hover{box-shadow:0 12px 28px rgba(0,0,0,.45);transform:translateY(-2px)}
 .card.dragging{opacity:.5}


### PR DESCRIPTION
## Summary
- Add -4 and -5 SP buttons and arrange -1 to -4 in a 2x2 grid
- Style SP buttons grid for consistent sizing
- Long rest now restores HP/SP, clears temp values, death saves, and status effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3d0898574832e96c06df72c19aeda