### PR TITLE
Prevent negative SP usage

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -475,6 +475,10 @@ function setHP(v){
 }
 function setSP(v){
   const prev = num(elSPBar.value);
+  if (num(v) < 0) {
+    alert("You don't have enough SP for that.");
+    return;
+  }
   elSPBar.value = Math.max(0, Math.min(num(elSPBar.max), v));
   elSPPill.textContent = `${num(elSPBar.value)}/${num(elSPBar.max)}`;
   if(prev > 0 && num(elSPBar.value) === 0) alert('Player is out of SP');


### PR DESCRIPTION
## Summary
- Block SP reductions that would result in negative values
- Alert player with "You don't have enough SP for that." when insufficient SP

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3eccd11e0832ea15cfc8000183c59