### PR TITLE
Shrink delete icons and checkboxes

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,12 +4,17 @@ import { saveCloud, loadCloud } from './storage.js';
 let lastFocus = null;
 let cccgPage = 1;
 const ruleFrame = qs('#modal-rules iframe');
-const ICON_TRASH = '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 7.5h12m-9 0v9m6-9v9M4.5 7.5l1 12A2.25 2.25 0 007.75 21h8.5a2.25 2.25 0 002.25-2.25l1-12M9.75 7.5V4.875A1.125 1.125 0 0110.875 3.75h2.25A1.125 1.125 0 0114.25 4.875V7.5"/></svg>';
+const ICON_TRASH = '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 7.5h12m-9 0v9m6-9v9M4.5 7.5l1 12A2.25 2.25 0 007.75 21h8.5a2.25 2.25 0 002.25-2.25l1-12M9.75 7.5V4.875A1.125 1.125 0 0110.875 3.75h2.25A1.125 1.125 0 0114.25 4.875V7.5"/></svg>';
 
 function applyDeleteIcon(btn){
   if(!btn) return;
   btn.innerHTML = ICON_TRASH;
   btn.setAttribute('aria-label','Delete');
+  btn.style.width = '15px';
+  btn.style.height = '15px';
+  btn.style.minHeight = '15px';
+  btn.style.padding = '0';
+  btn.style.flex = '0 0 auto';
 }
 
 function applyDeleteIcons(root=document){

--- a/styles/main.css
+++ b/styles/main.css
@@ -35,7 +35,7 @@ section h2{margin:0 0 10px;color:var(--accent);font-size:1.05rem}
 #statuses{grid-template-columns:repeat(2,1fr)}
 label{display:block;font-weight:700;margin-bottom:6px}
 input:not([type="checkbox"]),select,textarea,button{-webkit-appearance:none;-moz-appearance:none;appearance:none;width:100%;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:12px;transition:var(--transition)}
-input[type="checkbox"]{width:25px;height:25px;max-width:25px;max-height:25px;-webkit-appearance:checkbox;-moz-appearance:checkbox;appearance:checkbox;flex:0 0 auto;padding:0;margin:0 4px 0 0;}
+input[type="checkbox"]{width:15px;height:15px;max-width:15px;max-height:15px;-webkit-appearance:checkbox;-moz-appearance:checkbox;appearance:checkbox;flex:0 0 auto;padding:0;margin:0 4px 0 0;}
 button{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:var(--text-on-accent);border:none;font-weight:700;min-height:44px;cursor:pointer}
 button:hover{filter:brightness(1.1);transform:translateY(-1px)}
 button:active{transform:translateY(0)}


### PR DESCRIPTION
## Summary
- Size all delete icons to 15x15 pixels
- Reduce checkbox dimensions to 15x15

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3ed807c78832ead41ef7515b563c8