### PR TITLE
Ignore status alert on tab change

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -205,6 +205,7 @@ if (statusGrid) {
 document.addEventListener('click', e => {
   if (activeStatuses.size &&
       !e.target.closest('header .top') &&
+      !e.target.closest('header .tabs') &&
       !e.target.closest('#statuses')) {
     alert('Afflicted by: ' + Array.from(activeStatuses).join(', '));
   }


### PR DESCRIPTION
## Summary
- prevent status effect alerts when switching main tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ee83b8bc832e8f2836a775556e82