### PR TITLE
Prevent status warnings on tracker tools

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -206,7 +206,15 @@ document.addEventListener('click', e => {
   if (activeStatuses.size &&
       !e.target.closest('header .top') &&
       !e.target.closest('header .tabs') &&
-      !e.target.closest('#statuses')) {
+      !e.target.closest('#statuses') &&
+      !e.target.closest('#modal-enc') &&
+      !e.target.closest('#modal-load') &&
+      !e.target.closest('#modal-save') &&
+      !e.target.closest('#modal-log') &&
+      !e.target.closest('#modal-log-full') &&
+      !e.target.closest('#modal-rules') &&
+      !e.target.closest('#modal-campaign') &&
+      !e.target.closest('#btn-theme')) {
     alert('Afflicted by: ' + Array.from(activeStatuses).join(', '));
   }
 }, true);


### PR DESCRIPTION
## Summary
- Skip status effect alerts when interacting with Encounter Tracker, load/save modals, logs, campaign/rules viewers, and the theme switcher

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f2c1945c832eb303284e3be91c30