### PR TITLE
Enhance modal styling and responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,37 +17,37 @@
   <div class="top">
     <h1>Catalyst Core: Character Tracker</h1>
     <div class="actions">
-      <button id="btn-enc" class="icon" aria-label="Encounter / Initiative" title="Encounter / Initiative">
+      <button id="btn-enc" class="icon" aria-label="Encounter / Initiative" title="Encounter / Initiative" data-tip="Encounter / Initiative">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"/>
         </svg>
       </button>
-      <button id="btn-load" class="icon" aria-label="Load" title="Load">
+      <button id="btn-load" class="icon" aria-label="Load" title="Load" data-tip="Load from cloud">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"/>
         </svg>
       </button>
-      <button id="btn-save" class="icon" aria-label="Save" title="Save">
+      <button id="btn-save" class="icon" aria-label="Save" title="Save" data-tip="Save to cloud">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"/>
         </svg>
       </button>
-      <button id="btn-log"  class="icon" aria-label="Roll/Flip Log" title="Roll/Flip Log">
+      <button id="btn-log"  class="icon" aria-label="Roll/Flip Log" title="Roll/Flip Log" data-tip="Roll/Flip log">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z"/>
         </svg>
       </button>
-      <button id="btn-rules" class="icon" aria-label="Open Rules (CCCG)" title="Open Rules (CCCG)">
+      <button id="btn-rules" class="icon" aria-label="Open Rules (CCCG)" title="Open Rules (CCCG)" data-tip="Open rules">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
         </svg>
       </button>
-      <button id="btn-campaign" class="icon" aria-label="Campaign Log" title="Campaign Log">
+      <button id="btn-campaign" class="icon" aria-label="Campaign Log" title="Campaign Log" data-tip="Campaign log">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6-3h6m-6-3h6M9 3h6a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"/>
         </svg>
       </button>
-      <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme">
+      <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme" data-tip="Toggle theme">
         <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 3V5.25M18.364 5.63604L16.773 7.22703M21 12H18.75M18.364 18.364L16.773 16.773M12 18.75V21M7.22703 16.773L5.63604 18.364M5.25 12H3M7.22703 7.22703L5.63604 5.63604M15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z"/>
         </svg>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1129,13 +1129,31 @@ document.addEventListener('keydown', e=>{
 $('btn-save').addEventListener('click', ()=>{ $('save-key').value = localStorage.getItem('last-save') || $('superhero').value || ''; show('modal-save'); });
 $('btn-load').addEventListener('click', ()=>{ $('load-key').value = ''; show('modal-load'); });
 $('do-save').addEventListener('click', async ()=>{
+  const btn = $('do-save');
   const name = $('save-key').value.trim(); if(!name) return toast('Enter a name','error');
-  await saveCloud(name, serialize(), { getRTDB, toast }); hide('modal-save'); toast('Saved','success');
+  btn.classList.add('loading'); btn.disabled = true;
+  try{
+    await saveCloud(name, serialize(), { getRTDB, toast });
+    hide('modal-save'); toast('Saved','success');
+  }
+  finally{
+    btn.classList.remove('loading'); btn.disabled = false;
+  }
 });
 $('do-load').addEventListener('click', async ()=>{
+  const btn = $('do-load');
   const name = $('load-key').value.trim(); if(!name) return toast('Enter a name','error');
-  try{ const data = await loadCloud(name, { getRTDB, toast }); deserialize(data); hide('modal-load'); toast('Loaded','success'); }
-  catch(e){ console.error('Load failed', e); toast('Could not load: '+(e && e.message ? e.message : ''),'error'); }
+  btn.classList.add('loading'); btn.disabled = true;
+  try{
+    const data = await loadCloud(name, { getRTDB, toast });
+    deserialize(data); hide('modal-load'); toast('Loaded','success');
+  }
+  catch(e){
+    console.error('Load failed', e); toast('Could not load: '+(e && e.message ? e.message : ''),'error');
+  }
+  finally{
+    btn.classList.remove('loading'); btn.disabled = false;
+  }
 });
 
 // periodic cloud backup every 10 minutes

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,5 +1,5 @@
-:root{--bg:#0e1117;--surface:#151a23;--surface-2:#0b0f16;--text:#e5e7eb;--muted:#9aa3af;--accent:#3cc6ff;--accent-2:#2563eb;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#041319;--radius:12px;--transition:all .2s ease}
-:root.theme-light{--bg:#f9fafb;--surface:#fff;--surface-2:#f3f4f6;--text:#111827;--muted:#6b7280;--accent:#2563eb;--accent-2:#1e3a8a;--line:rgba(0,0,0,.1);--shadow:0 8px 28px rgba(0,0,0,.2);--text-on-accent:#fff}
+:root{--bg:#0e1117;--surface:#151a23;--surface-2:#0b0f16;--text:#f3f4f6;--muted:#9ca3af;--accent:#3b82f6;--accent-2:#1e40af;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#fff;--radius:12px;--transition:all .2s ease}
+:root.theme-light{--bg:#f9fafb;--surface:#fff;--surface-2:#f3f4f6;--text:#111827;--muted:#6b7280;--accent:#3b82f6;--accent-2:#1e40af;--line:rgba(0,0,0,.1);--shadow:0 8px 28px rgba(0,0,0,.2);--text-on-accent:#fff}
 :root.theme-high{--bg:#000;--surface:#000;--surface-2:#000;--text:#fff;--muted:#fff;--accent:#ff0;--accent-2:#0ff;--line:#fff;--shadow:none;--text-on-accent:#000}
 *,*::before,*::after{box-sizing:border-box}
 html{-webkit-text-size-adjust:100%;-moz-text-size-adjust:100%;text-size-adjust:100%}
@@ -20,18 +20,21 @@ h1{margin:0;font-size:1.1rem;color:var(--accent);font-weight:700}
 .icon:hover{background:var(--accent);color:var(--text-on-accent)}
 .icon:active{transform:translateY(1px)}
 .icon:focus-visible,.modal .x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+[data-tip]{position:relative;cursor:help}
+[data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
 .tabs{margin-top:10px;display:flex;gap:8px;flex-wrap:wrap}
 .tab{flex:1 0 110px;padding:10px 12px;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);font-weight:700;text-align:center;transition:var(--transition)}
 .tab:hover{background:var(--accent);color:var(--text-on-accent)}
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{max-width:980px;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}
-section{background:var(--surface);border:1px solid var(--line);border-radius:16px;padding:14px;margin-bottom:14px;box-shadow:var(--shadow)}
+section{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:14px;margin-bottom:14px;box-shadow:var(--shadow)}
 section h2{margin:0 0 10px;color:var(--accent);font-size:1.05rem}
 .grid{display:grid;gap:12px}
 .grid-1{grid-template-columns:1fr}
 .grid-2{grid-template-columns:1fr}
 .grid-3{grid-template-columns:1fr}
-@media(min-width:820px){.grid-2{grid-template-columns:repeat(2,1fr)}.grid-3{grid-template-columns:repeat(3,1fr)}}
+@media(min-width:600px){.grid-2{grid-template-columns:repeat(2,1fr)}.grid-3{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:900px){.grid-3{grid-template-columns:repeat(3,1fr)}}
 #statuses{grid-template-columns:repeat(2,1fr)}
 label{display:block;font-weight:700;margin-bottom:6px}
 input:not([type="checkbox"]),select,textarea,button{-webkit-appearance:none;-moz-appearance:none;appearance:none;width:100%;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:12px;transition:var(--transition)}
@@ -40,6 +43,9 @@ input[type="checkbox"]{width:15px;height:15px;max-width:15px;max-height:15px;-we
 button{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:var(--text-on-accent);border:none;font-weight:700;min-height:44px;cursor:pointer}
 button:hover{filter:brightness(1.1);transform:translateY(-1px)}
 button:active{transform:translateY(0)}
+button.loading{opacity:.8;pointer-events:none;position:relative;padding-right:2.5em}
+button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2px solid currentColor;border-top-color:transparent;border-radius:50%;right:8px;top:50%;transform:translateY(-50%);animation:spin 1s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
 .btn-sm{min-height:36px;padding:8px 10px;border-radius:var(--radius)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .inline{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
@@ -50,7 +56,7 @@ button:active{transform:translateY(0)}
 .inline>progress{flex:1;width:auto}
 .inline>.pill,
 .inline>.sr-only{flex:0;width:auto}
-@media(max-width:480px){
+@media(max-width:600px){
   .inline{flex-direction:column;align-items:stretch}
   .inline>input:not([type="checkbox"]),
   .inline>select,
@@ -75,9 +81,9 @@ button:active{transform:translateY(0)}
 .catalog-item.active .pill{border-color:var(--text-on-accent);color:var(--text-on-accent)}
 .small{font-size:.9rem;color:var(--muted)}
 #modal-rules .pdf-controls{position:absolute;bottom:16px;right:16px;display:flex;flex-direction:column;gap:8px;z-index:1}
-.overlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:1000;padding:16px}
+.overlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.6);backdrop-filter:blur(2px);z-index:1000;padding:16px}
 .overlay.hidden{display:none!important}
-.modal{background:var(--surface);border:1px solid var(--accent);border-radius:16px;max-width:720px;width:100%;padding:16px;box-shadow:var(--shadow);position:relative;max-height:calc(100vh - 32px);overflow:auto}
+.modal{background:var(--surface);border:1px solid var(--accent);border-radius:var(--radius);max-width:720px;width:100%;padding:24px;box-shadow:var(--shadow);position:relative;max-height:calc(100vh - 32px);overflow:auto}
 .modal h3{margin:0 0 8px;color:var(--accent)}
 .modal .x{position:sticky;top:8px;margin-left:auto;margin-right:8px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition);z-index:2}
 .modal .x:hover{color:var(--accent)}


### PR DESCRIPTION
## Summary
- polish modal overlays and dialog styles for stronger focus and consistent rounding
- introduce responsive grid and form breakpoints for better mobile layouts
- add tooltips and loading spinners to improve user feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3f591b8d0832eacf79642a3663459