### PR TITLE
Improve accessibility labels and tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
 <!-- INITIATIVE MODAL -->
 <div class="overlay hidden" id="modal-enc" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
-    <button class="x" data-close aria-label="Close">
+    <button class="x" data-close aria-label="Close" title="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
@@ -418,7 +418,7 @@
 
 <div class="overlay hidden" id="modal-hp-roll" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
-    <button class="x" data-close aria-label="Close">
+    <button class="x" data-close aria-label="Close" title="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
@@ -437,7 +437,7 @@
 <!-- LOG MODAL -->
 <div class="overlay hidden" id="modal-log" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
-    <button class="x" data-close aria-label="Close">
+    <button class="x" data-close aria-label="Close" title="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
@@ -454,7 +454,7 @@
 
 <div class="overlay hidden" id="modal-campaign" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
-    <button class="x" data-close aria-label="Close">
+    <button class="x" data-close aria-label="Close" title="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
@@ -472,7 +472,7 @@
 
 <div class="overlay hidden" id="modal-log-full" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
-    <button class="x" data-close aria-label="Close">
+    <button class="x" data-close aria-label="Close" title="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
@@ -489,7 +489,7 @@
 <!-- SAVE / LOAD -->
 <div class="overlay hidden" id="modal-save" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
-    <button class="x" data-close aria-label="Close">
+    <button class="x" data-close aria-label="Close" title="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
@@ -502,7 +502,7 @@
 </div>
 <div class="overlay hidden" id="modal-load" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
-    <button class="x" data-close aria-label="Close">
+    <button class="x" data-close aria-label="Close" title="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
@@ -517,7 +517,7 @@
 <!-- GEAR CATALOG -->
 <div class="overlay hidden" id="modal-catalog" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1" style="max-width:900px">
-    <button class="x" data-close aria-label="Close">
+    <button class="x" data-close aria-label="Close" title="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
@@ -541,21 +541,23 @@
 <!-- RULES (CCCG PDF) -->
 <div class="overlay hidden" id="modal-rules" aria-hidden="true">
   <div class="modal modal-rules" role="dialog" aria-modal="true" aria-label="CCCG — Character Creation Guide" tabindex="-1">
-    <button class="x" data-close aria-label="Close">
+    <button class="x" data-close aria-label="Close" title="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
     <div class="pdf-controls">
-      <button id="cccg-page-up" class="icon" aria-label="Previous Page">
+      <button id="cccg-page-up" class="icon" aria-label="Previous Page" title="Previous Page">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 19V5m0 0-7 7m7-7 7 7"/>
         </svg>
+        <span class="btn-label">Prev</span>
       </button>
-      <button id="cccg-page-down" class="icon" aria-label="Next Page">
+      <button id="cccg-page-down" class="icon" aria-label="Next Page" title="Next Page">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m0 0 7-7m-7 7-7-7"/>
         </svg>
+        <span class="btn-label">Next</span>
       </button>
     </div>
     <iframe src="./CCCCG - Catalyst Core Character Creation Guide.pdf" title="CCCG PDF"></iframe>

--- a/styles/main.css
+++ b/styles/main.css
@@ -75,6 +75,8 @@ button:active{transform:translateY(0)}
 .catalog-item.active .pill{border-color:var(--text-on-accent);color:var(--text-on-accent)}
 .small{font-size:.9rem;color:var(--muted)}
 #modal-rules .pdf-controls{position:absolute;bottom:16px;right:16px;display:flex;flex-direction:column;gap:8px;z-index:1}
+#modal-rules .pdf-controls .icon{flex-direction:column;height:auto;width:40px;padding:4px}
+#modal-rules .pdf-controls .btn-label{font-size:.75rem;margin-top:2px;color:var(--text)}
 .overlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:1000;padding:16px}
 .overlay.hidden{display:none!important}
 .modal{background:var(--surface);border:1px solid var(--accent);border-radius:16px;max-width:720px;width:100%;padding:16px;box-shadow:var(--shadow);position:relative;max-height:calc(100vh - 32px);overflow:auto}


### PR DESCRIPTION
## Summary
- add descriptive titles for all modal close buttons
- label PDF navigation icons with text and tooltips

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f63af6e0832e80341eff3391a6ea