### PR TITLE
Refine header bar with dropdown actions and breadcrumbs

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,60 +14,50 @@
 <!-- Firebase config is loaded from firebase-config.json -->
 
 <header>
-  <div class="top">
-    <h1>Catalyst Core: Character Tracker</h1>
-    <div class="actions">
-      <button id="btn-enc" class="icon" aria-label="Encounter / Initiative" title="Encounter / Initiative">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"/>
-        </svg>
-      </button>
-      <button id="btn-load" class="icon" aria-label="Load" title="Load">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"/>
-        </svg>
-      </button>
-      <button id="btn-save" class="icon" aria-label="Save" title="Save">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"/>
-        </svg>
-      </button>
-      <button id="btn-log"  class="icon" aria-label="Roll/Flip Log" title="Roll/Flip Log">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z"/>
-        </svg>
-      </button>
-      <button id="btn-rules" class="icon" aria-label="Open Rules (CCCG)" title="Open Rules (CCCG)">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
-        </svg>
-      </button>
-      <button id="btn-campaign" class="icon" aria-label="Campaign Log" title="Campaign Log">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6-3h6m-6-3h6M9 3h6a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"/>
-        </svg>
-      </button>
-      <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme">
-        <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 3V5.25M18.364 5.63604L16.773 7.22703M21 12H18.75M18.364 18.364L16.773 16.773M12 18.75V21M7.22703 16.773L5.63604 18.364M5.25 12H3M7.22703 7.22703L5.63604 5.63604M15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z"/>
-        </svg>
-        <svg id="icon-contrast" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" style="display:none">
-          <circle cx="12" cy="12" r="9"/>
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v18"/>
-        </svg>
-        <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" style="display:none">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/>
-        </svg>
-      </button>
+    <div class="top">
+      <h1>Catalyst Core: Character Tracker</h1>
+      <div class="actions">
+        <button id="btn-enc" class="icon" aria-label="Encounter / Initiative" title="Encounter / Initiative">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"/>
+          </svg>
+        </button>
+        <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme">
+          <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 3V5.25M18.364 5.63604L16.773 7.22703M21 12H18.75M18.364 18.364L16.773 16.773M12 18.75V21M7.22703 16.773L5.63604 18.364M5.25 12H3M7.22703 7.22703L5.63604 5.63604M15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z"/>
+          </svg>
+          <svg id="icon-contrast" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" style="display:none">
+            <circle cx="12" cy="12" r="9"/>
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v18"/>
+          </svg>
+          <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" style="display:none">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/>
+          </svg>
+        </button>
+        <div class="dropdown">
+          <button id="btn-menu" class="icon" aria-label="More Actions" title="More Actions">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 12a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Zm5.25 0a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Zm5.25 0a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z"/>
+            </svg>
+          </button>
+          <div id="menu-actions" class="dropdown-content">
+            <button id="btn-load">Load</button>
+            <button id="btn-save">Save</button>
+            <button id="btn-log">Roll/Flip Log</button>
+            <button id="btn-rules">Open Rules (CCCG)</button>
+            <button id="btn-campaign">Campaign Log</button>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="tabs">
-    <button class="tab active" data-go="combat">Combat</button>
-    <button class="tab" data-go="abilities">Abilities</button>
-    <button class="tab" data-go="powers">Powers</button>
-    <button class="tab" data-go="gear">Gear</button>
-    <button class="tab" data-go="story">Story</button>
-  </div>
+    <div class="tabs">
+      <button class="tab active" data-go="combat">Combat</button>
+      <button class="tab" data-go="abilities">Abilities</button>
+      <button class="tab" data-go="powers">Powers</button>
+      <button class="tab" data-go="gear">Gear</button>
+      <button class="tab" data-go="story">Story</button>
+    </div>
+    <div class="breadcrumbs" id="breadcrumbs">Home / Combat</div>
 </header>
 
 <main>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -109,10 +109,27 @@ if (btnTheme) {
   });
 }
 
+/* ========= header menu ========= */
+const btnMenu = $('btn-menu');
+const menuActions = $('menu-actions');
+if (btnMenu && menuActions) {
+  btnMenu.addEventListener('click', e => {
+    e.stopPropagation();
+    menuActions.classList.toggle('show');
+  });
+  document.addEventListener('click', e => {
+    if (!menuActions.contains(e.target) && e.target !== btnMenu) {
+      menuActions.classList.remove('show');
+    }
+  });
+}
+
 /* ========= tabs ========= */
 function setTab(name){
   qsa('section[data-tab]').forEach(s=> s.style.display = s.getAttribute('data-tab')===name ? 'block':'none');
   qsa('.tab').forEach(b=> b.classList.toggle('active', b.getAttribute('data-go')===name));
+  const bc = $('breadcrumbs');
+  if (bc) bc.textContent = `Home / ${name.charAt(0).toUpperCase()+name.slice(1)}`;
 }
 qsa('.tab').forEach(b=> b.addEventListener('click', ()=> setTab(b.getAttribute('data-go'))));
 setTab('combat');

--- a/styles/main.css
+++ b/styles/main.css
@@ -10,6 +10,11 @@ header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var
 .top{display:flex;align-items:center;justify-content:space-between;gap:10px}
 h1{margin:0;font-size:1.1rem;color:var(--accent);font-weight:700}
 .actions{display:flex;gap:8px}
+.dropdown{position:relative}
+.dropdown-content{display:none;position:absolute;right:0;top:100%;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);padding:8px;flex-direction:column;gap:8px;min-width:160px;z-index:10}
+.dropdown-content.show{display:flex}
+.dropdown-content button{background:var(--surface);color:var(--text);border:1px solid var(--accent);border-radius:var(--radius);min-height:unset;padding:8px 10px;text-align:left}
+.dropdown-content button:hover{background:var(--accent);color:var(--text-on-accent)}
 @media(max-width:600px){
   .top{flex-direction:column;align-items:center;text-align:center}
   .actions{flex-wrap:wrap;justify-content:center}
@@ -24,6 +29,7 @@ h1{margin:0;font-size:1.1rem;color:var(--accent);font-weight:700}
 .tab{flex:1 0 110px;padding:10px 12px;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);font-weight:700;text-align:center;transition:var(--transition)}
 .tab:hover{background:var(--accent);color:var(--text-on-accent)}
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
+.breadcrumbs{margin-top:8px;font-size:.9rem;color:var(--muted)}
 main{max-width:980px;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}
 section{background:var(--surface);border:1px solid var(--line);border-radius:16px;padding:14px;margin-bottom:14px;box-shadow:var(--shadow)}
 section h2{margin:0 0 10px;color:var(--accent);font-size:1.05rem}


### PR DESCRIPTION
## Summary
- Consolidate rarely used actions into a "More" dropdown
- Add breadcrumb navigation for multi-level pages
- Introduce styles and scripts for dropdown menu and breadcrumbs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f6251f44832eb2197f133aae675c