### PR TITLE
feat: add visual feedback for form controls

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -151,3 +151,58 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
 #hp-roll-list li button{
   flex:0 0 auto;
 }
+
+/* Enhanced form control feedback */
+input:not([type="checkbox"]):hover,
+select:hover,
+textarea:hover{
+  border-color:var(--accent-2);
+}
+
+input:not([type="checkbox"]):focus,
+select:focus,
+textarea:focus{
+  border-color:var(--accent);
+  box-shadow:0 0 0 2px rgba(59,130,246,.5);
+  outline:none;
+}
+
+/* Validation states */
+input:not([type="checkbox"]):invalid,
+textarea:invalid{
+  border-color:#dc2626;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23dc2626' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E");
+  background-repeat:no-repeat;
+  background-position:right 12px center;
+  background-size:16px;
+  padding-right:40px;
+}
+
+select:invalid{
+  border-color:#dc2626;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23dc2626' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E"),url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 8l4 4 4-4'/%3E%3C/svg%3E");
+  background-repeat:no-repeat,no-repeat;
+  background-position:right 12px center,right 36px center;
+  background-size:16px 16px,16px 16px;
+  padding-right:64px;
+}
+
+input:not([type="checkbox"])[required]:valid:not(:placeholder-shown),
+textarea[required]:valid:not(:placeholder-shown){
+  border-color:#16a34a;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2316a34a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");
+  background-repeat:no-repeat;
+  background-position:right 12px center;
+  background-size:16px;
+  padding-right:40px;
+}
+
+select[required]:valid{
+  border-color:#16a34a;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2316a34a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E"),url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 8l4 4 4-4'/%3E%3C/svg%3E");
+  background-repeat:no-repeat,no-repeat;
+  background-position:right 12px center,right 36px center;
+  background-size:16px 16px,16px 16px;
+  padding-right:64px;
+}
+


### PR DESCRIPTION
## Summary
- add hover and focus transitions for form controls with accent glow
- show validation error and success states with color cues and icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f7569044832e84802c3794fcc585