### PR TITLE
Streamline header navigation with dropdown menu and breadcrumbs

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,37 +22,21 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"/>
         </svg>
       </button>
-      <button id="btn-load" class="icon" aria-label="Load" title="Load" data-tip="Load from cloud">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"/>
-        </svg>
-      </button>
-      <button id="btn-save" class="icon" aria-label="Save" title="Save" data-tip="Save to cloud">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"/>
-        </svg>
-      </button>
-      <button id="btn-log"  class="icon" aria-label="Roll/Flip Log" title="Roll/Flip Log" data-tip="Roll/Flip log">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z"/>
-        </svg>
-      </button>
-      <button id="btn-rules" class="icon" aria-label="Open Rules (CCCG)" title="Open Rules (CCCG)" data-tip="Open rules">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
-        </svg>
-      </button>
-      <button id="btn-campaign" class="icon" aria-label="Campaign Log" title="Campaign Log" data-tip="Campaign log">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6-3h6m-6-3h6M9 3h6a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"/>
-        </svg>
-      </button>
-      <button id="btn-help" class="icon" aria-label="Help" title="Help" data-tip="Help">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 9a3.375 3.375 0 0 1 6.75 0c0 1.966-1.682 3.375-3.375 3.375S8.625 10.966 8.625 9zm3.375 7.5h.007v.007H12v-.007z"/>
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6.75 6.75 0 1 0 0-13.5 6.75 6.75 0 0 0 0 13.5z"/>
-        </svg>
-      </button>
+      <div class="dropdown">
+        <button id="btn-menu" class="icon" aria-label="More" title="More" data-tip="More">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5zm0 6a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5zm0 6a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5z"/>
+          </svg>
+        </button>
+        <div id="menu-actions" class="menu">
+          <button id="btn-load" title="Load from cloud">Load</button>
+          <button id="btn-save" title="Save to cloud">Save</button>
+          <button id="btn-log" title="Roll/Flip log">Roll/Flip Log</button>
+          <button id="btn-rules" title="Open rules">Rules</button>
+          <button id="btn-campaign" title="Campaign log">Campaign</button>
+          <button id="btn-help" title="Help">Help</button>
+        </div>
+      </div>
       <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme" data-tip="Toggle theme">
         <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 3V5.25M18.364 5.63604L16.773 7.22703M21 12H18.75M18.364 18.364L16.773 16.773M12 18.75V21M7.22703 16.773L5.63604 18.364M5.25 12H3M7.22703 7.22703L5.63604 5.63604M15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z"/>
@@ -67,6 +51,7 @@
       </button>
     </div>
   </div>
+  <nav class="breadcrumbs"><span>Home</span><span id="crumb-current">Combat</span></nav>
   <div class="tabs">
     <button class="tab active" data-go="combat">Combat</button>
     <button class="tab" data-go="abilities">Abilities</button>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -88,6 +88,9 @@ document.addEventListener('input', e=>{
 /* ========= theme ========= */
 const root = document.documentElement;
 const btnTheme = $('btn-theme');
+const btnMenu = $('btn-menu');
+const menuActions = $('menu-actions');
+const crumbCurrent = $('crumb-current');
 function applyTheme(t){
   root.classList.remove('theme-light','theme-high');
   if(t==='light') root.classList.add('theme-light');
@@ -109,10 +112,27 @@ if (btnTheme) {
   });
 }
 
+if (btnMenu && menuActions) {
+  btnMenu.addEventListener('click', e => {
+    e.stopPropagation();
+    menuActions.classList.toggle('show');
+  });
+  menuActions.addEventListener('click', () => menuActions.classList.remove('show'));
+  document.addEventListener('click', e => {
+    if (!e.target.closest('.dropdown')) {
+      menuActions.classList.remove('show');
+    }
+  });
+}
+
 /* ========= tabs ========= */
 function setTab(name){
   qsa('section[data-tab]').forEach(s=> s.style.display = s.getAttribute('data-tab')===name ? 'block':'none');
   qsa('.tab').forEach(b=> b.classList.toggle('active', b.getAttribute('data-go')===name));
+  if(crumbCurrent){
+    const tabBtn = qs(`.tab[data-go="${name}"]`);
+    crumbCurrent.textContent = tabBtn ? tabBtn.textContent : name;
+  }
 }
 qsa('.tab').forEach(b=> b.addEventListener('click', ()=> setTab(b.getAttribute('data-go'))));
 setTab('combat');

--- a/styles/main.css
+++ b/styles/main.css
@@ -13,6 +13,11 @@ h3{font-size:1.25rem;font-weight:600}
 header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(12px + env(safe-area-inset-top)) 14px 12px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px)}
 .top{display:flex;align-items:center;justify-content:space-between;gap:10px}
 .actions{display:flex;gap:8px}
+.dropdown{position:relative}
+.menu{position:absolute;top:calc(100% + 4px);right:0;display:none;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50}
+.menu.show{display:flex}
+.menu button{background:transparent;color:var(--text);border:none;padding:8px 12px;text-align:left;font-weight:400;min-height:auto;white-space:nowrap}
+.menu button:hover{background:var(--accent);color:var(--text-on-accent)}
 @media(max-width:600px){
   .top{flex-direction:column;align-items:center;text-align:center}
   .actions{flex-wrap:wrap;justify-content:center}
@@ -25,6 +30,8 @@ header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var
 .icon:focus-visible,.modal .x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 [data-tip]{position:relative;cursor:help}
 [data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
+.breadcrumbs{margin-top:8px;font-size:.875rem;color:var(--muted)}
+.breadcrumbs span+span::before{content:"/";margin:0 4px}
 .tabs{margin-top:10px;display:flex;gap:8px;flex-wrap:wrap}
 .tab{flex:1 0 110px;padding:10px 12px;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);font-weight:700;text-align:center;transition:var(--transition)}
 .tab:hover{background:var(--accent);color:var(--text-on-accent)}


### PR DESCRIPTION
## Summary
- Consolidate rarely used header actions into a dropdown menu and reduce on-screen icons.
- Add breadcrumb navigation to show current tab and aid multi-level navigation.
- Introduce supporting styles and script logic for menu toggling and breadcrumb updates.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f91fa3ac832e8f1a61ca2a5ab956