### PR TITLE
Add character creation wizard

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
           <button id="btn-log" title="Roll/Flip log">Roll/Flip Log</button>
           <button id="btn-rules" title="Open rules">Rules</button>
           <button id="btn-campaign" title="Campaign log">Campaign</button>
+          <button id="btn-wizard" title="Character creation wizard">Wizard</button>
           <button id="btn-help" title="Help">Help</button>
         </div>
       </div>
@@ -531,6 +532,49 @@
       <input id="catalog-search" placeholder="Search..."/>
     </fieldset>
     <div id="catalog-list" class="catalog"></div>
+</div>
+</div>
+
+<!-- CHARACTER CREATION WIZARD -->
+<div class="overlay hidden" id="modal-wizard" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" aria-label="Character Creation Wizard" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <div id="wizard-steps">
+      <div class="wizard-step">
+        <h3>Ability Scores</h3>
+        <div id="wizard-abil-grid" class="grid ability-grid"></div>
+      </div>
+      <div class="wizard-step">
+        <h3>Gear</h3>
+        <p>Use the buttons below to add starting gear.</p>
+        <div class="actions" style="justify-content:center">
+          <button id="wiz-add-weapon">Add Weapon</button>
+          <button id="wiz-add-armor">Add Armor</button>
+          <button id="wiz-add-item">Add Item</button>
+        </div>
+      </div>
+      <div class="wizard-step">
+        <h3>Story</h3>
+        <div class="grid grid-1">
+          <div class="card"><label for="wiz-superhero">Superhero Identity</label><input id="wiz-superhero"/></div>
+          <div class="card"><label for="wiz-secret">Secret Identity</label><input id="wiz-secret"/></div>
+          <div class="card"><label for="wiz-public">Public Identity</label><select id="wiz-public"><option value="Public">Public</option><option value="Secret">Secret</option></select></div>
+        </div>
+      </div>
+      <div class="wizard-step">
+        <h3>Summary</h3>
+        <div id="wizard-summary"></div>
+      </div>
+    </div>
+    <div class="wizard-nav">
+      <button id="wizard-prev">Back</button>
+      <span id="wizard-progress"></span>
+      <button id="wizard-next">Next</button>
+    </div>
   </div>
 </div>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1190,6 +1190,130 @@ setInterval(async ()=>{
   }
 }, 10 * 60 * 1000);
 
+/* ========= Character Creation Wizard ========= */
+const btnWizard = $('btn-wizard');
+const modalWizard = $('modal-wizard');
+if (btnWizard && modalWizard) {
+  const steps = qsa('#wizard-steps .wizard-step');
+  const prevBtn = $('wizard-prev');
+  const nextBtn = $('wizard-next');
+  const progress = $('wizard-progress');
+  let stepIndex = 0;
+
+  const abilGrid = $('wizard-abil-grid');
+  if (abilGrid) {
+    abilGrid.innerHTML = ABILS.map(a => `
+      <div class="ability-box">
+        <label for="wiz-${a}">${a.toUpperCase()}</label>
+        <div class="score">
+          <select id="wiz-${a}"></select>
+          <span class="mod" id="wiz-${a}-mod">+0</span>
+        </div>
+      </div>`).join('');
+    ABILS.forEach(a => {
+      const sel = $('wiz-' + a);
+      const orig = $(a);
+      const modSpan = $('wiz-' + a + '-mod');
+      for (let v = 10; v <= 24; v++) sel.add(new Option(v, v));
+      if (orig) sel.value = orig.value;
+      const sync = () => {
+        if (orig) {
+          orig.value = sel.value;
+          orig.dispatchEvent(new Event('change', { bubbles: true }));
+          if (modSpan) modSpan.textContent = $(a + '-mod').textContent;
+        }
+      };
+      sel.addEventListener('change', sync);
+    });
+  }
+
+  $('wiz-add-weapon').addEventListener('click', () => $('add-weapon').click());
+  $('wiz-add-armor').addEventListener('click', () => $('add-armor').click());
+  $('wiz-add-item').addEventListener('click', () => $('add-item').click());
+
+  const storyFields = [
+    ['wiz-superhero', 'superhero'],
+    ['wiz-secret', 'secret'],
+    ['wiz-public', 'publicIdentity']
+  ];
+  storyFields.forEach(([wizId, baseId]) => {
+    const w = $(wizId);
+    const b = $(baseId);
+    if (w && b) {
+      w.addEventListener('input', () => {
+        b.value = w.value;
+        b.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+    }
+  });
+
+  function populateSummary() {
+    const summary = $('wizard-summary');
+    if (!summary) return;
+    const abilList = ABILS.map(a => {
+      const el = $(a);
+      return `<li>${a.toUpperCase()}: ${el ? el.value : ''}</li>`;
+    }).join('');
+    const weapons = $('weapons').childElementCount;
+    const armors = $('armors').childElementCount;
+    const items = $('items').childElementCount;
+    const hero = $('superhero');
+    const secret = $('secret');
+    const pub = $('publicIdentity');
+    summary.innerHTML = `
+      <h4>Abilities</h4>
+      <ul>${abilList}</ul>
+      <h4>Gear</h4>
+      <ul>
+        <li>${weapons} weapon(s)</li>
+        <li>${armors} armor(s)</li>
+        <li>${items} item(s)</li>
+      </ul>
+      <h4>Story</h4>
+      <ul>
+        <li>Superhero: ${hero ? hero.value : ''}</li>
+        <li>Secret Identity: ${secret ? secret.value : ''}</li>
+        <li>Public Identity: ${pub ? pub.value : ''}</li>
+      </ul>`;
+  }
+
+  function showWizardStep(i) {
+    steps.forEach((s, idx) => s.classList.toggle('active', idx === i));
+    prevBtn.disabled = i === 0;
+    nextBtn.textContent = i === steps.length - 1 ? 'Finish' : 'Next';
+    if (progress) progress.textContent = `Step ${i + 1} of ${steps.length}`;
+    if (i === steps.length - 1) populateSummary();
+    stepIndex = i;
+  }
+
+  prevBtn.addEventListener('click', () => {
+    if (stepIndex > 0) showWizardStep(stepIndex - 1);
+  });
+  nextBtn.addEventListener('click', () => {
+    if (stepIndex < steps.length - 1) showWizardStep(stepIndex + 1);
+    else hide('modal-wizard');
+  });
+
+  btnWizard.addEventListener('click', () => {
+    ABILS.forEach(a => {
+      const sel = $('wiz-' + a);
+      const orig = $(a);
+      const modSpan = $('wiz-' + a + '-mod');
+      if (sel && orig) {
+        sel.value = orig.value;
+        if (modSpan) modSpan.textContent = $(a + '-mod').textContent;
+      }
+    });
+    storyFields.forEach(([wizId, baseId]) => {
+      const w = $(wizId);
+      const b = $(baseId);
+      if (w && b) w.value = b.value;
+    });
+    show('modal-wizard');
+    showWizardStep(0);
+  });
+}
+
 /* ========= Rules ========= */
 const btnRules = $('btn-rules');
 const btnPageUp = $('cccg-page-up');

--- a/styles/main.css
+++ b/styles/main.css
@@ -218,3 +218,9 @@ select[required]:valid{
   padding-right:64px;
 }
 
+/* wizard */
+.wizard-step{display:none}
+.wizard-step.active{display:block}
+.wizard-nav{display:flex;align-items:center;justify-content:space-between;margin-top:16px}
+#wizard-progress{flex:1;text-align:center}
+


### PR DESCRIPTION
## Summary
- Add "Wizard" option to menu and modal skeleton for step-by-step character creation
- Implement interactive wizard syncing ability scores, gear, and story inputs to the tracker
- Add final summary step with step indicator to review choices
- Style wizard steps and navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a400bb55c4832eabdd535ddde74b21