### PR TITLE
Improve wizard progress display with percentages

### DIFF
--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -61,8 +61,17 @@ describe('calculateArmorBonus', () => {
 });
 
 describe('wizardProgress', () => {
-  test('formats current step out of total', () => {
-    expect(wizardProgress(0, 3)).toBe('Step 1 of 3');
-    expect(wizardProgress(2, 3)).toBe('Step 3 of 3');
+  test('formats current step out of total with percentage', () => {
+    expect(wizardProgress(0, 3)).toBe('Step 1 of 3 (33%)');
+    expect(wizardProgress(2, 3)).toBe('Step 3 of 3 (100%)');
+  });
+
+  test('clamps step index within range', () => {
+    expect(wizardProgress(-1, 3)).toBe('Step 1 of 3 (33%)');
+    expect(wizardProgress(5, 3)).toBe('Step 3 of 3 (100%)');
+  });
+
+  test('handles non-positive totals', () => {
+    expect(wizardProgress(0, 0)).toBe('Step 1 of 1 (100%)');
   });
 });

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -7,7 +7,8 @@ export const proficiencyBonus = (level) => Math.floor((num(level) - 1) / 4) + 2;
 export const wizardProgress = (i, total) => {
   const curr = Math.max(1, Math.min(num(i) + 1, num(total)));
   const max = Math.max(num(total), curr);
-  return `Step ${curr} of ${max}`;
+  const pct = Math.round((curr / max) * 100);
+  return `Step ${curr} of ${max} (${pct}%)`;
 };
 export function calculateArmorBonus(){
   let body=[], head=[], shield=0, misc=0;


### PR DESCRIPTION
## Summary
- show completion percentage in the character creation wizard
- expand wizardProgress tests for edge cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a407d5cacc832eab52c9d0256c53c1