### PR TITLE
Cache rules PDF to prevent 404

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,11 @@
-const CACHE = 'cccg-cache-v2';
+const CACHE = 'cccg-cache-v3';
 const ASSETS = [
   './',
   './index.html',
   './styles/main.css',
   './scripts/main.js',
-  './scripts/helpers.js'
+  './scripts/helpers.js',
+  './ccccg.pdf'
 ];
 self.addEventListener('install', e => {
   self.skipWaiting();


### PR DESCRIPTION
## Summary
- Ensure rules PDF is pre-cached by service worker
- Bump cache version so clients pick up the PDF

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4316ce078832e8214b8effb52b149