### PR TITLE
fix: cache pdf for rules modal

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,11 @@
-const CACHE = 'cccg-cache-v2';
+const CACHE = 'cccg-cache-v3';
 const ASSETS = [
   './',
   './index.html',
   './styles/main.css',
   './scripts/main.js',
-  './scripts/helpers.js'
+  './scripts/helpers.js',
+  './ccccg.pdf'
 ];
 self.addEventListener('install', e => {
   self.skipWaiting();


### PR DESCRIPTION
## Summary
- cache CCCCG rules PDF in service worker
- bump cache version to ensure updated assets are used

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4316ce078832e8214b8effb52b149