### PR TITLE
Expand wizard to cover all CCCCG steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -551,17 +551,102 @@
     </button>
     <div id="wizard-steps">
       <div class="wizard-step">
+        <h3>Classification</h3>
+        <select id="wiz-classification">
+          <option value="">Select one</option>
+          <option>Mutant</option>
+          <option>Enhanced Human</option>
+          <option>Magic User</option>
+          <option>Alien/Extraterrestrial</option>
+          <option>Mystical Being</option>
+        </select>
+      </div>
+      <div class="wizard-step">
+        <h3>Power Style</h3>
+        <div class="grid grid-2">
+          <div class="card"><label for="wiz-power-style">Primary Style</label>
+            <select id="wiz-power-style">
+              <option value="">Select one</option>
+              <option>Physical Powerhouse</option>
+              <option>Energy Manipulator</option>
+              <option>Speedster</option>
+              <option>Telekinetic/Psychic</option>
+              <option>Illusionist</option>
+              <option>Shape-shifter</option>
+              <option>Elemental Controller</option>
+            </select>
+          </div>
+          <div class="card"><label for="wiz-power-style-2">Secondary Style</label>
+            <select id="wiz-power-style-2">
+              <option value="">Select one</option>
+              <option>None</option>
+              <option>Physical Powerhouse</option>
+              <option>Energy Manipulator</option>
+              <option>Speedster</option>
+              <option>Telekinetic/Psychic</option>
+              <option>Illusionist</option>
+              <option>Shape-shifter</option>
+              <option>Elemental Controller</option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <div class="wizard-step">
+        <h3>Origin Story</h3>
+        <select id="wiz-origin">
+          <option value="">Select one</option>
+          <option>The Accident</option>
+          <option>The Experiment</option>
+          <option>The Legacy</option>
+          <option>The Awakening</option>
+          <option>The Pact</option>
+          <option>The Lost Time</option>
+          <option>The Exposure</option>
+          <option>The Rebirth</option>
+          <option>The Vigil</option>
+          <option>The Redemption</option>
+        </select>
+      </div>
+      <div class="wizard-step">
         <h3>Ability Scores</h3>
         <div id="wizard-abil-grid" class="grid ability-grid"></div>
       </div>
       <div class="wizard-step">
-        <h3>Gear</h3>
-        <p>Use the buttons below to add starting gear.</p>
+        <h3>Toughness Class (TC)</h3>
+        <input id="wiz-tc" type="number" inputmode="numeric"/>
+      </div>
+      <div class="wizard-step">
+        <h3>Hit Points (HP)</h3>
+        <input id="wiz-hp" type="number" inputmode="numeric"/>
+      </div>
+      <div class="wizard-step">
+        <h3>Customize Powers &amp; Gear</h3>
+        <p>Use the buttons below to add starting powers and gear.</p>
         <div class="actions" style="justify-content:center">
+          <button id="wiz-add-power">Add Power</button>
           <button id="wiz-add-weapon">Add Weapon</button>
           <button id="wiz-add-armor">Add Armor</button>
           <button id="wiz-add-item">Add Item</button>
         </div>
+      </div>
+      <div class="wizard-step">
+        <h3>Stamina Points (SP)</h3>
+        <input id="wiz-sp-max" type="number" inputmode="numeric"/>
+      </div>
+      <div class="wizard-step">
+        <h3>Alignment</h3>
+        <select id="wiz-alignment">
+          <option value="">Select one</option>
+          <option>Paragon (Lawful Light)</option>
+          <option>Guardian (Neutral Light)</option>
+          <option>Vigilante (Chaotic Light)</option>
+          <option>Sentinel (Lawful Neutral)</option>
+          <option>Outsider (True Neutral)</option>
+          <option>Wildcard (Chaotic Neutral)</option>
+          <option>Inquisitor (Lawful Shadow)</option>
+          <option>Anti-Hero (Neutral Shadow)</option>
+          <option>Renegade (Chaotic Shadow)</option>
+        </select>
       </div>
       <div class="wizard-step">
         <h3>Story</h3>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1243,9 +1243,52 @@ if (btnWizard && modalWizard) {
     });
   }
 
+  $('wiz-add-power').addEventListener('click', () => $('add-power').click());
   $('wiz-add-weapon').addEventListener('click', () => $('add-weapon').click());
   $('wiz-add-armor').addEventListener('click', () => $('add-armor').click());
   $('wiz-add-item').addEventListener('click', () => $('add-item').click());
+
+  const selectFields = [
+    ['wiz-classification', 'classification'],
+    ['wiz-power-style', 'power-style'],
+    ['wiz-power-style-2', 'power-style-2'],
+    ['wiz-origin', 'origin'],
+    ['wiz-alignment', 'alignment']
+  ];
+  selectFields.forEach(([wizId, baseId]) => {
+    const w = $(wizId);
+    const b = $(baseId);
+    if (w && b) {
+      w.addEventListener('change', () => {
+        b.value = w.value;
+        b.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+  });
+
+  const tcField = $('wiz-tc');
+  if (tcField && elTC) {
+    tcField.addEventListener('input', () => {
+      elTC.value = tcField.value;
+      elTC.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  const hpField = $('wiz-hp');
+  if (hpField && elHPBar) {
+    hpField.addEventListener('input', () => {
+      elHPBar.max = hpField.value || 0;
+      setHP(hpField.value);
+    });
+  }
+
+  const spField = $('wiz-sp-max');
+  if (spField && elSPBar) {
+    spField.addEventListener('input', () => {
+      elSPBar.max = spField.value || 0;
+      setSP(spField.value);
+    });
+  }
 
   const storyFields = [
     ['wiz-superhero', 'superhero'],
@@ -1291,6 +1334,14 @@ if (btnWizard && modalWizard) {
         if (modSpan) modSpan.textContent = $(a + '-mod').textContent;
       }
     });
+    selectFields.forEach(([wizId, baseId]) => {
+      const w = $(wizId);
+      const b = $(baseId);
+      if (w && b) w.value = b.value;
+    });
+    if (tcField && elTC) tcField.value = elTC.value;
+    if (hpField && elHPBar) hpField.value = elHPBar.max;
+    if (spField && elSPBar) spField.value = elSPBar.max;
     storyFields.forEach(([wizId, baseId]) => {
       const w = $(wizId);
       const b = $(baseId);


### PR DESCRIPTION
## Summary
- extend character creation wizard to include classification, power style, origin story, TC, HP, SP, alignment, and story steps from the CCCCG
- add buttons to create powers and gear directly from the wizard
- sync wizard inputs with existing sheet fields for a seamless setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a43bec88a0832e8e784c8126ac554e