### PR TITLE
Remove auto-calculated fields from wizard

### DIFF
--- a/index.html
+++ b/index.html
@@ -612,14 +612,6 @@
         <div id="wizard-abil-grid" class="grid ability-grid"></div>
       </div>
       <div class="wizard-step">
-        <h3>Toughness Class (TC)</h3>
-        <input id="wiz-tc" type="number" inputmode="numeric"/>
-      </div>
-      <div class="wizard-step">
-        <h3>Hit Points (HP)</h3>
-        <input id="wiz-hp" type="number" inputmode="numeric"/>
-      </div>
-      <div class="wizard-step">
         <h3>Customize Powers &amp; Gear</h3>
         <p>Use the buttons below to add starting powers and gear.</p>
         <div class="actions" style="justify-content:center">
@@ -628,10 +620,6 @@
           <button id="wiz-add-armor">Add Armor</button>
           <button id="wiz-add-item">Add Item</button>
         </div>
-      </div>
-      <div class="wizard-step">
-        <h3>Stamina Points (SP)</h3>
-        <input id="wiz-sp-max" type="number" inputmode="numeric"/>
       </div>
       <div class="wizard-step">
         <h3>Alignment</h3>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1266,30 +1266,6 @@ if (btnWizard && modalWizard) {
     }
   });
 
-  const tcField = $('wiz-tc');
-  if (tcField && elTC) {
-    tcField.addEventListener('input', () => {
-      elTC.value = tcField.value;
-      elTC.dispatchEvent(new Event('input', { bubbles: true }));
-    });
-  }
-
-  const hpField = $('wiz-hp');
-  if (hpField && elHPBar) {
-    hpField.addEventListener('input', () => {
-      elHPBar.max = hpField.value || 0;
-      setHP(hpField.value);
-    });
-  }
-
-  const spField = $('wiz-sp-max');
-  if (spField && elSPBar) {
-    spField.addEventListener('input', () => {
-      elSPBar.max = spField.value || 0;
-      setSP(spField.value);
-    });
-  }
-
   const storyFields = [
     ['wiz-superhero', 'superhero'],
     ['wiz-secret', 'secret'],
@@ -1339,9 +1315,6 @@ if (btnWizard && modalWizard) {
       const b = $(baseId);
       if (w && b) w.value = b.value;
     });
-    if (tcField && elTC) tcField.value = elTC.value;
-    if (hpField && elHPBar) hpField.value = elHPBar.max;
-    if (spField && elSPBar) spField.value = elSPBar.max;
     storyFields.forEach(([wizId, baseId]) => {
       const w = $(wizId);
       const b = $(baseId);


### PR DESCRIPTION
## Summary
- drop Toughness Class, Hit Points, and Stamina Points steps from the character creation wizard
- remove sync logic for those auto-derived values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a457994af8832eb9f180c7209470af