### PR TITLE
Ensure Firebase config loads from correct path

### DIFF
--- a/__tests__/firebase.test.js
+++ b/__tests__/firebase.test.js
@@ -1,0 +1,26 @@
+import { jest } from '@jest/globals';
+
+describe('loadFirebaseConfig', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('fetches default config file', async () => {
+    const mockFetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    global.fetch = mockFetch;
+    const { loadFirebaseConfig } = await import('../scripts/firebase.js');
+    await loadFirebaseConfig();
+    expect(mockFetch).toHaveBeenCalledWith('firebase-config.json');
+  });
+
+  test('respects FIREBASE_CONFIG_URL override', async () => {
+    const mockFetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    global.fetch = mockFetch;
+    global.FIREBASE_CONFIG_URL = 'alt-config.json';
+    const { loadFirebaseConfig } = await import('../scripts/firebase.js');
+    await loadFirebaseConfig();
+    expect(mockFetch).toHaveBeenCalledWith('alt-config.json');
+    delete global.FIREBASE_CONFIG_URL;
+  });
+});
+

--- a/scripts/firebase.js
+++ b/scripts/firebase.js
@@ -1,0 +1,28 @@
+// Utility for loading Firebase configuration.
+// Separated from main.js so it can be unit tested in isolation without
+// triggering DOM-heavy side effects.
+
+let firebaseCfgPromise;
+
+/**
+ * Fetch the Firebase configuration JSON.
+ *
+ * The config file lives alongside index.html by default. A global
+ * `FIREBASE_CONFIG_URL` can override the location and `FIREBASE_CONFIG`
+ * can supply additional/override values.
+ */
+export async function loadFirebaseConfig() {
+  if (!firebaseCfgPromise) {
+    const url = globalThis.FIREBASE_CONFIG_URL || 'firebase-config.json';
+    firebaseCfgPromise = fetch(url)
+      .then(r => (r.ok ? r.json() : null))
+      .catch(() => null);
+  }
+
+  let cfg = await firebaseCfgPromise;
+  if (globalThis.FIREBASE_CONFIG) {
+    cfg = Object.assign({}, cfg, globalThis.FIREBASE_CONFIG);
+  }
+  return cfg;
+}
+


### PR DESCRIPTION
## Summary
- refactor Firebase config loading into a standalone module
- default to `firebase-config.json` and allow URL overrides
- test configuration loader behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46c209618832e9e5500bc3bba940b