### PR TITLE
Render CCCCG rules page-by-page with PDF.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -672,11 +672,12 @@
         </svg>
       </button>
     </div>
-    <iframe src="./ccccg.pdf" title="CCCG PDF"></iframe>
+    <canvas id="cccg-canvas"></canvas>
   </div>
 </div>
 
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 <script type="module" src="scripts/main.js"></script>
 </body>
 </html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,9 +3,34 @@ import { $, qs, qsa, num, mod, calculateArmorBonus, wizardProgress } from './hel
 import { saveLocal, loadLocal } from './storage.js';
 let lastFocus = null;
 let cccgPage = 1;
-const ruleFrame = qs('#modal-rules iframe');
+const cccgCanvas = qs('#cccg-canvas');
+const cccgCtx = cccgCanvas ? cccgCanvas.getContext('2d') : null;
 const CCCCG_SRC = './ccccg.pdf';
+let cccgDoc = null;
+if (typeof pdfjsLib !== 'undefined') {
+  pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
+}
 const ICON_TRASH = '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 7.5h12m-9 0v9m6-9v9M4.5 7.5l1 12A2.25 2.25 0 007.75 21h8.5a2.25 2.25 0 002.25-2.25l1-12M9.75 7.5V4.875A1.125 1.125 0 0110.875 3.75h2.25A1.125 1.125 0 0114.25 4.875V7.5"/></svg>';
+
+async function renderCCCG(){
+  if(!cccgCanvas || !cccgCtx || typeof pdfjsLib === 'undefined') return;
+  if(!cccgDoc){
+    try{
+      cccgDoc = await pdfjsLib.getDocument(CCCCG_SRC).promise;
+    }catch(e){ return; }
+  }
+  const total = cccgDoc.numPages;
+  if(cccgPage < 1) cccgPage = 1;
+  if(cccgPage > total) cccgPage = total;
+  const page = await cccgDoc.getPage(cccgPage);
+  const viewport = page.getViewport({ scale:1 });
+  const width = cccgCanvas.parentElement.clientWidth;
+  const scale = width / viewport.width;
+  const vp = page.getViewport({ scale });
+  cccgCanvas.height = vp.height;
+  cccgCanvas.width = vp.width;
+  await page.render({ canvasContext: cccgCtx, viewport: vp }).promise;
+}
 
 function applyDeleteIcon(btn){
   if(!btn) return;
@@ -838,7 +863,7 @@ qsa('[data-rule]').forEach(el=>{
   el.title = `See CCCCG p.${page}`;
   el.addEventListener('click', ()=>{
     cccgPage = page;
-    if(ruleFrame) ruleFrame.src = `${CCCCG_SRC}#page=${cccgPage}`;
+    renderCCCG();
     show('modal-rules');
   });
 });
@@ -1085,15 +1110,11 @@ document.addEventListener('keydown', e=>{
     if (e.key === 'PageDown') {
       e.preventDefault();
       cccgPage++;
-      if (ruleFrame) {
-        ruleFrame.src = `${CCCCG_SRC}#page=${cccgPage}`;
-      }
+      renderCCCG();
     } else if (e.key === 'PageUp') {
       e.preventDefault();
       if (cccgPage > 1) cccgPage--;
-      if (ruleFrame) {
-        ruleFrame.src = `${CCCCG_SRC}#page=${cccgPage}`;
-      }
+      renderCCCG();
     }
   }
 });
@@ -1263,20 +1284,20 @@ const btnPageUp = $('cccg-page-up');
 const btnPageDown = $('cccg-page-down');
 if (btnRules) {
   btnRules.addEventListener('click', ()=>{
-    if(ruleFrame) ruleFrame.src = `${CCCCG_SRC}#page=${cccgPage}`;
+    renderCCCG();
     show('modal-rules');
   });
 }
 if (btnPageUp) {
   btnPageUp.addEventListener('click', ()=>{
     if(cccgPage>1) cccgPage--;
-    if(ruleFrame) ruleFrame.src = `${CCCCG_SRC}#page=${cccgPage}`;
+    renderCCCG();
   });
 }
 if (btnPageDown) {
   btnPageDown.addEventListener('click', ()=>{
     cccgPage++;
-    if(ruleFrame) ruleFrame.src = `${CCCCG_SRC}#page=${cccgPage}`;
+    renderCCCG();
   });
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -102,7 +102,7 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
 .modal .actions{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}
 #modal-rules{align-items:stretch;padding:0}
 #modal-rules .modal-rules{max-width:none;width:100%;height:100%;border-radius:0;border:none;padding:0;max-height:none}
-#modal-rules .modal-rules iframe{width:100%;height:100%;border:none}
+#modal-rules .modal-rules canvas{width:100%;height:100%;display:block}
 .toast{position:fixed;bottom:18px;right:18px;background:var(--surface);border:1px solid var(--accent);padding:10px 12px;border-radius:var(--radius);opacity:0;transform:translateY(8px);transition:opacity .2s,transform .2s;z-index:2000}
 .toast.show{opacity:1;transform:translateY(0)}
 .toast.success{border-color:var(--success);color:var(--success)}


### PR DESCRIPTION
## Summary
- replace rules iframe with canvas and PDF.js viewer
- add PDF.js rendering logic for page navigation
- style rules modal for canvas display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a482c9ccb4832ebbd594abccc1c5ae