### PR TITLE
Clamp negative armor bonuses

### DIFF
--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -58,6 +58,17 @@ describe('calculateArmorBonus', () => {
     `;
     expect(calculateArmorBonus()).toBe(10);
   });
+
+  test('ignores negative armor bonuses', () => {
+    document.body.innerHTML = `
+      <div data-kind="armor">
+        <input type="checkbox" data-f="equipped" checked>
+        <input data-f="bonus" value="-5">
+        <select data-f="slot"><option>Head</option></select>
+      </div>
+    `;
+    expect(calculateArmorBonus()).toBe(0);
+  });
 });
 
 describe('wizardProgress', () => {

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -15,7 +15,7 @@ export function calculateArmorBonus(){
   qsa("[data-kind='armor']").forEach(card=>{
     const eq = qs("input[type='checkbox'][data-f='equipped']", card);
     const bonusEl = qs("input[data-f='bonus']", card);
-    const bonus = num(bonusEl ? bonusEl.value : 0);
+    const bonus = Math.max(0, num(bonusEl ? bonusEl.value : 0));
     const slotEl = qs("select[data-f='slot']", card);
     const slot = slotEl ? slotEl.value : 'Body';
     if (eq && eq.checked){


### PR DESCRIPTION
## Summary
- ignore negative armor values when computing total AC bonus
- add regression test to ensure negative armor bonuses are ignored

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a48c4168cc832ebd5e86891df5ac9d