### PR TITLE
fix: ensure proficiency bonus minimum

### DIFF
--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -19,6 +19,9 @@ describe('proficiencyBonus', () => {
     expect(proficiencyBonus(1)).toBe(2);
     expect(proficiencyBonus(5)).toBe(3);
     expect(proficiencyBonus('12')).toBe(4);
+    expect(proficiencyBonus(0)).toBe(2);
+    expect(proficiencyBonus(-3)).toBe(2);
+    expect(proficiencyBonus('abc')).toBe(2);
   });
 });
 

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -3,7 +3,15 @@ export const qs = (s, r=document) => r.querySelector(s);
 export const qsa = (s, r=document) => Array.from(r.querySelectorAll(s));
 export const num = (v) => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
 export const mod = (score) => Math.floor((num(score) - 10) / 2);
-export const proficiencyBonus = (level) => Math.floor((num(level) - 1) / 4) + 2;
+// Proficiency bonuses in 5e are based on character level and always assume a
+// minimum level of 1. The previous implementation allowed invalid or
+// non-numeric values to fall through as level 0 which produced an incorrect
+// bonus of 1. Clamp the provided level to at least 1 so that malformed input
+// still yields the baseline +2 bonus.
+export const proficiencyBonus = (level) => {
+  const lvl = Math.max(1, num(level));
+  return Math.floor((lvl - 1) / 4) + 2;
+};
 export const wizardProgress = (i, total) => {
   const curr = Math.max(1, Math.min(num(i) + 1, num(total)));
   const max = Math.max(num(total), curr);


### PR DESCRIPTION
## Summary
- clamp proficiencyBonus input to at least level 1
- expand tests for proficiency bonus edge cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48e3ad0a8832e92f335784df34860