### PR TITLE
Add player registration and DM account management

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -1,0 +1,36 @@
+import {
+  registerPlayer,
+  getPlayers,
+  registerDM,
+  loginDM,
+  editPlayerCharacter,
+  savePlayerCharacter,
+  loadPlayerCharacter,
+} from '../scripts/users.js';
+
+describe('user management', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('registers players and lists them', () => {
+    registerPlayer('Alice');
+    registerPlayer('Bob');
+    expect(getPlayers()).toEqual(['Alice', 'Bob']);
+  });
+
+  test('dm registration and editing', async () => {
+    registerPlayer('Alice');
+    registerDM('secret');
+    expect(loginDM('secret')).toBe(true);
+    await savePlayerCharacter('Alice', { hp: 10 });
+    await editPlayerCharacter('Alice', { hp: 20 });
+    const data = await loadPlayerCharacter('Alice');
+    expect(data.hp).toBe(20);
+  });
+
+  test('edit fails without dm', () => {
+    expect(() => editPlayerCharacter('Bob', {})).toThrow('Not authorized');
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -68,6 +68,32 @@
 </header>
 
 <main>
+  <!-- USER ADMIN -->
+  <section id="user-admin">
+    <h2>User Admin</h2>
+    <fieldset class="card">
+      <legend>Register Player</legend>
+      <div class="inline">
+        <input id="player-name" placeholder="Player name"/>
+        <button id="register-player" class="btn-sm">Register</button>
+      </div>
+    </fieldset>
+    <fieldset class="card">
+      <legend>DM Account</legend>
+      <div class="inline">
+        <input id="dm-password" type="password" placeholder="Password"/>
+        <button id="dm-register" class="btn-sm">Register DM</button>
+        <button id="dm-login" class="btn-sm">Login DM</button>
+      </div>
+    </fieldset>
+    <fieldset class="card" id="dm-tools" style="display:none">
+      <legend>Edit Player</legend>
+      <div class="inline">
+        <select id="player-select"></select>
+        <button id="load-player" class="btn-sm">Load</button>
+      </div>
+    </fieldset>
+  </section>
   <!-- COMBAT -->
   <section data-tab="combat">
     <h2 data-rule="8">Tools</h2>
@@ -678,6 +704,7 @@
 
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
+<script type="module" src="scripts/users.js"></script>
 <script type="module" src="scripts/main.js"></script>
 </body>
 </html>

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -1,0 +1,129 @@
+import { saveLocal, loadLocal } from './storage.js';
+import { $ } from './helpers.js';
+
+const PLAYERS_KEY = 'players';
+const DM_KEY = 'dm-account';
+const DM_SESSION = 'dm-session';
+
+export function getPlayers() {
+  const raw = localStorage.getItem(PLAYERS_KEY);
+  return raw ? JSON.parse(raw) : [];
+}
+
+export function registerPlayer(name) {
+  const players = getPlayers();
+  if (name && !players.includes(name)) {
+    players.push(name);
+    localStorage.setItem(PLAYERS_KEY, JSON.stringify(players));
+  }
+  return players;
+}
+
+export function registerDM(password) {
+  if (localStorage.getItem(DM_KEY)) throw new Error('DM already registered');
+  localStorage.setItem(DM_KEY, JSON.stringify({ password }));
+}
+
+export function loginDM(password) {
+  const dm = JSON.parse(localStorage.getItem(DM_KEY) || '{}');
+  if (dm.password === password) {
+    localStorage.setItem(DM_SESSION, '1');
+    return true;
+  }
+  return false;
+}
+
+export function isDM() {
+  return localStorage.getItem(DM_SESSION) === '1';
+}
+
+export function logoutDM() {
+  localStorage.removeItem(DM_SESSION);
+}
+
+export function savePlayerCharacter(player, data) {
+  return saveLocal('player:' + player, data);
+}
+
+export function loadPlayerCharacter(player) {
+  return loadLocal('player:' + player);
+}
+
+export function editPlayerCharacter(player, data) {
+  if (!isDM()) throw new Error('Not authorized');
+  return savePlayerCharacter(player, data);
+}
+
+// ===== DOM Wiring =====
+function updatePlayerList() {
+  const sel = $('player-select');
+  if (!sel) return;
+  const players = getPlayers();
+  sel.innerHTML = players.map(p => `<option value="${p}">${p}</option>`).join('');
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    updatePlayerList();
+
+    const regBtn = $('register-player');
+    if (regBtn) {
+      regBtn.addEventListener('click', () => {
+        const nameInput = $('player-name');
+        const name = nameInput.value.trim();
+        registerPlayer(name);
+        nameInput.value = '';
+        updatePlayerList();
+      });
+    }
+
+    const dmRegBtn = $('dm-register');
+    if (dmRegBtn) {
+      dmRegBtn.addEventListener('click', () => {
+        const pass = $('dm-password').value;
+        try {
+          registerDM(pass);
+          console.log('DM registered');
+        } catch (e) {
+          console.error('DM already registered');
+        }
+      });
+    }
+
+    const dmLoginBtn = $('dm-login');
+    if (dmLoginBtn) {
+      dmLoginBtn.addEventListener('click', () => {
+        const pass = $('dm-password').value;
+        if (loginDM(pass)) {
+          const tools = $('dm-tools');
+          if (tools) tools.style.display = 'block';
+          updatePlayerList();
+        } else {
+          console.error('Invalid password');
+        }
+      });
+    }
+
+    if (isDM()) {
+      const tools = $('dm-tools');
+      if (tools) tools.style.display = 'block';
+      updatePlayerList();
+    }
+
+    const loadBtn = $('load-player');
+    if (loadBtn) {
+      loadBtn.addEventListener('click', async () => {
+        const sel = $('player-select');
+        if (!sel || !sel.value) return;
+        try {
+          const data = await loadPlayerCharacter(sel.value);
+          localStorage.setItem('autosave', JSON.stringify(data));
+          location.reload();
+        } catch (e) {
+          console.error('Could not load player', e);
+        }
+      });
+    }
+  });
+}
+


### PR DESCRIPTION
## Summary
- add user admin section for registering players and DM login
- manage players and DM permissions via new users.js module
- support DM editing player characters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d767f468832eabf628af45e01706