### PR TITLE
Remove save modal and simplify saving

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,20 +488,7 @@
   </div>
 </div>
 
-<!-- SAVE / LOAD -->
-<div class="overlay hidden" id="modal-save" aria-hidden="true">
-  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
-    <button class="x" data-close aria-label="Close">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
-      </svg>
-    </button>
-    <h3>Save Character</h3>
-    <label for="save-key">Save name</label>
-    <input id="save-key" placeholder="e.g., Shawn"/>
-    <div class="actions"><button id="do-save">Save</button></div>
-  </div>
-</div>
+<!-- LOAD -->
 <div class="overlay hidden" id="modal-load" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
     <button class="x" data-close aria-label="Close">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -255,7 +255,6 @@ document.addEventListener('click', e => {
       !e.target.closest('#statuses') &&
       !e.target.closest('#modal-enc') &&
       !e.target.closest('#modal-load') &&
-      !e.target.closest('#modal-save') &&
       !e.target.closest('#modal-log') &&
       !e.target.closest('#modal-log-full') &&
       !e.target.closest('#modal-rules') &&
@@ -1127,22 +1126,22 @@ document.addEventListener('keydown', e=>{
   }
   pushHistory();
 })();
-$('btn-save').addEventListener('click', ()=>{ $('save-key').value = localStorage.getItem('last-save') || $('superhero').value || ''; show('modal-save'); });
-$('btn-load').addEventListener('click', ()=>{ $('load-key').value = ''; show('modal-load'); });
-$('do-save').addEventListener('click', async ()=>{
-  const btn = $('do-save');
-  const name = $('save-key').value.trim(); if(!name) return toast('Enter a name','error');
+$('btn-save').addEventListener('click', async ()=>{
+  const btn = $('btn-save');
+  const name = $('superhero').value.trim() || localStorage.getItem('last-save');
+  if(!name) return toast('Enter a name','error');
   btn.classList.add('loading'); btn.disabled = true;
   try{
     const data = serialize();
     await saveLocal(name, data);
     try { await saveCloud(name, data); } catch(e) { console.error(e); }
-    hide('modal-save'); toast('Saved','success');
+    toast('Saved','success');
   }
   finally{
     btn.classList.remove('loading'); btn.disabled = false;
   }
 });
+$('btn-load').addEventListener('click', ()=>{ $('load-key').value = ''; show('modal-load'); });
 $('do-load').addEventListener('click', async ()=>{
   const btn = $('do-load');
   const name = $('load-key').value.trim(); if(!name) return toast('Enter a name','error');


### PR DESCRIPTION
## Summary
- drop unused save modal markup and related event handling
- save characters directly from the Save button using hero name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4d882af80832e9f503a18a43fbad4