### PR TITLE
Add player login and automatic save feedback

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -1,0 +1,43 @@
+import {
+  registerPlayer,
+  getPlayers,
+  registerDM,
+  loginDM,
+  loginPlayer,
+  currentPlayer,
+  editPlayerCharacter,
+  savePlayerCharacter,
+  loadPlayerCharacter,
+} from '../scripts/users.js';
+
+describe('user management', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('registers players with passwords and login', () => {
+    registerPlayer('Alice', 'pw1');
+    registerPlayer('Bob', 'pw2');
+    expect(getPlayers()).toEqual([
+      { name: 'Alice', password: 'pw1' },
+      { name: 'Bob', password: 'pw2' },
+    ]);
+    expect(loginPlayer('Alice', 'pw1')).toBe(true);
+    expect(currentPlayer()).toBe('Alice');
+  });
+
+  test('dm registration and editing', async () => {
+    registerPlayer('Alice', 'pw');
+    registerDM('secret');
+    expect(loginDM('secret')).toBe(true);
+    await savePlayerCharacter('Alice', { hp: 10 });
+    await editPlayerCharacter('Alice', { hp: 20 });
+    const data = await loadPlayerCharacter('Alice');
+    expect(data.hp).toBe(20);
+  });
+
+  test('edit fails without dm', () => {
+    expect(() => editPlayerCharacter('Bob', {})).toThrow('Not authorized');
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -68,6 +68,34 @@
 </header>
 
 <main>
+  <!-- USER ADMIN -->
+  <section id="user-admin">
+    <h2>User Admin</h2>
+    <fieldset class="card">
+      <legend>Player Account</legend>
+      <div class="inline">
+        <input id="player-name" placeholder="Player name"/>
+        <input id="player-pass" type="password" placeholder="Password"/>
+        <button id="player-register" class="btn-sm">Register</button>
+        <button id="player-login" class="btn-sm">Login</button>
+      </div>
+    </fieldset>
+    <fieldset class="card">
+      <legend>DM Account</legend>
+      <div class="inline">
+        <input id="dm-password" type="password" placeholder="Password"/>
+        <button id="dm-register" class="btn-sm">Register DM</button>
+        <button id="dm-login" class="btn-sm">Login DM</button>
+      </div>
+    </fieldset>
+    <fieldset class="card" id="dm-tools" style="display:none">
+      <legend>Edit Player</legend>
+      <div class="inline">
+        <select id="player-select"></select>
+        <button id="load-player" class="btn-sm">Load</button>
+      </div>
+    </fieldset>
+  </section>
   <!-- COMBAT -->
   <section data-tab="combat">
     <h2 data-rule="8">Tools</h2>
@@ -678,6 +706,7 @@
 
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
+<script type="module" src="scripts/users.js"></script>
 <script type="module" src="scripts/main.js"></script>
 </body>
 </html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,7 @@
 /* ========= helpers ========= */
 import { $, qs, qsa, num, mod, calculateArmorBonus, wizardProgress } from './helpers.js';
 import { saveLocal, loadLocal, saveCloud, loadCloud } from './storage.js';
+import { currentPlayer } from './users.js';
 let lastFocus = null;
 let cccgPage = 1;
 const cccgCanvas = qs('#cccg-canvas');
@@ -1127,7 +1128,22 @@ document.addEventListener('keydown', e=>{
   }
   pushHistory();
 })();
-$('btn-save').addEventListener('click', ()=>{ $('save-key').value = localStorage.getItem('last-save') || $('superhero').value || ''; show('modal-save'); });
+$('btn-save').addEventListener('click', async ()=>{
+  const player = currentPlayer();
+  if (player) {
+    const data = serialize();
+    const localRes = await saveLocal('player:' + player, data);
+    const cloudRes = await saveCloud('player:' + player, data);
+    let msg = '';
+    msg += localRes.success ? 'Local save succeeded' : `Local save failed: ${localRes.error}`;
+    msg += '\n';
+    msg += cloudRes.success ? 'Cloud save succeeded' : `Cloud save failed: ${cloudRes.error}`;
+    alert(msg);
+  } else {
+    $('save-key').value = localStorage.getItem('last-save') || $('superhero').value || '';
+    show('modal-save');
+  }
+});
 $('btn-load').addEventListener('click', ()=>{ $('load-key').value = ''; show('modal-load'); });
 $('do-save').addEventListener('click', async ()=>{
   const btn = $('do-save');

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -2,8 +2,10 @@ export async function saveLocal(name, payload) {
   try {
     localStorage.setItem('save:' + name, JSON.stringify(payload));
     localStorage.setItem('last-save', name);
+    return { success: true };
   } catch (e) {
     console.error('Local save failed', e);
+    return { success: false, error: e.message };
   }
 }
 
@@ -70,8 +72,10 @@ export async function saveCloud(name, payload) {
     const { ref, set } = await import('https://www.gstatic.com/firebasejs/11.0.1/firebase-database.js');
     await set(ref(db, 'saves/' + name), payload);
     localStorage.setItem('last-save', name);
+    return { success: true };
   } catch (e) {
     console.error('Cloud save failed', e);
+    return { success: false, error: e.message };
   }
 }
 

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -1,0 +1,163 @@
+import { saveLocal, loadLocal } from './storage.js';
+import { $ } from './helpers.js';
+
+const PLAYERS_KEY = 'players';
+const DM_KEY = 'dm-account';
+const DM_SESSION = 'dm-session';
+const PLAYER_SESSION = 'player-session';
+
+export function getPlayers() {
+  const raw = localStorage.getItem(PLAYERS_KEY);
+  return raw ? JSON.parse(raw) : [];
+}
+
+export function registerPlayer(name, password) {
+  const players = getPlayers();
+  if (name && password && !players.find(p => p.name === name)) {
+    players.push({ name, password });
+    localStorage.setItem(PLAYERS_KEY, JSON.stringify(players));
+  }
+  return players;
+}
+
+export function loginPlayer(name, password) {
+  const players = getPlayers();
+  const player = players.find(p => p.name === name && p.password === password);
+  if (player) {
+    localStorage.setItem(PLAYER_SESSION, name);
+    return true;
+  }
+  return false;
+}
+
+export function currentPlayer() {
+  return localStorage.getItem(PLAYER_SESSION);
+}
+
+export function logoutPlayer() {
+  localStorage.removeItem(PLAYER_SESSION);
+}
+
+export function registerDM(password) {
+  if (localStorage.getItem(DM_KEY)) throw new Error('DM already registered');
+  localStorage.setItem(DM_KEY, JSON.stringify({ password }));
+}
+
+export function loginDM(password) {
+  const dm = JSON.parse(localStorage.getItem(DM_KEY) || '{}');
+  if (dm.password === password) {
+    localStorage.setItem(DM_SESSION, '1');
+    return true;
+  }
+  return false;
+}
+
+export function isDM() {
+  return localStorage.getItem(DM_SESSION) === '1';
+}
+
+export function logoutDM() {
+  localStorage.removeItem(DM_SESSION);
+}
+
+export function savePlayerCharacter(player, data) {
+  return saveLocal('player:' + player, data);
+}
+
+export function loadPlayerCharacter(player) {
+  return loadLocal('player:' + player);
+}
+
+export function editPlayerCharacter(player, data) {
+  if (!isDM()) throw new Error('Not authorized');
+  return savePlayerCharacter(player, data);
+}
+
+// ===== DOM Wiring =====
+function updatePlayerList() {
+  const sel = $('player-select');
+  if (!sel) return;
+  const players = getPlayers();
+  sel.innerHTML = players.map(p => `<option value="${p.name}">${p.name}</option>`).join('');
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    updatePlayerList();
+
+    const regBtn = $('player-register');
+    if (regBtn) {
+      regBtn.addEventListener('click', () => {
+        const name = $('player-name').value.trim();
+        const pass = $('player-pass').value;
+        registerPlayer(name, pass);
+        $('player-name').value = '';
+        $('player-pass').value = '';
+        updatePlayerList();
+      });
+    }
+
+    const loginBtn = $('player-login');
+    if (loginBtn) {
+      loginBtn.addEventListener('click', () => {
+        const name = $('player-name').value.trim();
+        const pass = $('player-pass').value;
+        if (!loginPlayer(name, pass)) {
+          alert('Invalid player login');
+        } else {
+          alert('Player logged in');
+        }
+        $('player-pass').value = '';
+      });
+    }
+
+    const dmRegBtn = $('dm-register');
+    if (dmRegBtn) {
+      dmRegBtn.addEventListener('click', () => {
+        const pass = $('dm-password').value;
+        try {
+          registerDM(pass);
+          console.log('DM registered');
+        } catch (e) {
+          console.error('DM already registered');
+        }
+      });
+    }
+
+    const dmLoginBtn = $('dm-login');
+    if (dmLoginBtn) {
+      dmLoginBtn.addEventListener('click', () => {
+        const pass = $('dm-password').value;
+        if (loginDM(pass)) {
+          const tools = $('dm-tools');
+          if (tools) tools.style.display = 'block';
+          updatePlayerList();
+        } else {
+          console.error('Invalid password');
+        }
+      });
+    }
+
+    if (isDM()) {
+      const tools = $('dm-tools');
+      if (tools) tools.style.display = 'block';
+      updatePlayerList();
+    }
+
+    const loadBtn = $('load-player');
+    if (loadBtn) {
+      loadBtn.addEventListener('click', async () => {
+        const sel = $('player-select');
+        if (!sel || !sel.value) return;
+        try {
+          const data = await loadPlayerCharacter(sel.value);
+          localStorage.setItem('autosave', JSON.stringify(data));
+          location.reload();
+        } catch (e) {
+          console.error('Could not load player', e);
+        }
+      });
+    }
+  });
+}
+


### PR DESCRIPTION
## Summary
- allow players to register/login with passwords and track session
- auto-save logged in player's character to local and cloud with alert showing success/failures
- return save status from storage helpers for detailed feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d767f468832eabf628af45e01706