### PR TITLE
feat: add player login and save status

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -3,6 +3,7 @@ import {
   getPlayers,
   registerDM,
   loginDM,
+  loginPlayer,
   editPlayerCharacter,
   savePlayerCharacter,
   loadPlayerCharacter,
@@ -14,13 +15,21 @@ describe('user management', () => {
   });
 
   test('registers players and lists them', () => {
-    registerPlayer('Alice');
-    registerPlayer('Bob');
+    registerPlayer('Alice', 'a');
+    registerPlayer('Bob', 'b');
     expect(getPlayers()).toEqual(['Alice', 'Bob']);
   });
 
+  test('player login and save', async () => {
+    registerPlayer('Alice', 'pass');
+    expect(loginPlayer('Alice', 'pass')).toBe(true);
+    await savePlayerCharacter('Alice', { hp: 10 });
+    const data = await loadPlayerCharacter('Alice');
+    expect(data.hp).toBe(10);
+  });
+
   test('dm registration and editing', async () => {
-    registerPlayer('Alice');
+    registerPlayer('Alice', 'pw');
     registerDM('secret');
     expect(loginDM('secret')).toBe(true);
     await savePlayerCharacter('Alice', { hp: 10 });
@@ -29,8 +38,9 @@ describe('user management', () => {
     expect(data.hp).toBe(20);
   });
 
-  test('edit fails without dm', () => {
-    expect(() => editPlayerCharacter('Bob', {})).toThrow('Not authorized');
+  test('save fails without login', async () => {
+    registerPlayer('Bob', 'pw2');
+    await expect(savePlayerCharacter('Bob', {})).rejects.toThrow('Not authorized');
   });
 });
 

--- a/index.html
+++ b/index.html
@@ -72,10 +72,12 @@
   <section id="user-admin">
     <h2>User Admin</h2>
     <fieldset class="card">
-      <legend>Register Player</legend>
+      <legend>Player Account</legend>
       <div class="inline">
         <input id="player-name" placeholder="Player name"/>
+        <input id="player-password" type="password" placeholder="Password"/>
         <button id="register-player" class="btn-sm">Register</button>
+        <button id="login-player" class="btn-sm">Login</button>
       </div>
     </fieldset>
     <fieldset class="card">

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -4,6 +4,7 @@ export async function saveLocal(name, payload) {
     localStorage.setItem('last-save', name);
   } catch (e) {
     console.error('Local save failed', e);
+    throw e;
   }
 }
 
@@ -72,6 +73,7 @@ export async function saveCloud(name, payload) {
     localStorage.setItem('last-save', name);
   } catch (e) {
     console.error('Cloud save failed', e);
+    throw e;
   }
 }
 


### PR DESCRIPTION
## Summary
- add player account login with password
- require login to save characters and report local/cloud save results
- propagate storage save errors for accurate messaging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4db470f8c832e9d9789a048fbe4d8