### PR TITLE
Hide DM login behind footer secret

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -1,7 +1,6 @@
 import {
   registerPlayer,
   getPlayers,
-  registerDM,
   loginDM,
   loginPlayer,
   editPlayerCharacter,
@@ -28,10 +27,9 @@ describe('user management', () => {
     expect(data.hp).toBe(10);
   });
 
-  test('dm registration and editing', async () => {
+  test('dm editing', async () => {
     registerPlayer('Alice', 'pw');
-    registerDM('secret');
-    expect(loginDM('secret')).toBe(true);
+    expect(loginDM('Dragons22!')).toBe(true);
     await savePlayerCharacter('Alice', { hp: 10 });
     await editPlayerCharacter('Alice', { hp: 20 });
     const data = await loadPlayerCharacter('Alice');

--- a/index.html
+++ b/index.html
@@ -42,6 +42,11 @@
           <button id="btn-help" title="Help">Help</button>
         </div>
       </div>
+      <button id="btn-dm-edit" class="icon" aria-label="Edit Player" title="Edit Player" style="display:none">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0zM4.5 20.25a7.5 7.5 0 0 1 15 0v.75H4.5v-.75z"/>
+        </svg>
+      </button>
       <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme" data-tip="Toggle theme">
         <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 3V5.25M18.364 5.63604L16.773 7.22703M21 12H18.75M18.364 18.364L16.773 16.773M12 18.75V21M7.22703 16.773L5.63604 18.364M5.25 12H3M7.22703 7.22703L5.63604 5.63604M15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z"/>
@@ -75,23 +80,15 @@
       <div class="inline">
         <input id="player-name" placeholder="Player name"/>
         <input id="player-password" type="password" placeholder="Password"/>
-        <button id="register-player" class="btn-sm">Register</button>
-        <button id="login-player" class="btn-sm">Login</button>
-      </div>
-    </fieldset>
-    <fieldset class="card">
-      <legend>DM Account</legend>
-      <div class="inline">
-        <input id="dm-password" type="password" placeholder="Password"/>
-        <button id="dm-register" class="btn-sm">Register DM</button>
-        <button id="dm-login" class="btn-sm">Login DM</button>
+        <button id="register-player" class="btn-sm" type="button">Register</button>
+        <button id="login-player" class="btn-sm" type="button">Login</button>
       </div>
     </fieldset>
     <fieldset class="card" id="dm-tools" style="display:none">
       <legend>Edit Player</legend>
       <div class="inline">
         <select id="player-select"></select>
-        <button id="load-player" class="btn-sm">Load</button>
+        <button id="load-player" class="btn-sm" type="button">Load</button>
       </div>
     </fieldset>
   </section>
@@ -678,7 +675,7 @@
 
 <footer>
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
-  <p>Product of MorVox industries ® 2025</p>
+  <p>Product of MorVox industries <button id="dm-secret" class="dm-secret" aria-label="DM Login">®</button> 2025</p>
 </footer>
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -3,8 +3,8 @@ import { $ } from './helpers.js';
 
 const PLAYERS_KEY = 'players';
 const PLAYER_SESSION = 'player-session';
-const DM_KEY = 'dm-account';
 const DM_SESSION = 'dm-session';
+const DM_PASSWORD = 'Dragons22!';
 
 function getPlayersRaw() {
   const raw = localStorage.getItem(PLAYERS_KEY);
@@ -42,14 +42,8 @@ export function logoutPlayer() {
   localStorage.removeItem(PLAYER_SESSION);
 }
 
-export function registerDM(password) {
-  if (localStorage.getItem(DM_KEY)) throw new Error('DM already registered');
-  localStorage.setItem(DM_KEY, JSON.stringify({ password }));
-}
-
 export function loginDM(password) {
-  const dm = JSON.parse(localStorage.getItem(DM_KEY) || '{}');
-  if (dm.password === password) {
+  if (password === DM_PASSWORD) {
     localStorage.setItem(DM_SESSION, '1');
     return true;
   }
@@ -116,37 +110,37 @@ if (typeof document !== 'undefined') {
       });
     }
 
-    const dmRegBtn = $('dm-register');
-    if (dmRegBtn) {
-      dmRegBtn.addEventListener('click', () => {
-        const pass = $('dm-password').value;
-        try {
-          registerDM(pass);
-          console.log('DM registered');
-        } catch (e) {
-          console.error('DM already registered');
-        }
-      });
+    function showDMUI() {
+      const btn = $('btn-dm-edit');
+      if (btn) btn.style.display = 'inline-flex';
     }
 
-    const dmLoginBtn = $('dm-login');
-    if (dmLoginBtn) {
-      dmLoginBtn.addEventListener('click', () => {
-        const pass = $('dm-password').value;
+    const secret = $('dm-secret');
+    if (secret) {
+      secret.addEventListener('click', () => {
+        const pass = prompt('DM Password');
         if (loginDM(pass)) {
-          const tools = $('dm-tools');
-          if (tools) tools.style.display = 'block';
-          updatePlayerList();
+          showDMUI();
         } else {
           console.error('Invalid password');
         }
       });
     }
 
+    const dmEditBtn = $('btn-dm-edit');
+    if (dmEditBtn) {
+      dmEditBtn.addEventListener('click', () => {
+        const tools = $('dm-tools');
+        if (tools) {
+          const show = tools.style.display === 'none' || tools.style.display === '';
+          tools.style.display = show ? 'block' : 'none';
+          if (show) updatePlayerList();
+        }
+      });
+    }
+
     if (isDM()) {
-      const tools = $('dm-tools');
-      if (tools) tools.style.display = 'block';
-      updatePlayerList();
+      showDMUI();
     }
 
     const loadBtn = $('load-player');

--- a/styles/main.css
+++ b/styles/main.css
@@ -226,3 +226,5 @@ select[required]:valid{
 .wizard-nav{display:flex;justify-content:space-between;align-items:center;margin-top:16px}
 #wizard-progress{flex:1;text-align:center}
 
+.dm-secret{background:none;border:none;color:inherit;font:inherit;padding:0;margin:0;cursor:default}
+


### PR DESCRIPTION
## Summary
- Hide DM login behind plain-text footer button
- Add DM-only nav button to edit player accounts
- Fix player registration buttons to avoid form submission

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e28324c8832ea200b9a9834e1ef2