### PR TITLE
Add login modal and fix player registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
           <button id="btn-help" title="Help">Help</button>
         </div>
       </div>
+      <button id="btn-player" class="btn-sm" title="Player Account">Log In</button>
       <button id="btn-dm-edit" class="icon" aria-label="Edit Player" title="Edit Player" style="display:none">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0zM4.5 20.25a7.5 7.5 0 0 1 15 0v.75H4.5v-.75z"/>
@@ -72,26 +73,6 @@
 </header>
 
 <main>
-  <!-- USER ADMIN -->
-  <section id="user-admin">
-    <h2>User Admin</h2>
-    <fieldset class="card">
-      <legend>Player Account</legend>
-      <div class="inline">
-        <input id="player-name" placeholder="Player name"/>
-        <input id="player-password" type="password" placeholder="Password"/>
-        <button id="register-player" class="btn-sm" type="button">Register</button>
-        <button id="login-player" class="btn-sm" type="button">Login</button>
-      </div>
-    </fieldset>
-    <fieldset class="card" id="dm-tools" style="display:none">
-      <legend>Edit Player</legend>
-      <div class="inline">
-        <select id="player-select"></select>
-        <button id="load-player" class="btn-sm" type="button">Load</button>
-      </div>
-    </fieldset>
-  </section>
   <!-- COMBAT -->
   <section data-tab="combat">
     <h2 data-rule="8">Tools</h2>
@@ -400,6 +381,34 @@
     </div>
   </section>
 </main>
+
+<!-- PLAYER ACCOUNT MODAL -->
+<div class="overlay hidden" id="modal-player" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>User Account</h3>
+    <fieldset class="card">
+      <legend>Player Account</legend>
+      <div class="inline">
+        <input id="player-name" placeholder="Player name"/>
+        <input id="player-password" type="password" placeholder="Password"/>
+        <button id="register-player" class="btn-sm" type="button">Register</button>
+        <button id="login-player" class="btn-sm" type="button">Login</button>
+      </div>
+    </fieldset>
+    <fieldset class="card" id="dm-tools" style="display:none">
+      <legend>Edit Player</legend>
+      <div class="inline">
+        <select id="player-select"></select>
+        <button id="load-player" class="btn-sm" type="button">Load</button>
+      </div>
+    </fieldset>
+  </div>
+</div>
 
 <!-- ONBOARDING MODAL -->
 <div class="overlay hidden" id="modal-tour" aria-hidden="true">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -691,6 +691,10 @@ const btnHelp = $('btn-help');
 if (btnHelp) {
   btnHelp.addEventListener('click', ()=>{ show('modal-tour'); });
 }
+const btnPlayer = $('btn-player');
+if (btnPlayer) {
+  btnPlayer.addEventListener('click', ()=>{ show('modal-player'); });
+}
 qsa('[data-close]').forEach(b=> b.addEventListener('click', ()=>{ const ov=b.closest('.overlay'); if(ov) hide(ov.id); }));
 
 /* ========= Card Helper ========= */

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -81,9 +81,35 @@ function updatePlayerList() {
   sel.innerHTML = players.map(p => `<option value="${p}">${p}</option>`).join('');
 }
 
+function toast(msg, type = 'info') {
+  const t = $('toast');
+  if (!t) return;
+  t.textContent = msg;
+  t.className = `toast ${type}`;
+  t.classList.add('show');
+  setTimeout(() => t.classList.remove('show'), 1200);
+}
+
+function hideModal() {
+  const m = $('modal-player');
+  if (m) {
+    m.classList.add('hidden');
+    m.setAttribute('aria-hidden', 'true');
+  }
+}
+
+function updatePlayerButton() {
+  const btn = $('btn-player');
+  if (btn) {
+    const p = currentPlayer();
+    btn.textContent = p ? p : 'Log In';
+  }
+}
+
 if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', () => {
     updatePlayerList();
+    updatePlayerButton();
 
     const regBtn = $('register-player');
     if (regBtn) {
@@ -96,6 +122,7 @@ if (typeof document !== 'undefined') {
         nameInput.value = '';
         passInput.value = '';
         updatePlayerList();
+        toast('Player registered','success');
       });
     }
 
@@ -104,8 +131,12 @@ if (typeof document !== 'undefined') {
       loginBtn.addEventListener('click', () => {
         const name = $('player-name').value.trim();
         const pass = $('player-password').value;
-        if (!loginPlayer(name, pass)) {
-          console.error('Invalid credentials');
+        if (loginPlayer(name, pass)) {
+          toast(`Logged in as ${name}`,'success');
+          updatePlayerButton();
+          hideModal();
+        } else {
+          toast('Invalid credentials','error');
         }
       });
     }
@@ -130,11 +161,15 @@ if (typeof document !== 'undefined') {
     const dmEditBtn = $('btn-dm-edit');
     if (dmEditBtn) {
       dmEditBtn.addEventListener('click', () => {
+        const modal = $('modal-player');
+        if (modal) {
+          modal.classList.remove('hidden');
+          modal.setAttribute('aria-hidden','false');
+        }
         const tools = $('dm-tools');
         if (tools) {
-          const show = tools.style.display === 'none' || tools.style.display === '';
-          tools.style.display = show ? 'block' : 'none';
-          if (show) updatePlayerList();
+          tools.style.display = 'block';
+          updatePlayerList();
         }
       });
     }


### PR DESCRIPTION
## Summary
- Add a top navigation **Log In** button that opens a new player account modal
- Provide registration and login feedback with toasts and hide modal after login
- Allow DM edit button to open the player modal and display tools

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e556f4a8832e8ce424d96568b5ce