### PR TITLE
Handle malformed player storage data

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -36,6 +36,11 @@ describe('user management', () => {
     expect(data.hp).toBe(20);
   });
 
+  test('handles corrupted player storage gracefully', () => {
+    localStorage.setItem('players', '{not valid json');
+    expect(getPlayers()).toEqual([]);
+  });
+
   test('save fails without login', async () => {
     registerPlayer('Bob', 'pw2');
     await expect(savePlayerCharacter('Bob', {})).rejects.toThrow('Not authorized');

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -8,7 +8,16 @@ const DM_PASSWORD = 'Dragons22!';
 
 function getPlayersRaw() {
   const raw = localStorage.getItem(PLAYERS_KEY);
-  return raw ? JSON.parse(raw) : {};
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    // If the stored data is corrupted or invalid JSON, discard it so the
+    // application can continue operating with a clean slate instead of
+    // throwing a runtime error that breaks the page.
+    console.error('Failed to parse players from localStorage', e);
+    return {};
+  }
 }
 
 export function getPlayers() {


### PR DESCRIPTION
## Summary
- protect player parsing from invalid localStorage JSON to avoid page crash
- add regression test for corrupted player storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ecc2840c832e811f9742169b0671