### PR TITLE
Move player login to menu and expose DM players button

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,10 +40,10 @@
           <button id="btn-rules" title="Open rules">Rules</button>
           <button id="btn-campaign" title="Campaign log">Campaign</button>
           <button id="btn-help" title="Help">Help</button>
+          <button id="btn-player" title="Player Account">Log In</button>
         </div>
       </div>
-      <button id="btn-player" class="btn-sm" title="Player Account">Log In</button>
-      <button id="btn-dm" class="btn-sm hidden" title="Manage Players">Players</button>
+      <button id="btn-dm" class="btn-sm" title="Manage Players">Players</button>
       <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme" data-tip="Toggle theme">
         <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 3V5.25M18.364 5.63604L16.773 7.22703M21 12H18.75M18.364 18.364L16.773 16.773M12 18.75V21M7.22703 16.773L5.63604 18.364M5.25 12H3M7.22703 7.22703L5.63604 5.63604M15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z"/>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -698,7 +698,14 @@ if (btnPlayer) {
 }
 const btnDM = $('btn-dm');
 if (btnDM) {
-  btnDM.addEventListener('click', ()=>{ renderDMList(); show('modal-dm'); });
+  btnDM.addEventListener('click', ()=>{
+    if (isDM()) {
+      renderDMList();
+      show('modal-dm');
+    } else {
+      show('modal-player');
+    }
+  });
 }
 function renderDMList(){
   const list = $('dm-player-list');

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -111,7 +111,8 @@ function updatePlayerButton() {
 function updateDMButton() {
   const btn = $('btn-dm');
   if (btn) {
-    btn.classList.toggle('hidden', !isDM());
+    // DM players button should remain visible even when not logged in
+    btn.classList.remove('hidden');
   }
 }
 


### PR DESCRIPTION
## Summary
- Move player login action into the More dropdown
- Show DM Players button regardless of DM login and open login modal when necessary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f0e31aac832e8324b9d04c8c92d6