### PR TITLE
Move DM players control into More menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
           <button id="btn-campaign" title="Campaign log">Campaign</button>
           <button id="btn-help" title="Help">Help</button>
           <button id="btn-player" title="Player Account">Log In</button>
+          <button id="btn-dm" title="Manage Players" hidden>Players</button>
         </div>
       </div>
-      <button id="btn-dm" class="btn-sm" title="Manage Players">Players</button>
       <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme" data-tip="Toggle theme">
         <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 3V5.25M18.364 5.63604L16.773 7.22703M21 12H18.75M18.364 18.364L16.773 16.773M12 18.75V21M7.22703 16.773L5.63604 18.364M5.25 12H3M7.22703 7.22703L5.63604 5.63604M15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z"/>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -699,15 +699,13 @@ if (btnPlayer) {
 const btnDM = $('btn-dm');
 if (btnDM) {
   btnDM.addEventListener('click', ()=>{
-    if (isDM()) {
-      renderDMList();
-      show('modal-dm');
-    } else {
-      show('modal-player');
-    }
+    if (!isDM()) return;
+    renderDMList();
+    show('modal-dm');
   });
 }
 function renderDMList(){
+  if(!isDM()) return;
   const list = $('dm-player-list');
   if(!list) return;
   const players = getPlayers();

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -111,8 +111,7 @@ function updatePlayerButton() {
 function updateDMButton() {
   const btn = $('btn-dm');
   if (btn) {
-    // DM players button should remain visible even when not logged in
-    btn.classList.remove('hidden');
+    btn.hidden = !isDM();
   }
 }
 


### PR DESCRIPTION
## Summary
- Relocate Players management button into the More dropdown
- Hide the Players option unless a DM session is active
- Guard DM player list rendering against non-DM access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f543d3a8832e963eff06fdbab895