### PR TITLE
Move DM login to hidden header section

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,12 @@
     <button class="tab" data-go="gear">Gear</button>
     <button class="tab" data-go="story">Story</button>
   </div>
+  <div id="dm-login" hidden>
+    <div class="inline">
+      <input id="dm-password" type="password" placeholder="DM password"/>
+      <button id="login-dm" class="btn-sm" type="button">Login DM</button>
+    </div>
+  </div>
 </header>
 
 <main>
@@ -396,14 +402,7 @@
         <button id="login-player" class="btn-sm" type="button">Login</button>
       </div>
     </fieldset>
-    <fieldset class="card">
-      <legend>DM Account</legend>
-      <div class="inline">
-        <input id="dm-password" type="password" placeholder="DM password"/>
-        <button id="login-dm" class="btn-sm" type="button">Login DM</button>
-      </div>
-    </fieldset>
-</div>
+  </div>
 </div>
 
 <div class="overlay hidden" id="modal-dm" aria-hidden="true">

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -158,6 +158,8 @@ if (typeof document !== 'undefined') {
           toast('DM logged in','success');
           $('dm-password').value = '';
           updateDMButton();
+          const box = $('dm-login');
+          if (box) box.hidden = true;
           hideModal();
         } else {
           toast('Invalid credentials','error');


### PR DESCRIPTION
## Summary
- Place DM login form in a hidden section at the bottom of the header
- Remove DM login from player modal and hide header form after a successful login

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f73d9a58832ebdb5031b51c15805