### PR TITLE
Enhance help modal with feature list and tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,19 +29,19 @@
         </svg>
       </button>
       <div class="dropdown">
-        <button id="btn-menu" class="icon" aria-label="More" title="More" data-tip="More">
+          <button id="btn-menu" class="icon" aria-label="More">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5zm0 6a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5zm0 6a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5z"/>
           </svg>
         </button>
         <div id="menu-actions" class="menu">
-          <button id="btn-save" title="Save">Save</button>
-          <button id="btn-log" title="Roll/Flip log">Roll/Flip Log</button>
-          <button id="btn-rules" title="Open rules">Rules</button>
-          <button id="btn-campaign" title="Campaign log">Campaign</button>
-          <button id="btn-help" title="Help">Help</button>
-          <button id="btn-player" title="Player Account">Log In</button>
-          <button id="btn-dm" title="Manage Players" hidden>Players</button>
+            <button id="btn-save">Save</button>
+            <button id="btn-log">Roll/Flip Log</button>
+            <button id="btn-rules">Rules</button>
+            <button id="btn-campaign">Campaign</button>
+            <button id="btn-help">Help</button>
+            <button id="btn-player">Log In</button>
+            <button id="btn-dm" hidden>Players</button>
         </div>
       </div>
       <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme" data-tip="Toggle theme">
@@ -439,6 +439,13 @@
     </button>
     <h3>Welcome to the Tracker</h3>
     <p>Use the tabs to navigate your sheet. Changes save automatically and work offline.</p>
+    <ul class="feature-list">
+      <li data-tip="Roll any die or flip a coin quickly">Dice rolling and coin flips</li>
+      <li data-tip="Track HP, SP, and conditions">Combat statistics and status effects</li>
+      <li data-tip="Keep notes and history for your adventures">Campaign and roll logs</li>
+      <li data-tip="Works even without an internet connection">Offline auto-saving</li>
+      <li data-tip="Switch between light and dark modes">Theme toggling</li>
+    </ul>
     <div class="actions"><button id="tour-ok">Get Started</button></div>
   </div>
 </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -88,6 +88,7 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
 .card.dragging{opacity:.5}
 .catalog{max-height:360px;overflow:auto;border:1px dashed var(--line);border-radius:10px;padding:6px}
 .perk-list{margin:0;padding-left:20px;list-style:disc}
+.feature-list{margin:0 0 12px;padding-left:20px;list-style:disc}
 .catalog-item{display:grid;grid-template-columns:auto 1fr auto;gap:10px;align-items:center;padding:8px;border-bottom:1px solid var(--line)}
 .catalog-item:last-child{border-bottom:none}
 .catalog-item.active{background:var(--accent);color:var(--text-on-accent)}


### PR DESCRIPTION
## Summary
- expand Help modal with feature list and tooltips
- style feature list for onboarding modal
- remove tooltips from items in the More menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4fdf566a0832e8569b0d2f7d3e83c