### PR TITLE
Remove redundant tooltips from More menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,19 +29,19 @@
         </svg>
       </button>
       <div class="dropdown">
-        <button id="btn-menu" class="icon" aria-label="More" title="More" data-tip="More">
+        <button id="btn-menu" class="icon" aria-label="More">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5zm0 6a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5zm0 6a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5z"/>
           </svg>
         </button>
         <div id="menu-actions" class="menu">
-          <button id="btn-save" title="Save" data-tip="Save your sheet">Save</button>
-          <button id="btn-log" title="Roll/Flip log" data-tip="View roll and flip history">Roll/Flip Log</button>
-          <button id="btn-rules" title="Open rules" data-tip="Open the rules reference">Rules</button>
-          <button id="btn-campaign" title="Campaign log" data-tip="Review your campaign log">Campaign</button>
-          <button id="btn-help" title="Help" data-tip="Learn about all features">Help</button>
-          <button id="btn-player" title="Player Account" data-tip="Log in to your player account">Log In</button>
-          <button id="btn-dm" title="Manage Players" data-tip="Manage connected players" hidden>Players</button>
+          <button id="btn-save">Save</button>
+          <button id="btn-log">Roll/Flip Log</button>
+          <button id="btn-rules">Rules</button>
+          <button id="btn-campaign">Campaign</button>
+          <button id="btn-help">Help</button>
+          <button id="btn-player">Log In</button>
+          <button id="btn-dm" hidden>Players</button>
         </div>
       </div>
       <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme" data-tip="Toggle theme">


### PR DESCRIPTION
## Summary
- Remove title and custom tooltip attributes from More menu actions including Help to reduce clutter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a543587080832e980fd8c515485b29