### PR TITLE
Align navigation button sizes

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -24,8 +24,8 @@ header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var
   .actions{flex-wrap:wrap;justify-content:center}
   .tabs{justify-content:center}
 }
-.icon{width:32px;height:32px;border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition)}
-.icon svg,.modal .x svg{width:20px;height:20px}
+.icon{width:30px;height:30px;border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition)}
+.icon svg{width:18px;height:18px}.modal .x svg{width:20px;height:20px}
 .icon:hover{background:var(--accent);color:var(--text-on-accent)}
 .icon:active{transform:translateY(1px)}
 .icon:focus-visible,.modal .x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
@@ -34,8 +34,8 @@ header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var
 .breadcrumbs{margin-top:4px;font-size:.875rem;color:var(--muted)}
 .breadcrumbs span+span::before{content:"/";margin:0 4px}
 .tabs{margin-top:6px;display:flex;gap:8px;flex-wrap:nowrap;justify-content:center}
-.tab{width:32px;height:32px;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition)}
-.tab svg{width:20px;height:20px}
+.tab{width:30px;height:30px;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition)}
+.tab svg{width:18px;height:18px}
 .tab:hover{background:var(--accent);color:var(--text-on-accent)}
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{max-width:65ch;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}


### PR DESCRIPTION
## Summary
- Standardize header navigation buttons to 30x30 pixels and scale icons accordingly
- Match top tab buttons at 30x30 with proportionate 18px symbols for consistent layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5466f2980832e944378ca86551431