### PR TITLE
Add player logout and registration validation

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -3,6 +3,8 @@ import {
   getPlayers,
   loginDM,
   loginPlayer,
+  logoutPlayer,
+  currentPlayer,
   editPlayerCharacter,
   savePlayerCharacter,
   loadPlayerCharacter,
@@ -19,12 +21,25 @@ describe('user management', () => {
     expect(getPlayers()).toEqual(['Alice', 'Bob']);
   });
 
+  test('registration requires name and password', () => {
+    registerPlayer('', 'pw');
+    registerPlayer('Charlie', '');
+    expect(getPlayers()).toEqual([]);
+  });
+
   test('player login and save', async () => {
     registerPlayer('Alice', 'pass');
     expect(loginPlayer('Alice', 'pass')).toBe(true);
     await savePlayerCharacter('Alice', { hp: 10 });
     const data = await loadPlayerCharacter('Alice');
     expect(data.hp).toBe(10);
+  });
+
+  test('player logout clears session', () => {
+    registerPlayer('Dana', 'pw');
+    expect(loginPlayer('Dana', 'pw')).toBe(true);
+    logoutPlayer();
+    expect(currentPlayer()).toBeNull();
   });
 
   test('dm editing', async () => {

--- a/index.html
+++ b/index.html
@@ -416,6 +416,7 @@
         <input id="player-password" type="password" placeholder="Password"/>
         <button id="register-player" class="btn-sm" type="button">Register</button>
         <button id="login-player" class="btn-sm" type="button">Login</button>
+        <button id="logout-player" class="btn-sm" type="button" hidden>Logout</button>
       </div>
     </fieldset>
   </div>

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -102,9 +102,13 @@ function hideModal() {
 
 function updatePlayerButton() {
   const btn = $('btn-player');
+  const logoutBtn = $('logout-player');
+  const p = currentPlayer();
   if (btn) {
-    const p = currentPlayer();
     btn.textContent = p ? p : 'Log In';
+  }
+  if (logoutBtn) {
+    logoutBtn.hidden = !p;
   }
 }
 
@@ -127,6 +131,18 @@ if (typeof document !== 'undefined') {
         const passInput = $('player-password');
         const name = nameInput.value.trim();
         const pass = passInput.value;
+        if (!name && !pass) {
+          toast('Player name and password required','error');
+          return;
+        }
+        if (!name) {
+          toast('Player name required','error');
+          return;
+        }
+        if (!pass) {
+          toast('Password required','error');
+          return;
+        }
         registerPlayer(name, pass);
         nameInput.value = '';
         passInput.value = '';
@@ -147,6 +163,16 @@ if (typeof document !== 'undefined') {
         } else {
           toast('Invalid credentials','error');
         }
+      });
+    }
+
+    const logoutBtn = $('logout-player');
+    if (logoutBtn) {
+      logoutBtn.addEventListener('click', () => {
+        logoutPlayer();
+        toast('Logged out','info');
+        updatePlayerButton();
+        hideModal();
       });
     }
 


### PR DESCRIPTION
## Summary
- validate player registration inputs and show error toast if name or password missing
- add logout button for players and hide it until logged in
- test player logout and registration requirements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a553e5c480832eb9969f2e88c7dc2a