### PR TITLE
Enable DM to load player characters from cloud

### DIFF
--- a/__tests__/dm_cloud.test.js
+++ b/__tests__/dm_cloud.test.js
@@ -1,0 +1,30 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../scripts/storage.js', () => ({
+  saveLocal: jest.fn(),
+  loadLocal: jest.fn().mockRejectedValue(new Error('No save found')),
+  loadCloud: jest.fn().mockResolvedValue({ hp: 30 }),
+  deleteSave: jest.fn(),
+}));
+
+const users = await import('../scripts/users.js');
+const storage = await import('../scripts/storage.js');
+
+const { registerPlayer, loginDM, loadPlayerCharacter } = users;
+
+describe('DM cloud fallback', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    storage.loadLocal.mockRejectedValue(new Error('No save found'));
+    storage.loadCloud.mockResolvedValue({ hp: 30 });
+  });
+
+  test('loads from cloud when local missing', async () => {
+    registerPlayer('Eve', 'pw');
+    expect(loginDM('Dragons22!')).toBe(true);
+    const data = await loadPlayerCharacter('Eve');
+    expect(storage.loadLocal).toHaveBeenCalledWith('player:Eve');
+    expect(storage.loadCloud).toHaveBeenCalledWith('player:Eve');
+    expect(data.hp).toBe(30);
+  });
+});

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -1,4 +1,4 @@
-import { saveLocal, loadLocal } from './storage.js';
+import { saveLocal, loadLocal, loadCloud } from './storage.js';
 import { $ } from './helpers.js';
 
 const PLAYERS_KEY = 'players';
@@ -74,7 +74,15 @@ export async function savePlayerCharacter(player, data) {
 
 export async function loadPlayerCharacter(player) {
   if (currentPlayer() !== player && !isDM()) throw new Error('Not authorized');
-  return loadLocal('player:' + player);
+  try {
+    return await loadLocal('player:' + player);
+  } catch (e) {
+    // If the character isn't saved locally (e.g. attempting to view a player's
+    // sheet from another device), fall back to the cloud save. This allows the
+    // DM to load any player's character as long as it exists in the shared
+    // database.
+    return await loadCloud('player:' + player);
+  }
 }
 
 export function editPlayerCharacter(player, data) {


### PR DESCRIPTION
## Summary
- allow `loadPlayerCharacter` to fall back to cloud saves when local data is missing so DMs can access players' characters from any device
- add test ensuring DM load falls back to cloud when no local save exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5554dad80832e991eebb3230ef4c8