### PR TITLE
Handle corrupted player data

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -54,6 +54,7 @@ describe('user management', () => {
   test('handles corrupted player storage gracefully', () => {
     localStorage.setItem('players', '{not valid json');
     expect(getPlayers()).toEqual([]);
+    expect(localStorage.getItem('players')).toBeNull();
   });
 
   test('save fails without login', async () => {

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -16,6 +16,7 @@ function getPlayersRaw() {
     // application can continue operating with a clean slate instead of
     // throwing a runtime error that breaks the page.
     console.error('Failed to parse players from localStorage', e);
+    localStorage.removeItem(PLAYERS_KEY);
     return {};
   }
 }


### PR DESCRIPTION
## Summary
- Clear invalid player data from localStorage when JSON parsing fails
- Test that corrupted player storage is removed and doesn't break the app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5568b6128832ea78286a83ad7a923