### PR TITLE
Increase icon and tab sizes for clarity

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -24,9 +24,9 @@ header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var
   .actions{flex-wrap:wrap;justify-content:center}
   .tabs{justify-content:center}
 }
-.icon{width:30px;height:30px;border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition)}
-.icon svg{width:60%;height:60%}.modal .x svg{width:20px;height:20px}
-.top .icon svg{width:80%;height:80%}
+.icon{width:44px;height:44px;border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition)}
+.icon svg{width:80%;height:80%}.modal .x svg{width:20px;height:20px}
+.top .icon svg{width:90%;height:90%}
 .icon:hover{background:var(--accent);color:var(--text-on-accent)}
 .icon:active{transform:translateY(1px)}
 .icon:focus-visible,.modal .x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
@@ -35,8 +35,8 @@ header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var
 .breadcrumbs{margin-top:4px;font-size:.875rem;color:var(--muted)}
 .breadcrumbs span+span::before{content:"/";margin:0 4px}
 .tabs{margin-top:6px;display:flex;gap:8px;flex-wrap:nowrap;justify-content:center}
-.tab{width:30px;height:30px;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition)}
-.tab svg{width:80%;height:80%}
+.tab{width:44px;height:44px;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition)}
+.tab svg{width:90%;height:90%}
 .tab:hover{background:var(--accent);color:var(--text-on-accent)}
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{max-width:65ch;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}


### PR DESCRIPTION
## Summary
- Enlarge icon buttons to 44px and scale internal SVGs for legibility
- Increase tab button dimensions and icon scaling for clearer navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5586ab53c832eac591865d1b0f952