### PR TITLE
style: center and shrink footer

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -43,7 +43,8 @@ main{max-width:65ch;margin:16px auto;padding:0 12px calc(16px + env(safe-area-in
 section{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:14px;margin-bottom:14px;box-shadow:var(--shadow)}
 section h2{margin:0 0 10px}
 p{max-width:65ch}
-footer{text-align:center;margin-top:24px;padding:12px 0;color:var(--muted)}
+footer{text-align:center;font-size:9pt;margin-top:24px;padding:12px 0;color:var(--muted)}
+footer p{max-width:none}
 .grid{display:grid;gap:12px}
 .grid-1{grid-template-columns:1fr}
 .grid-2{grid-template-columns:1fr}


### PR DESCRIPTION
## Summary
- reduce footer font to 9pt and ensure full-width centering on all pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a560f4f1dc832eb6e9cfdd43f5b914