### PR TITLE
Remove rule PDF link from tools header

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 <main>
   <!-- COMBAT -->
   <section data-tab="combat">
-    <h2 data-rule="8">Tools</h2>
+    <h2>Tools</h2>
     <div class="grid grid-2">
       <fieldset class="card">
         <legend>Dice Roll</legend>


### PR DESCRIPTION
## Summary
- remove data-rule attribute from Tools header to stop opening rules PDF when clicked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b0c5a66c832e893a44b59943a4d0