### PR TITLE
Refactor header layout for Vigilante Dossier

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"/>
 <meta name="theme-color" content="#0e1117"/>
 <meta name="color-scheme" content="dark light"/>
-<title>Catalyst Core: Character Tracker (Clean)</title>
+<title>Vigilante Dossier</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"/>
 <link rel="stylesheet" href="styles/main.css"/>
 </head>
@@ -14,36 +14,7 @@
 
 <header>
   <div class="top">
-    <h1>Catalyst Core: Character Tracker</h1>
-    <div class="actions">
-      <button id="btn-enc" class="icon" aria-label="Encounter / Initiative" title="Encounter / Initiative" data-tip="Encounter / Initiative">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"/>
-        </svg>
-      </button>
-      <button id="btn-wizard" class="icon" aria-label="Character creation wizard" title="Character creation wizard" data-tip="Character wizard">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9.8132 15.9038L9 18.75L8.1868 15.9038C7.75968 14.4089 6.59112 13.2403 5.09619 12.8132L2.25 12L5.09619 11.1868C6.59113 10.7597 7.75968 9.59112 8.1868 8.09619L9 5.25L9.8132 8.09619C10.2403 9.59113 11.4089 10.7597 12.9038 11.1868L15.75 12L12.9038 12.8132C11.4089 13.2403 10.2403 14.4089 9.8132 15.9038Z"/>
-          <path stroke-linecap="round" stroke-linejoin="round" d="M18.2589 8.71454L18 9.75L17.7411 8.71454C17.4388 7.50533 16.4947 6.56117 15.2855 6.25887L14.25 6L15.2855 5.74113C16.4947 5.43883 17.4388 4.49467 17.7411 3.28546L18 2.25L18.2589 3.28546C18.5612 4.49467 19.5053 5.43883 20.7145 5.74113L21.75 6L20.7145 6.25887C19.5053 6.56117 18.5612 7.50533 18.2589 8.71454Z"/>
-          <path stroke-linecap="round" stroke-linejoin="round" d="M16.8942 20.5673L16.5 21.75L16.1058 20.5673C15.8818 19.8954 15.3546 19.3682 14.6827 19.1442L13.5 18.75L14.6827 18.3558C15.3546 18.1318 15.8818 17.6046 16.1058 16.9327L16.5 15.75L16.8942 16.9327C17.1182 17.6046 17.6454 18.1318 18.3173 18.3558L19.5 18.75L18.3173 19.1442C17.6454 19.3682 17.1182 19.8954 16.8942 20.5673Z"/>
-        </svg>
-      </button>
-      <div class="dropdown">
-        <button id="btn-menu" class="icon" aria-label="More">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5zm0 6a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5zm0 6a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5z"/>
-          </svg>
-        </button>
-        <div id="menu-actions" class="menu">
-          <button id="btn-save">Save</button>
-          <button id="btn-log">Roll/Flip Log</button>
-          <button id="btn-rules">Rules</button>
-          <button id="btn-campaign">Campaign</button>
-          <button id="btn-help">Help</button>
-          <button id="btn-player">Log In</button>
-          <button id="btn-dm" hidden>Players</button>
-        </div>
-      </div>
+    <div class="title-group">
       <button id="btn-theme" class="icon" aria-label="Toggle Theme" title="Toggle Theme" data-tip="Toggle theme">
         <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 3V5.25M18.364 5.63604L16.773 7.22703M21 12H18.75M18.364 18.364L16.773 16.773M12 18.75V21M7.22703 16.773L5.63604 18.364M5.25 12H3M7.22703 7.22703L5.63604 5.63604M15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z"/>
@@ -56,6 +27,18 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/>
         </svg>
       </button>
+      <h1>Vigilante Dossier</h1>
+    </div>
+    <div id="menu-actions" class="actions">
+      <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
+      <button id="btn-wizard" class="btn-sm" aria-label="Character creation wizard" title="Character creation wizard">Character wizard</button>
+      <button id="btn-save" class="btn-sm">Save</button>
+      <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
+      <button id="btn-rules" class="btn-sm">Rules</button>
+      <button id="btn-campaign" class="btn-sm">Campaign</button>
+      <button id="btn-help" class="btn-sm">Help</button>
+      <button id="btn-player" class="btn-sm">Log In</button>
+      <button id="btn-dm" class="btn-sm" hidden>Players</button>
     </div>
   </div>
   <div class="tabs">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -116,8 +116,6 @@ document.addEventListener('input', e=>{
 /* ========= theme ========= */
 const root = document.documentElement;
 const btnTheme = $('btn-theme');
-const btnMenu = $('btn-menu');
-const menuActions = $('menu-actions');
 const crumbCurrent = $('crumb-current');
 function applyTheme(t){
   root.classList.remove('theme-light','theme-high');
@@ -140,18 +138,7 @@ if (btnTheme) {
   });
 }
 
-if (btnMenu && menuActions) {
-  btnMenu.addEventListener('click', e => {
-    e.stopPropagation();
-    menuActions.classList.toggle('show');
-  });
-  menuActions.addEventListener('click', () => menuActions.classList.remove('show'));
-  document.addEventListener('click', e => {
-    if (!e.target.closest('.dropdown')) {
-      menuActions.classList.remove('show');
-    }
-  });
-}
+// menu actions are always visible; no toggle needed
 
 /* ========= tabs ========= */
 function setTab(name){

--- a/styles/main.css
+++ b/styles/main.css
@@ -8,12 +8,15 @@ html{height:100%}body{min-height:100%}
 body{margin:0;background:var(--bg);color:var(--text);font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased;overflow-x:hidden;line-height:1.6;font-size:16px}
 h1,h2,h3,h4{font-family:inherit;line-height:1.25;margin:0 0 .5em}
 h1{font-size:2rem;font-weight:700;color:var(--accent)}
-header h1{font-size:1.25rem}
+header h1{font-size:1rem}
 h2{font-size:1.5rem;font-weight:600;color:var(--accent)}
 h3{font-size:1.25rem;font-weight:600}
 header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(8px + env(safe-area-inset-top)) 10px 8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px)}
 .top{display:flex;align-items:center;justify-content:space-between;gap:10px}
+.title-group{display:flex;align-items:center;gap:6px}
 .actions{display:flex;gap:6px}
+#menu-actions{flex-wrap:wrap}
+#menu-actions button{width:auto}
 .dropdown{position:relative}
 .menu{position:absolute;top:calc(100% + 4px);right:0;display:none;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50}
 .menu.show{display:flex}


### PR DESCRIPTION
## Summary
- Rename application to "Vigilante Dossier" and redesign header
- Move theme toggle to the left and show menu actions inline on the right
- Remove dropdown logic now that menu is always visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b8dd10b8832eb56ab9c5394bfb5d