### PR TITLE
Add password recovery challenge question

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -8,6 +8,7 @@ import {
   editPlayerCharacter,
   savePlayerCharacter,
   loadPlayerCharacter,
+  recoverPlayerPassword,
 } from '../scripts/users.js';
 
 describe('user management', () => {
@@ -16,19 +17,21 @@ describe('user management', () => {
   });
 
   test('registers players and lists them', () => {
-    registerPlayer('Alice', 'a');
-    registerPlayer('Bob', 'b');
+    registerPlayer('Alice', 'a', 'pet?', 'cat');
+    registerPlayer('Bob', 'b', 'pet?', 'dog');
     expect(getPlayers()).toEqual(['Alice', 'Bob']);
   });
 
   test('registration requires name and password', () => {
-    registerPlayer('', 'pw');
-    registerPlayer('Charlie', '');
+    registerPlayer('', 'pw', 'q', 'a');
+    registerPlayer('Charlie', '', 'q', 'a');
+    registerPlayer('Dana', 'pw', '', 'a');
+    registerPlayer('Eve', 'pw', 'q', '');
     expect(getPlayers()).toEqual([]);
   });
 
   test('player login and save', async () => {
-    registerPlayer('Alice', 'pass');
+    registerPlayer('Alice', 'pass', 'pet?', 'cat');
     expect(loginPlayer('Alice', 'pass')).toBe(true);
     await savePlayerCharacter('Alice', { hp: 10 });
     const data = await loadPlayerCharacter('Alice');
@@ -36,14 +39,14 @@ describe('user management', () => {
   });
 
   test('player logout clears session', () => {
-    registerPlayer('Dana', 'pw');
+    registerPlayer('Dana', 'pw', 'pet?', 'cat');
     expect(loginPlayer('Dana', 'pw')).toBe(true);
     logoutPlayer();
     expect(currentPlayer()).toBeNull();
   });
 
   test('dm editing', async () => {
-    registerPlayer('Alice', 'pw');
+    registerPlayer('Alice', 'pw', 'pet?', 'cat');
     expect(loginDM('Dragons22!')).toBe(true);
     await savePlayerCharacter('Alice', { hp: 10 });
     await editPlayerCharacter('Alice', { hp: 20 });
@@ -58,8 +61,14 @@ describe('user management', () => {
   });
 
   test('save fails without login', async () => {
-    registerPlayer('Bob', 'pw2');
+    registerPlayer('Bob', 'pw2', 'pet?', 'cat');
     await expect(savePlayerCharacter('Bob', {})).rejects.toThrow('Not authorized');
+  });
+
+  test('password recovery', () => {
+    registerPlayer('Frank', 'pw', 'color?', 'blue');
+    expect(recoverPlayerPassword('Frank', 'blue')).toBe('pw');
+    expect(recoverPlayerPassword('Frank', 'red')).toBeNull();
   });
 });
 

--- a/index.html
+++ b/index.html
@@ -397,8 +397,15 @@
       <div class="inline">
         <input id="player-name" placeholder="Player name"/>
         <input id="player-password" type="password" placeholder="Password"/>
+      </div>
+      <div class="inline">
+        <input id="player-question" placeholder="Security question"/>
+        <input id="player-answer" type="password" placeholder="Security answer"/>
+      </div>
+      <div class="inline">
         <button id="register-player" class="btn-sm" type="button">Register</button>
         <button id="login-player" class="btn-sm" type="button">Login</button>
+        <button id="recover-player" class="btn-sm" type="button">Recover</button>
         <button id="logout-player" class="btn-sm" type="button" hidden>Logout</button>
       </div>
     </fieldset>


### PR DESCRIPTION
## Summary
- store security question and answer during player registration
- allow password recovery via challenge question in the UI
- test password recovery flow and updated registration requirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5bafa6cfc832e9114fc56645efc2e