### PR TITLE
Consolidate header actions into dropdown menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,14 +29,19 @@
       </button>
       <h1>Vigilante Dossier</h1>
     </div>
-    <div id="menu-actions" class="actions">
-      <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
-      <button id="btn-wizard" class="btn-sm" aria-label="Character creation wizard" title="Character creation wizard">Character wizard</button>
-      <button id="btn-save" class="btn-sm">Save</button>
-      <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
-      <button id="btn-rules" class="btn-sm">Rules</button>
-      <button id="btn-campaign" class="btn-sm">Campaign</button>
-      <button id="btn-help" class="btn-sm">Help</button>
+    <div class="actions">
+      <div class="dropdown">
+        <button id="btn-menu" class="btn-sm">Menu</button>
+        <div id="menu-actions" class="menu">
+          <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
+          <button id="btn-wizard" class="btn-sm" aria-label="Character creation wizard" title="Character creation wizard">Character wizard</button>
+          <button id="btn-save" class="btn-sm">Save</button>
+          <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
+          <button id="btn-rules" class="btn-sm">Rules</button>
+          <button id="btn-campaign" class="btn-sm">Campaign</button>
+          <button id="btn-help" class="btn-sm">Help</button>
+        </div>
+      </div>
       <button id="btn-player" class="btn-sm">Log In</button>
       <button id="btn-dm" class="btn-sm" hidden>Players</button>
     </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -138,7 +138,18 @@ if (btnTheme) {
   });
 }
 
-// menu actions are always visible; no toggle needed
+const btnMenu = $('btn-menu');
+const menuActions = $('menu-actions');
+if (btnMenu && menuActions) {
+  btnMenu.addEventListener('click', () => {
+    menuActions.classList.toggle('show');
+  });
+  document.addEventListener('click', e => {
+    if (!btnMenu.contains(e.target) && !menuActions.contains(e.target)) {
+      menuActions.classList.remove('show');
+    }
+  });
+}
 
 /* ========= tabs ========= */
 function setTab(name){

--- a/styles/main.css
+++ b/styles/main.css
@@ -15,8 +15,6 @@ header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var
 .top{display:flex;align-items:center;justify-content:space-between;gap:10px}
 .title-group{display:flex;align-items:center;gap:6px}
 .actions{display:flex;gap:6px}
-#menu-actions{flex-wrap:wrap}
-#menu-actions button{width:auto}
 .dropdown{position:relative}
 .menu{position:absolute;top:calc(100% + 4px);right:0;display:none;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50}
 .menu.show{display:flex}


### PR DESCRIPTION
## Summary
- Replace multiple header buttons with a single menu that lists Encounter/Initiative, Character wizard, Save, Roll/Flip Log, Rules, Campaign, and Help options.
- Add JavaScript to toggle the dropdown and close it when clicking outside.
- Streamline header styles for the new dropdown structure.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5bd6b05a4832eaa44dbfe6c756e1c