### PR TITLE
Simplify login modal with registration and recovery overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,18 +400,65 @@
     <fieldset class="card">
       <legend>Player Account</legend>
       <div class="inline">
-        <input id="player-name" placeholder="Player name"/>
-        <input id="player-password" type="password" placeholder="Password"/>
+        <input id="login-player-name" placeholder="Player name"/>
+        <input id="login-player-password" type="password" placeholder="Password"/>
       </div>
       <div class="inline">
-        <input id="player-question" placeholder="Security question"/>
-        <input id="player-answer" type="password" placeholder="Security answer"/>
+        <button id="login-player" class="btn-sm" type="button">Login</button>
+        <a id="open-register" href="#">Register</a>
+        <a id="open-recover" href="#">Recover</a>
+        <button id="logout-player" class="btn-sm" type="button" hidden>Logout</button>
+      </div>
+    </fieldset>
+  </div>
+</div>
+
+<!-- PLAYER REGISTRATION MODAL -->
+<div class="overlay hidden" id="modal-register" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Register Player</h3>
+    <fieldset class="card">
+      <legend>Player Account</legend>
+      <div class="inline">
+        <input id="register-player-name" placeholder="Player name"/>
+        <input id="register-player-password" type="password" placeholder="Password"/>
+      </div>
+      <div class="inline">
+        <input id="register-player-question" placeholder="Security question"/>
+        <input id="register-player-answer" type="password" placeholder="Security answer"/>
       </div>
       <div class="inline">
         <button id="register-player" class="btn-sm" type="button">Register</button>
-        <button id="login-player" class="btn-sm" type="button">Login</button>
+      </div>
+    </fieldset>
+  </div>
+</div>
+
+<!-- PASSWORD RECOVERY MODAL -->
+<div class="overlay hidden" id="modal-recover" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Recover Password</h3>
+    <fieldset class="card">
+      <legend>Password Recovery</legend>
+      <div class="inline">
+        <input id="recover-name" placeholder="Player name"/>
+      </div>
+      <div class="inline">
+        <p id="recover-question"></p>
+      </div>
+      <div class="inline">
+        <input id="recover-answer" type="password" placeholder="Security answer"/>
         <button id="recover-player" class="btn-sm" type="button">Recover</button>
-        <button id="logout-player" class="btn-sm" type="button" hidden>Logout</button>
       </div>
     </fieldset>
   </div>

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -114,8 +114,16 @@ function toast(msg, type = 'info') {
   setTimeout(() => t.classList.remove('show'), 1200);
 }
 
-function hideModal() {
-  const m = $('modal-player');
+function showModal(id) {
+  const m = $(id);
+  if (m) {
+    m.classList.remove('hidden');
+    m.setAttribute('aria-hidden', 'false');
+  }
+}
+
+function hideModal(id) {
+  const m = $(id);
   if (m) {
     m.classList.add('hidden');
     m.setAttribute('aria-hidden', 'true');
@@ -149,10 +157,10 @@ if (typeof document !== 'undefined') {
     const regBtn = $('register-player');
     if (regBtn) {
       regBtn.addEventListener('click', () => {
-        const nameInput = $('player-name');
-        const passInput = $('player-password');
-        const questionInput = $('player-question');
-        const answerInput = $('player-answer');
+        const nameInput = $('register-player-name');
+        const passInput = $('register-player-password');
+        const questionInput = $('register-player-question');
+        const answerInput = $('register-player-answer');
         const name = nameInput.value.trim();
         const pass = passInput.value;
         const question = questionInput.value.trim();
@@ -183,38 +191,60 @@ if (typeof document !== 'undefined') {
         questionInput.value = '';
         answerInput.value = '';
         toast('Player registered','success');
+        hideModal('modal-register');
       });
     }
 
     const loginBtn = $('login-player');
     if (loginBtn) {
       loginBtn.addEventListener('click', () => {
-        const name = $('player-name').value.trim();
-        const pass = $('player-password').value;
+        const name = $('login-player-name').value.trim();
+        const pass = $('login-player-password').value;
         if (loginPlayer(name, pass)) {
           toast(`Logged in as ${name}`,'success');
           updatePlayerButton();
           updateDMButton();
-          hideModal();
+          hideModal('modal-player');
         } else {
           toast('Invalid credentials','error');
         }
       });
     }
 
+    const regLink = $('open-register');
+    if (regLink) {
+      regLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        showModal('modal-register');
+      });
+    }
+
+    const recoverLink = $('open-recover');
+    if (recoverLink) {
+      recoverLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        showModal('modal-recover');
+      });
+    }
+
+    const recoverName = $('recover-name');
+    if (recoverName) {
+      recoverName.addEventListener('input', () => {
+        const q = getPlayerQuestion(recoverName.value.trim());
+        const qEl = $('recover-question');
+        if (qEl) qEl.textContent = q || '';
+      });
+    }
+
     const recoverBtn = $('recover-player');
     if (recoverBtn) {
       recoverBtn.addEventListener('click', () => {
-        const name = $('player-name').value.trim();
-        const question = getPlayerQuestion(name);
-        if (!question) {
-          toast('Player not found','error');
-          return;
-        }
-        const answer = prompt(question);
+        const name = $('recover-name').value.trim();
+        const answer = $('recover-answer').value;
         const pass = recoverPlayerPassword(name, answer);
         if (pass) {
           toast(`Password: ${pass}`,'info');
+          hideModal('modal-recover');
         } else {
           toast('Incorrect answer','error');
         }
@@ -227,7 +257,7 @@ if (typeof document !== 'undefined') {
         logoutPlayer();
         toast('Logged out','info');
         updatePlayerButton();
-        hideModal();
+        hideModal('modal-player');
       });
     }
 


### PR DESCRIPTION
## Summary
- Simplify player login modal to show only credentials
- Add separate modals for registration and password recovery
- Wire up links and logic for new registration and recovery flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5bf2be0e8832eb9783b7f03eecc4e