### PR TITLE
Replace combat and gear icons, reorganize menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,23 +33,26 @@
       <div class="dropdown">
         <button id="btn-menu" class="btn-sm">Menu</button>
         <div id="menu-actions" class="menu">
-          <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
+          <button id="btn-player" class="btn-sm">Log In</button>
           <button id="btn-wizard" class="btn-sm" aria-label="Character creation wizard" title="Character creation wizard">Character wizard</button>
+          <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
           <button id="btn-save" class="btn-sm">Save</button>
           <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
-          <button id="btn-rules" class="btn-sm">Rules</button>
           <button id="btn-campaign" class="btn-sm">Campaign</button>
+          <button id="btn-rules" class="btn-sm">Rules</button>
           <button id="btn-help" class="btn-sm">Help</button>
         </div>
       </div>
-      <button id="btn-player" class="btn-sm">Log In</button>
       <button id="btn-dm" class="btn-sm" hidden>Players</button>
     </div>
   </div>
   <div class="tabs">
     <button class="tab active" data-go="combat" aria-label="Combat" title="Combat">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.7498L11.25 14.9998L15 9.74985M12 2.71411C9.8495 4.75073 6.94563 5.99986 3.75 5.99986C3.69922 5.99986 3.64852 5.99955 3.59789 5.99892C3.2099 7.17903 3 8.43995 3 9.74991C3 15.3414 6.82432 20.0397 12 21.3719C17.1757 20.0397 21 15.3414 21 9.74991C21 8.43995 20.7901 7.17903 20.4021 5.99892C20.3515 5.99955 20.3008 5.99986 20.25 5.99986C17.0544 5.99986 14.1505 4.75073 12 2.71411Z"/>
+        <polyline stroke-linecap="round" stroke-linejoin="round" points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/>
+        <line stroke-linecap="round" stroke-linejoin="round" x1="13" y1="19" x2="19" y2="13"/>
+        <line stroke-linecap="round" stroke-linejoin="round" x1="16" y1="16" x2="20" y2="20"/>
+        <line stroke-linecap="round" stroke-linejoin="round" x1="19" y1="21" x2="21" y2="19"/>
       </svg>
     </button>
     <button class="tab" data-go="abilities" aria-label="Abilities" title="Abilities">
@@ -66,7 +69,7 @@
     </button>
     <button class="tab" data-go="gear" aria-label="Gear" title="Gear">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M11.4194 15.1694L17.25 21C18.2855 22.0355 19.9645 22.0355 21 21C22.0355 19.9645 22.0355 18.2855 21 17.25L15.1233 11.3733M11.4194 15.1694L13.9155 12.1383C14.2315 11.7546 14.6542 11.5132 15.1233 11.3733M11.4194 15.1694L6.76432 20.8219C6.28037 21.4096 5.55897 21.75 4.79768 21.75C3.39064 21.75 2.25 20.6094 2.25 19.2023C2.25 18.441 2.59044 17.7196 3.1781 17.2357L10.0146 11.6056M15.1233 11.3733C15.6727 11.2094 16.2858 11.1848 16.8659 11.2338C16.9925 11.2445 17.1206 11.25 17.25 11.25C19.7353 11.25 21.75 9.23528 21.75 6.75C21.75 6.08973 21.6078 5.46268 21.3523 4.89779L18.0762 8.17397C16.9605 7.91785 16.0823 7.03963 15.8262 5.92397L19.1024 2.64774C18.5375 2.39223 17.9103 2.25 17.25 2.25C14.7647 2.25 12.75 4.26472 12.75 6.75C12.75 6.87938 12.7555 7.00749 12.7662 7.13411C12.8571 8.20956 12.6948 9.39841 11.8617 10.0845L11.7596 10.1686M10.0146 11.6056L5.90901 7.5H4.5L2.25 3.75L3.75 2.25L7.5 4.5V5.90901L11.7596 10.1686M10.0146 11.6056L11.7596 10.1686M18.375 18.375L15.75 15.75M4.86723 19.125H4.87473V19.1325H4.86723V19.125Z"/>
+        <path stroke-linecap="round" stroke-linejoin="round" d="M20.38 3.46 16 2a4 4 0 0 1-8 0L3.62 3.46a2 2 0 0 0-1.34 2.23l.58 3.47a1 1 0 0 0 .99.84H6v10c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V10h2.15a1 1 0 0 0 .99-.84l.58-3.47a2 2 0 0 0-1.34-2.23z"/>
       </svg>
     </button>
     <button class="tab" data-go="story" aria-label="Story" title="Story">


### PR DESCRIPTION
## Summary
- Swap combat tab icon for a sword and gear tab icon for a shirt
- Move Log In into menu and reorder menu items by usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ce8420e4832ea3772e623d06a4bf