### PR TITLE
Reduce modal header prominence

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -98,9 +98,9 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
 #modal-rules .pdf-controls{position:absolute;bottom:16px;right:16px;display:flex;flex-direction:column;gap:8px;z-index:1}
 .overlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.6);backdrop-filter:blur(2px);z-index:1000;padding:16px;opacity:1;pointer-events:auto;transition:opacity .2s ease}
 .overlay.hidden{opacity:0;pointer-events:none}
-.modal{background:var(--surface);border:1px solid var(--accent);border-radius:var(--radius);max-width:720px;width:100%;padding:24px;box-shadow:var(--shadow);position:relative;max-height:calc(100vh - 32px);overflow:auto;transform:scale(1);opacity:1;transition:transform .2s ease,opacity .2s ease}
+.modal{background:var(--surface);border:1px solid var(--accent);border-radius:var(--radius);max-width:720px;width:100%;padding:16px;box-shadow:var(--shadow);position:relative;max-height:calc(100vh - 32px);overflow:auto;transform:scale(1);opacity:1;transition:transform .2s ease,opacity .2s ease}
 .overlay.hidden .modal{transform:scale(.95);opacity:0}
-.modal h3{margin:0 0 8px;color:var(--accent)}
+.modal h3{margin:0 0 4px;color:var(--accent);font-size:1rem;font-weight:600}
 .modal .x{position:sticky;top:8px;margin-left:auto;margin-right:8px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition);z-index:2}
 .modal .x:hover{color:var(--accent)}
 .modal .actions{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}


### PR DESCRIPTION
## Summary
- shrink modal padding and header font size to keep content at the forefront

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5e2273978832e8a1af3f3f7c191ee