### PR TITLE
Remove Home breadcrumbs header

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,6 @@
       </svg>
     </button>
   </div>
-  <nav class="breadcrumbs"><span>Home</span><span id="crumb-current">Combat</span></nav>
 </header>
 
 <main>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -116,7 +116,6 @@ document.addEventListener('input', e=>{
 /* ========= theme ========= */
 const root = document.documentElement;
 const btnTheme = $('btn-theme');
-const crumbCurrent = $('crumb-current');
 function applyTheme(t){
   root.classList.remove('theme-light','theme-high');
   if(t==='light') root.classList.add('theme-light');
@@ -155,10 +154,6 @@ if (btnMenu && menuActions) {
 function setTab(name){
   qsa('section[data-tab]').forEach(s=> s.style.display = s.getAttribute('data-tab')===name ? 'block':'none');
   qsa('.tab').forEach(b=> b.classList.toggle('active', b.getAttribute('data-go')===name));
-  if(crumbCurrent){
-    const tabBtn = qs(`.tab[data-go="${name}"]`);
-    crumbCurrent.textContent = tabBtn ? (tabBtn.getAttribute('aria-label') || name) : name;
-  }
 }
 qsa('.tab').forEach(b=> b.addEventListener('click', ()=> setTab(b.getAttribute('data-go'))));
 setTab('combat');

--- a/styles/main.css
+++ b/styles/main.css
@@ -33,8 +33,6 @@ header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var
 .icon:focus-visible,.tab:focus-visible,.modal .x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 [data-tip]{position:relative;cursor:help}
 [data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
-.breadcrumbs{margin-top:4px;font-size:.875rem;color:var(--muted)}
-.breadcrumbs span+span::before{content:"/";margin:0 4px}
 .tabs{margin-top:6px;display:flex;gap:8px;flex-wrap:nowrap;justify-content:center}
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{max-width:65ch;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}


### PR DESCRIPTION
## Summary
- Remove breadcrumb navigation from header and associated styles
- Clean up tab logic by dropping crumb update code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5ea678dfc832e87c6ad6171945223