### PR TITLE
Trim modal headers and remove initiative breadcrumbs

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,7 +529,6 @@
       </svg>
     </button>
     <h3>Encounter Tracker</h3>
-    <div class="inline" style="margin-bottom:6px"><span class="pill" id="round-pill">Round 1</span><span class="pill" id="turn-pill"></span></div>
     <fieldset class="inline">
       <legend class="sr-only">Add Combatant</legend>
       <label for="enc-name" class="sr-only">Name</label>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -992,7 +992,6 @@ function saveEnc(){
   localStorage.setItem('enc-turn', String(turn));
 }
 function renderEnc(){
-  $('round-pill').textContent='Round '+round;
   const list=$('enc-list'); list.innerHTML='';
     roster.forEach((r,idx)=>{
       const row=document.createElement('div');
@@ -1001,12 +1000,6 @@ function renderEnc(){
       list.appendChild(row);
     });
     applyDeleteIcons(list);
-    const turnName = roster[turn] && roster[turn].name ? roster[turn].name : '';
-    const turnEl = $('turn-pill');
-  if(turnEl){
-    turnEl.textContent = turnName ? `Turn: ${turnName}` : '';
-    turnEl.style.display = turnName ? '' : 'none';
-  }
   qsa('[data-del]', list).forEach(b=> b.addEventListener('click', ()=>{
     const i=Number(b.dataset.del);
     roster.splice(i,1);

--- a/styles/main.css
+++ b/styles/main.css
@@ -103,7 +103,7 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
 .overlay.hidden{opacity:0;pointer-events:none}
 .modal{background:var(--surface);border:1px solid var(--accent);border-radius:var(--radius);max-width:720px;width:100%;padding:16px;box-shadow:var(--shadow);position:relative;max-height:calc(100vh - 32px);overflow:auto;transform:scale(1);opacity:1;transition:transform .2s ease,opacity .2s ease}
 .overlay.hidden .modal{transform:scale(.95);opacity:0}
-.modal h3{margin:0 0 4px;color:var(--accent);font-size:1rem;font-weight:600}
+.modal h3{margin:0 0 4px;color:var(--accent);font-size:.9rem;line-height:1.2;font-weight:600}
 .modal .x{position:sticky;top:8px;margin-left:auto;margin-right:8px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition);z-index:2}
 .modal .x:hover{color:var(--accent)}
 .modal .actions{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}


### PR DESCRIPTION
## Summary
- Remove round/turn breadcrumb pills from initiative tracker modal
- Drop unused breadcrumb updates in JS
- Reduce modal heading size for more compact popups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fc8b8fa4832e9cfb73d0a51e1ed0