### PR TITLE
Right-align compact header menu

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -12,10 +12,10 @@ header h1{font-size:1rem}
 h2{font-size:1.5rem;font-weight:600;color:var(--accent)}
 h3{font-size:1.25rem;font-weight:600}
 header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(8px + env(safe-area-inset-top)) 10px 8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;flex-direction:column}
-header.compact{flex-direction:row;align-items:center;padding:4px 10px}
+header.compact{flex-direction:row;align-items:center;justify-content:flex-end;padding:4px 10px}
 header.compact #btn-theme,header.compact h1,header.compact #btn-dm{display:none}
-header.compact .top{margin-right:8px;flex:0 0 auto}
-header.compact .tabs{margin-top:0;flex:1;justify-content:flex-start}
+header.compact .top{margin-left:8px;margin-right:0;flex:0 0 auto;order:2}
+header.compact .tabs{margin-top:0;flex:0 0 auto;order:1;justify-content:flex-end}
 .top{display:flex;align-items:center;justify-content:center;gap:8px}
 .title-group{display:flex;align-items:center;gap:6px}
 .actions{display:flex;gap:6px}


### PR DESCRIPTION
## Summary
- Right-align compact header elements so top bar anchors to the right
- Place menu button as rightmost item when header shrinks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a60360d9f8832e8b0d511f4b9b3058