### PR TITLE
feat: persist theme per user and add dynamic background

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -128,16 +128,26 @@ function applyTheme(t){
     qs('#icon-moon', btnTheme).style.display = t==='high' ? 'block' : 'none';
   }
 }
-applyTheme(localStorage.getItem('theme') || 'dark');
+function loadTheme(){
+  const player=currentPlayer();
+  const key=player?`theme:${player}`:'theme';
+  const theme=localStorage.getItem(key)||localStorage.getItem('theme')||'dark';
+  applyTheme(theme);
+}
+loadTheme();
 if (btnTheme) {
   btnTheme.addEventListener('click', ()=>{
     const themes=['dark','light','high','forest','ocean'];
-    const curr=localStorage.getItem('theme')||'dark';
+    const player=currentPlayer();
+    const key=player?`theme:${player}`:'theme';
+    const curr=localStorage.getItem(key)||'dark';
     const next=themes[(themes.indexOf(curr)+1)%themes.length];
-    localStorage.setItem('theme', next);
+    localStorage.setItem(key, next);
+    if(player) localStorage.setItem('theme', next);
     applyTheme(next);
   });
 }
+window.addEventListener('playerChanged', loadTheme);
 
 const btnMenu = $('btn-menu');
 const menuActions = $('menu-actions');

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -52,6 +52,9 @@ export function loginPlayer(name, password) {
   const p = players[name];
   if (p && p.password === password) {
     localStorage.setItem(PLAYER_SESSION, name);
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('playerChanged'));
+    }
     return true;
   }
   return false;
@@ -63,6 +66,9 @@ export function currentPlayer() {
 
 export function logoutPlayer() {
   localStorage.removeItem(PLAYER_SESSION);
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('playerChanged'));
+  }
 }
 
 export function loginDM(password) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -6,8 +6,8 @@
 *,*::before,*::after{box-sizing:border-box}
 html{-webkit-text-size-adjust:100%;-moz-text-size-adjust:100%;text-size-adjust:100%}
 body,h1,h2,h3,h4,p,figure,blockquote,dl,dd{margin:0}
-html{height:100%}body{min-height:100%}
-body{margin:0;background:var(--bg);color:var(--text);font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased;overflow-x:hidden;line-height:1.6;font-size:16px}
+html{height:100%;background:var(--bg);transition:var(--transition);}body{min-height:100%}
+body{margin:0;background:transparent;color:var(--text);font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased;overflow-x:hidden;line-height:1.6;font-size:16px;transition:var(--transition)}
 h1,h2,h3,h4{font-family:inherit;line-height:1.25;margin:0 0 .5em}
 h1{font-size:2rem;font-weight:700;color:var(--accent)}
 header h1{font-size:1rem}


### PR DESCRIPTION
## Summary
- apply theme from per-user saved preference and listen for login changes
- dispatch playerChanged events on player login/logout
- animate page background and ensure it updates with theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6116e8bf4832e843506ffea2a9c50