### PR TITLE
Improve header transition and tab spacing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -13,12 +13,13 @@ h1{font-size:2rem;font-weight:700;color:var(--accent)}
 header h1{font-size:1rem}
 h2{font-size:1.5rem;font-weight:600;color:var(--accent)}
 h3{font-size:1.25rem;font-weight:600}
-header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(8px + env(safe-area-inset-top)) 10px 8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;flex-direction:column}
+header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(8px + env(safe-area-inset-top)) 10px 8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;flex-direction:column;transition:var(--transition)}
 header.compact{flex-direction:row;align-items:center;justify-content:flex-end;padding:4px 10px}
-header.compact #btn-theme,header.compact h1,header.compact #btn-dm{display:none}
+header #btn-theme,header h1,header #btn-dm{transition:var(--transition)}
+header.compact #btn-theme,header.compact h1,header.compact #btn-dm{opacity:0;max-width:0;margin:0;padding:0;pointer-events:none}
 header.compact .top{margin-left:8px;margin-right:0;flex:0 0 auto;order:2}
-header.compact .tabs{margin-top:0;flex:0 0 auto;order:1;justify-content:flex-end}
-.top{display:flex;align-items:center;justify-content:center;gap:8px}
+header.compact .tabs{margin-top:0;flex:1;order:1;justify-content:space-evenly}
+.top{display:flex;align-items:center;justify-content:center;gap:8px;transition:var(--transition)}
 .title-group{display:flex;align-items:center;gap:6px}
 .actions{display:flex;gap:6px}
 .dropdown{position:relative}
@@ -29,7 +30,7 @@ header.compact .tabs{margin-top:0;flex:0 0 auto;order:1;justify-content:flex-end
 @media(max-width:600px){
   .top{flex-wrap:wrap;justify-content:center;text-align:center}
   .actions{flex-wrap:wrap;justify-content:center}
-  .tabs{justify-content:center}
+  .tabs{justify-content:space-evenly}
 }
 .icon,.tab{padding:2px;width:27px;height:27px;min-height:27px;aspect-ratio:1/1;border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition)}
 .icon svg,.tab svg{width:27px;height:27px}
@@ -39,7 +40,7 @@ header.compact .tabs{margin-top:0;flex:0 0 auto;order:1;justify-content:flex-end
 .icon:focus-visible,.tab:focus-visible,.modal .x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 [data-tip]{position:relative;cursor:help}
 [data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
-.tabs{margin-top:6px;display:flex;gap:8px;flex-wrap:nowrap;justify-content:center}
+.tabs{margin-top:6px;display:flex;flex-wrap:nowrap;justify-content:space-evenly;width:100%;gap:0;transition:var(--transition)}
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{max-width:65ch;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}
 section{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:14px;margin-bottom:14px;box-shadow:var(--shadow)}


### PR DESCRIPTION
## Summary
- Smooth header collapse by fading out theme, title and DM buttons and adding transitions
- Evenly distribute tab buttons across the bar for better alignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a618c44934832eb6916a9f78629df5