### PR TITLE
Add roll-to-hit buttons for attacks and signature moves

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -855,6 +855,21 @@ function createCard(kind, pref = {}) {
   });
   const delWrap = document.createElement('div');
   delWrap.className = 'inline';
+  if (kind === 'weapon' || kind === 'sig') {
+    const hitBtn = document.createElement('button');
+    hitBtn.className = 'btn-sm';
+    hitBtn.textContent = 'Roll to Hit';
+    const out = document.createElement('span');
+    out.className = 'pill result';
+    hitBtn.addEventListener('click', () => {
+      const roll = 1 + Math.floor(Math.random() * 20);
+      out.textContent = roll;
+      const name = qs("[data-f='name']", card)?.value || (kind === 'sig' ? 'Signature Move' : 'Attack');
+      pushLog(diceLog, { t: Date.now(), text: `${name} attack roll: ${roll}` }, 'dice-log');
+    });
+    delWrap.appendChild(hitBtn);
+    delWrap.appendChild(out);
+  }
   const delBtn = document.createElement('button');
   delBtn.className = 'btn-sm';
   delBtn.dataset.act = 'del';


### PR DESCRIPTION
## Summary
- Add "Roll to Hit" button to weapon and signature move cards that rolls a single d20 and logs the result

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a61e17ff84832ebe220315113b0ee3