### PR TITLE
Add roll-to-hit option for powers and signature moves

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -855,7 +855,7 @@ function createCard(kind, pref = {}) {
   });
   const delWrap = document.createElement('div');
   delWrap.className = 'inline';
-  if (kind === 'weapon' || kind === 'sig') {
+  if (kind === 'weapon' || kind === 'sig' || kind === 'power') {
     const hitBtn = document.createElement('button');
     hitBtn.className = 'btn-sm';
     hitBtn.textContent = 'Roll to Hit';
@@ -864,7 +864,7 @@ function createCard(kind, pref = {}) {
     hitBtn.addEventListener('click', () => {
       const roll = 1 + Math.floor(Math.random() * 20);
       out.textContent = roll;
-      const name = qs("[data-f='name']", card)?.value || (kind === 'sig' ? 'Signature Move' : 'Attack');
+      const name = qs("[data-f='name']", card)?.value || (kind === 'sig' ? 'Signature Move' : (kind === 'power' ? 'Power' : 'Attack'));
       pushLog(diceLog, { t: Date.now(), text: `${name} attack roll: ${roll}` }, 'dice-log');
     });
     delWrap.appendChild(hitBtn);


### PR DESCRIPTION
## Summary
- add roll-to-hit button generation for power cards in addition to weapons and signature moves
- log power rolls with appropriate default name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6225b6a74832ea00611d846f4b9e3