### PR TITLE
Style saves and skills like ability scores

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,11 +217,11 @@
     </fieldset>
     <fieldset class="card">
       <legend>Saving Throws</legend>
-      <div class="inline" id="saves"></div>
+      <div id="saves" class="grid ability-grid"></div>
     </fieldset>
     <fieldset class="card">
       <legend>Skills</legend>
-      <div class="grid grid-2" id="skills"></div>
+      <div id="skills" class="grid ability-grid"></div>
     </fieldset>
   </section>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -196,8 +196,10 @@ ABILS.forEach(a=>{ const sel=$(a); for(let v=10; v<=24; v++) sel.add(new Option(
 
 const saveGrid = $('saves');
 saveGrid.innerHTML = ABILS.map(a=>`
-  <div class="inline">
-    <label class="inline"><input type="checkbox" id="save-${a}-prof"/> ${a.toUpperCase()} <span class="pill pill-sm" id="save-${a}">+0</span></label>
+  <div class="ability-box">
+    <label>${a.toUpperCase()}</label>
+    <div class="score"><span class="score-val" id="save-${a}">+0</span></div>
+    <label class="inline"><input type="checkbox" id="save-${a}-prof"/> Proficient</label>
     <button class="btn-sm" data-roll-save="${a}">Roll</button>
     <span class="pill result" id="save-${a}-res"></span>
   </div>
@@ -225,8 +227,10 @@ const SKILLS = [
 ];
 const skillGrid = $('skills');
 skillGrid.innerHTML = SKILLS.map((s,i)=>`
-  <div class="inline">
-    <label class="inline"><input type="checkbox" id="skill-${i}-prof"/> ${s.name} <span class="pill pill-sm" id="skill-${i}">+0</span></label>
+  <div class="ability-box">
+    <label>${s.name}</label>
+    <div class="score"><span class="score-val" id="skill-${i}">+0</span></div>
+    <label class="inline"><input type="checkbox" id="skill-${i}-prof"/> Proficient</label>
     <button class="btn-sm" data-roll-skill="${i}">Roll</button>
     <span class="pill result" id="skill-${i}-res"></span>
   </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -147,6 +147,17 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
   text-align:center;
 }
 
+.ability-box .score-val{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  width:100%;
+  height:72px;
+  font-size:1.8rem;
+  border:1px solid var(--line);
+  border-radius:var(--radius);
+}
+
 .ability-box .mod{
   position:absolute;
   bottom:4px;


### PR DESCRIPTION
## Summary
- Render saving throws and skills using ability-box layout
- Add styling for score boxes and update grid classes in markup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a636bbade4832e970e68dac56c2431