### PR TITLE
Rename Arcana and Animal Handling skills

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -215,8 +215,8 @@ saveGrid.innerHTML = ABILS.map(a=>`
 
 const SKILLS = [
   { name: 'Acrobatics', abil: 'dex' },
-  { name: 'Animal Handling', abil: 'wis' },
-  { name: 'Arcana', abil: 'int' },
+  { name: 'Biocontrol', abil: 'wis' },
+  { name: 'Technology', abil: 'int' },
   { name: 'Athletics', abil: 'str' },
   { name: 'Deception', abil: 'cha' },
   { name: 'History', abil: 'int' },


### PR DESCRIPTION
## Summary
- rename skill "Arcana" to "Technology"
- rename skill "Animal Handling" to "Biocontrol"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a63ea42948832e95a117d7e7dedcc1