### PR TITLE
Prevent roll and flip result pills from shrinking

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,14 +95,14 @@
           <input id="dice-count" type="number" inputmode="numeric" min="1" value="1"/>
           <button id="roll-dice" class="btn-sm">Roll</button>
         </div>
-        <span class="pill result" id="dice-out"></span>
+        <span class="pill result" id="dice-out" data-placeholder="000"></span>
       </fieldset>
       <fieldset class="card">
         <legend>Coin Flip</legend>
         <div class="inline">
           <button id="flip" class="btn-sm">Flip</button>
         </div>
-        <span class="pill result" id="flip-out"></span>
+        <span class="pill result" id="flip-out" data-placeholder="Heads"></span>
       </fieldset>
     </div>
     <fieldset class="card">

--- a/styles/main.css
+++ b/styles/main.css
@@ -86,6 +86,7 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
 .pill-sm{padding:2px 6px;font-size:.75rem}
 .pill.result{font-size:1rem;font-weight:700;}
+.pill.result:empty::before{content:attr(data-placeholder);visibility:hidden;}
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:8px;}
 .death-saves input[type="checkbox"]{margin:0;}
 .sp-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;flex:1;}


### PR DESCRIPTION
## Summary
- Add hidden placeholders to the dice and coin result pills so they retain width before showing results
- Style pill results to use placeholder text when empty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a63f0b73d8832e97a37dc415899587