### PR TITLE
Prevent roll and flip result pills from shrinking

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,14 +95,14 @@
           <input id="dice-count" type="number" inputmode="numeric" min="1" value="1"/>
           <button id="roll-dice" class="btn-sm">Roll</button>
         </div>
-        <span class="pill result" id="dice-out"></span>
+        <span class="pill result" id="dice-out" data-placeholder="000"></span>
       </fieldset>
       <fieldset class="card">
         <legend>Coin Flip</legend>
         <div class="inline">
           <button id="flip" class="btn-sm">Flip</button>
         </div>
-        <span class="pill result" id="flip-out"></span>
+        <span class="pill result" id="flip-out" data-placeholder="Heads"></span>
       </fieldset>
     </div>
     <fieldset class="card">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -209,7 +209,7 @@ saveGrid.innerHTML = ABILS.map(a=>`
     <div class="score"><span class="score-val" id="save-${a}">+0</span></div>
     <label class="inline"><input type="checkbox" id="save-${a}-prof"/> Proficient</label>
     <button class="btn-sm" data-roll-save="${a}">Roll</button>
-    <span class="pill result" id="save-${a}-res"></span>
+    <span class="pill result" id="save-${a}-res" data-placeholder="000"></span>
   </div>
 `).join('');
 
@@ -240,7 +240,7 @@ skillGrid.innerHTML = SKILLS.map((s,i)=>`
     <div class="score"><span class="score-val" id="skill-${i}">+0</span></div>
     <label class="inline"><input type="checkbox" id="skill-${i}-prof"/> Proficient</label>
     <button class="btn-sm" data-roll-skill="${i}">Roll</button>
-    <span class="pill result" id="skill-${i}-res"></span>
+    <span class="pill result" id="skill-${i}-res" data-placeholder="000"></span>
   </div>
 `).join('');
 
@@ -911,6 +911,7 @@ function createCard(kind, pref = {}) {
     hitBtn.textContent = 'Roll to Hit';
     const out = document.createElement('span');
     out.className = 'pill result';
+    out.dataset.placeholder = '000';
     hitBtn.addEventListener('click', () => {
       const pb = num(elProfBonus.value)||2;
       const rangeVal = qs("[data-f='range']", card)?.value || '';

--- a/styles/main.css
+++ b/styles/main.css
@@ -86,6 +86,7 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
 .pill-sm{padding:2px 6px;font-size:.75rem}
 .pill.result{font-size:1rem;font-weight:700;}
+.pill.result:empty::before{content:attr(data-placeholder);visibility:hidden;}
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:8px;}
 .death-saves input[type="checkbox"]{margin:0;}
 .sp-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;flex:1;}


### PR DESCRIPTION
## Summary
- Add hidden placeholders to dice and coin result pills so they retain width before showing results
- Apply the same placeholder logic to saving throw, skill check, and attack roll result pills
- Style pill results to use placeholder text when empty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a63f0b73d8832e97a37dc415899587