### PR TITLE
style: align roll and flip controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 <main>
   <!-- COMBAT -->
   <section data-tab="combat">
-    <div class="grid grid-2">
+    <div class="grid grid-2 roll-flip-grid">
       <fieldset class="card">
         <legend>Dice Roll</legend>
         <div class="inline">

--- a/styles/main.css
+++ b/styles/main.css
@@ -87,6 +87,20 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
 .pill-sm{padding:2px 6px;font-size:.75rem}
 .pill.result{font-size:1rem;font-weight:700;}
 .pill.result:empty::before{content:attr(data-placeholder);visibility:hidden;}
+.roll-flip-grid{grid-template-columns:repeat(2,1fr);gap:8px;}
+.roll-flip-grid .inline{flex-wrap:nowrap;gap:4px;}
+.roll-flip-grid select,
+.roll-flip-grid input,
+.roll-flip-grid button,
+.roll-flip-grid .pill{padding:4px 6px;min-height:28px;}
+.roll-flip-grid .pill.result{font-size:.85rem;}
+@media(max-width:600px){
+  .roll-flip-grid{grid-template-columns:repeat(2,1fr);}
+  .roll-flip-grid .inline{flex-direction:row;}
+  .roll-flip-grid .inline>input:not([type="checkbox"]),
+  .roll-flip-grid .inline>select{flex:1;width:auto;}
+  .roll-flip-grid .inline>button{flex:0 0 auto;width:auto;}
+}
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:8px;}
 .death-saves input[type="checkbox"]{margin:0;}
 .sp-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;flex:1;}


### PR DESCRIPTION
## Summary
- ensure roll and flip controls render side-by-side
- shrink inputs, buttons, and pills for compact layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a642d77bcc832e8c0fb42961bdc1e8