### PR TITLE
style: tighten roll control layout

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -93,7 +93,8 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
 .roll-flip-grid input,
 .roll-flip-grid button,
 .roll-flip-grid .pill{padding:4px 6px;min-height:28px;}
-.roll-flip-grid .pill.result{font-size:.85rem;}
+.roll-flip-grid .pill.result{font-size:.85rem;min-width:40px;}
+#dice-count{flex:0 0 30px;width:30px;}
 @media(max-width:600px){
   .roll-flip-grid{grid-template-columns:repeat(2,1fr);}
   .roll-flip-grid .inline{flex-direction:row;}


### PR DESCRIPTION
## Summary
- keep roll result pills at least 40px wide
- lock dice count field to 30px for compact controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a64753059c832eac538a827cbe7432