### PR TITLE
Add skull animation before death alert

### DIFF
--- a/index.html
+++ b/index.html
@@ -803,6 +803,7 @@
   <p>Product of XoVrom industries ® 2025</p>
   <p><a href="#" id="dm-login-link">DM Login</a></p>
 </footer>
+<div id="death-animation" aria-hidden="true">💀</div>
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 <script type="module" src="scripts/users.js"></script>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -717,12 +717,30 @@ $('flip').addEventListener('click', ()=>{
   $('flip-out').textContent = v;
   pushLog(coinLog, {t:Date.now(), text:v}, 'coin-log');
   renderLogs();
-  renderFullLogs();
+renderFullLogs();
 });
+
+function playDeathAnimation(){
+  const anim = $('death-animation');
+  if(!anim) return Promise.resolve();
+  return new Promise(res=>{
+    anim.classList.add('show');
+    const done=()=>{
+      anim.classList.remove('show');
+      anim.removeEventListener('animationend', done);
+      res();
+    };
+    anim.addEventListener('animationend', done);
+  });
+}
+
 const deathBoxes = ['death-save-1','death-save-2','death-save-3'].map(id => $(id));
+let deathHandled=false;
 deathBoxes.forEach((box) => {
-  box.addEventListener('change', () => {
-    if (deathBoxes.every(b => b.checked)) {
+  box.addEventListener('change', async () => {
+    if (!deathHandled && deathBoxes.every(b => b.checked)) {
+      deathHandled=true;
+      await playDeathAnimation();
       alert('You have fallen, your sacrifice will be remembered.');
     }
   });

--- a/styles/main.css
+++ b/styles/main.css
@@ -104,6 +104,27 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
 }
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:8px;justify-content:center;}
 .death-saves input[type="checkbox"]{margin:0;}
+#death-animation{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:10rem;
+  color:var(--text);
+  pointer-events:none;
+  opacity:0;
+  z-index:3000;
+}
+#death-animation.show{
+  animation:deathFade 2s ease forwards;
+}
+@keyframes deathFade{
+  0%{opacity:0;}
+  20%{opacity:1;}
+  80%{opacity:1;}
+  100%{opacity:0;}
+}
 .sp-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;flex:1;}
 .sp-grid .btn-sm{width:100%;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}


### PR DESCRIPTION
## Summary
- show a skull animation when all death saves are marked
- alert the existing death message after animation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a64bb6f738832eab53e390d435183e