### PR TITLE
Add screen animations for healing and saving actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -801,11 +801,13 @@
 <footer>
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
   <p>Product of XoVrom industries ® 2025</p>
-  <p><a href="#" id="dm-login-link">DM Login</a></p>
- </footer>
- <div id="death-animation" aria-hidden="true">💀</div>
- <div id="damage-animation" aria-hidden="true"></div>
- <div class="toast" id="toast" role="status" aria-live="polite"></div>
+ <p><a href="#" id="dm-login-link">DM Login</a></p>
+</footer>
+<div id="death-animation" aria-hidden="true">💀</div>
+<div id="damage-animation" aria-hidden="true"></div>
+<div id="heal-animation" aria-hidden="true"></div>
+<div id="save-animation" aria-hidden="true">💾</div>
+<div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 <script type="module" src="scripts/users.js"></script>
 <script type="module" src="scripts/main.js"></script>

--- a/styles/main.css
+++ b/styles/main.css
@@ -145,6 +145,46 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
   30%{transform:scale(1.2);opacity:1;}
   100%{transform:scale(1);opacity:0;}
 }
+#heal-animation{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:8rem;
+  color:var(--success);
+  pointer-events:none;
+  opacity:0;
+  z-index:3000;
+}
+#heal-animation.show{
+  animation:healRise 1s ease forwards;
+}
+@keyframes healRise{
+  0%{transform:translateY(20px);opacity:0;}
+  30%{transform:translateY(0);opacity:1;}
+  100%{transform:translateY(-20px);opacity:0;}
+}
+#save-animation{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:6rem;
+  color:var(--accent);
+  pointer-events:none;
+  opacity:0;
+  z-index:3000;
+}
+#save-animation.show{
+  animation:saveSpin 1s ease forwards;
+}
+@keyframes saveSpin{
+  0%{transform:scale(0) rotate(-180deg);opacity:0;}
+  30%{transform:scale(1.2) rotate(0deg);opacity:1;}
+  100%{transform:scale(1) rotate(0deg);opacity:0;}
+}
 .sp-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;flex:1;}
 .sp-grid .btn-sm{width:100%;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .2s ease,transform .2s ease}


### PR DESCRIPTION
## Summary
- Show center-screen effects for HP damage, healing, and save success
- Implement new heal and save animations with accompanying CSS
- Hook animations into HP controls and save action

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a64eb4e2b4832e9903e1ab960b1220