### PR TITLE
Fix roll result animation sign

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -626,7 +626,7 @@ $('hp-dmg').addEventListener('click', ()=>{
     d-=use;
   }
   setHP(num(elHPBar.value)-d);
-  playDamageAnimation(d);
+  playDamageAnimation(-d);
 });
 $('hp-heal').addEventListener('click', ()=>{
   const d=num($('hp-amt').value)||0;
@@ -744,7 +744,7 @@ renderFullLogs();
 function playDamageAnimation(amount){
   const anim=$('damage-animation');
   if(!anim) return Promise.resolve();
-  anim.textContent=`-${amount}`;
+  anim.textContent=`${amount}`;
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{


### PR DESCRIPTION
## Summary
- Render damage animation with the provided value instead of forcing a negative sign
- Pass negative value when applying damage so roll results display as positive numbers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6509b6c6c832e93c4c7e8c26bb57a