### PR TITLE
Increase death save checkbox spacing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -108,7 +108,7 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
   .roll-flip-grid .inline>select{flex:1;width:auto;}
   .roll-flip-grid .inline>button{flex:0 0 auto;width:auto;}
 }
-.death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:8px;justify-content:center;}
+.death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:12px;justify-content:center;}
 .death-saves input[type="checkbox"]{margin:0;}
 #death-animation{
   position:fixed;


### PR DESCRIPTION
## Summary
- expand gap between death save checkboxes for clearer spacing in modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a65377ec10832e87c1da692da4135e