### PR TITLE
Add smooth tab transition when header is compact

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -182,7 +182,24 @@ function setTab(name){
     localStorage.setItem('active-tab', name);
   } catch (e) {}
 }
-qsa('.tab').forEach(b=> b.addEventListener('click', ()=> setTab(b.getAttribute('data-go'))));
+
+const switchTab = name => {
+  if (headerEl && headerEl.classList.contains('compact')) {
+    headerEl.classList.add('hide-tabs');
+    const onScroll = () => {
+      if (window.scrollY === 0) {
+        headerEl.classList.remove('hide-tabs');
+        setTab(name);
+        window.removeEventListener('scroll', onScroll);
+      }
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  } else {
+    setTab(name);
+  }
+};
+qsa('.tab').forEach(b=> b.addEventListener('click', ()=> switchTab(b.getAttribute('data-go'))));
 let initialTab = 'combat';
 try {
   const storedTab = localStorage.getItem('active-tab');

--- a/styles/main.css
+++ b/styles/main.css
@@ -19,6 +19,7 @@ header #btn-theme,header h1,header #btn-dm{transition:opacity .3s ease,max-width
 header.compact #btn-theme,header.compact h1,header.compact #btn-dm{opacity:0;max-width:0;margin:0;padding:0;pointer-events:none}
 header.compact .top{margin-left:8px;margin-right:0;flex:0 0 auto;order:2}
 header.compact .tabs{margin-top:0;flex:1;order:1;justify-content:space-evenly}
+header.hide-tabs .tabs{opacity:0;pointer-events:none}
 .top{display:flex;align-items:center;justify-content:center;gap:8px;transition:var(--transition)}
 .title-group{display:flex;align-items:center;gap:6px}
 .actions{display:flex;gap:6px}


### PR DESCRIPTION
## Summary
- Fade out tab bar and scroll to top before switching tabs when header is compact
- Add CSS rule to hide tab buttons during transition for smoother animation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a657f4e290832e913fa0f1098b13dd