### PR TITLE
Prevent background interaction while modals are open

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,6 +4,7 @@ import { saveLocal, saveCloud } from './storage.js';
 import { currentPlayer, getPlayers, loadPlayerCharacter, isDM } from './users.js';
 import confetti from 'https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.module.mjs';
 let lastFocus = null;
+let openModals = 0;
 let cccgPage = 1;
 const cccgCanvas = qs('#cccg-canvas');
 const cccgCtx = cccgCanvas ? cccgCanvas.getContext('2d') : null;
@@ -51,8 +52,13 @@ function applyDeleteIcons(root=document){
 }
 function show(id){
   const el = $(id);
-  if(!el) return;
+  if(!el || !el.classList.contains('hidden')) return;
   lastFocus = document.activeElement;
+  if (openModals === 0) {
+    document.body.classList.add('modal-open');
+    qsa('body > :not(.overlay)').forEach(e => e.setAttribute('inert',''));
+  }
+  openModals++;
   el.classList.remove('hidden');
   el.setAttribute('aria-hidden','false');
   const focusEl = el.querySelector('[autofocus],input,select,textarea,button');
@@ -62,11 +68,16 @@ function show(id){
 }
 function hide(id){
   const el = $(id);
-  if(!el) return;
+  if(!el || el.classList.contains('hidden')) return;
   el.classList.add('hidden');
   el.setAttribute('aria-hidden','true');
   if (lastFocus && typeof lastFocus.focus === 'function') {
     lastFocus.focus();
+  }
+  openModals = Math.max(0, openModals - 1);
+  if (openModals === 0) {
+    document.body.classList.remove('modal-open');
+    qsa('body > :not(.overlay)').forEach(e => e.removeAttribute('inert'));
   }
 }
 let audioCtx = null;

--- a/styles/main.css
+++ b/styles/main.css
@@ -250,6 +250,8 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
 .overlay.hidden{opacity:0;pointer-events:none}
 .modal{background:var(--surface);border:1px solid var(--accent);border-radius:var(--radius);max-width:720px;width:100%;padding:16px;box-shadow:var(--shadow);position:relative;max-height:calc(100vh - 32px);overflow:auto;transform:scale(1);opacity:1;transition:transform .2s ease,opacity .2s ease}
 .overlay.hidden .modal{transform:scale(.95);opacity:0}
+body.modal-open{overflow:hidden}
+body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
 .modal h3{margin:0 0 4px;color:var(--accent);font-size:.9rem;line-height:1.2;font-weight:600}
 .modal .x{position:sticky;top:8px;margin-left:auto;margin-right:8px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition);z-index:2}
 .modal .x:hover{color:var(--accent)}


### PR DESCRIPTION
## Summary
- Track active modals and set `inert` on page content so the background can't be interacted with while any modal is open
- Add styles to disable pointer events and scrolling for the page when a modal is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a660fea67c832ea08950aa6a1200a6