### PR TITLE
Move DM players button into menu after login

### DIFF
--- a/__tests__/dm_button.test.js
+++ b/__tests__/dm_button.test.js
@@ -1,0 +1,27 @@
+import '../scripts/users.js';
+
+describe('DM Players button visibility', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = `
+      <div class="dropdown">
+        <div id="menu-actions" class="menu">
+          <button id="btn-dm" class="btn-sm" hidden>Players</button>
+        </div>
+      </div>
+      <input id="dm-password" />
+      <button id="login-dm"></button>
+      <div id="toast"></div>
+    `;
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  test('hidden by default and visible after DM login', () => {
+    const dmBtn = document.getElementById('btn-dm');
+    expect(dmBtn.hidden).toBe(true);
+    document.getElementById('dm-password').value = 'Dragons22!';
+    document.getElementById('login-dm').click();
+    expect(dmBtn.hidden).toBe(false);
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -42,9 +42,9 @@
         <button id="btn-campaign" class="btn-sm">Campaign</button>
         <button id="btn-rules" class="btn-sm">Rules</button>
         <button id="btn-help" class="btn-sm">Help</button>
+        <button id="btn-dm" class="btn-sm" hidden>Players</button>
       </div>
     </div>
-    <button id="btn-dm" class="btn-sm" hidden>Players</button>
   </div>
   <div class="tabs">
     <button class="tab active" data-go="combat" aria-label="Combat" title="Combat">

--- a/styles/main.css
+++ b/styles/main.css
@@ -15,8 +15,8 @@ h2{font-size:1.5rem;font-weight:600;color:var(--accent)}
 h3{font-size:1.25rem;font-weight:600}
 header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(8px + env(safe-area-inset-top)) 10px 8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;flex-direction:column;transition:padding .3s ease}
 header.compact{flex-direction:row;align-items:center;justify-content:flex-end;padding:4px 10px}
-header #btn-theme,header h1,header #btn-dm{transition:opacity .3s ease,max-width .3s ease,margin .3s ease,padding .3s ease;overflow:hidden}
-header.compact #btn-theme,header.compact h1,header.compact #btn-dm{opacity:0;max-width:0;margin:0;padding:0;pointer-events:none}
+header #btn-theme,header h1{transition:opacity .3s ease,max-width .3s ease,margin .3s ease,padding .3s ease;overflow:hidden}
+header.compact #btn-theme,header.compact h1{opacity:0;max-width:0;margin:0;padding:0;pointer-events:none}
 header.compact .top{margin-left:8px;margin-right:0;flex:0 0 auto;order:2}
 header.compact .tabs{margin-top:0;flex:1;order:1;justify-content:space-evenly}
 header.hide-tabs .tabs{opacity:0;pointer-events:none}


### PR DESCRIPTION
## Summary
- Move DM "Players" control into dropdown menu
- Hide DM options until successful DM login
- Test that button only appears after logging in as DM

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a66591137c832e9f22b12dd2857c60