### PR TITLE
style: thicken HP and SP progress bars

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -84,6 +84,23 @@ button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2
   .inline>button,
   .inline>progress{flex:none;width:100%;height:36px}
 }
+progress{
+  -webkit-appearance:none;
+  appearance:none;
+  border:1px solid var(--accent);
+  border-radius:999px;
+  background:var(--surface-2);
+  overflow:hidden;
+}
+progress::-webkit-progress-bar{
+  background:var(--surface-2);
+}
+progress::-webkit-progress-value{
+  background:var(--accent);
+}
+progress::-moz-progress-bar{
+  background:var(--accent);
+}
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
 #hp-pill,#sp-pill{height:36px;padding:0 10px;display:inline-flex;align-items:center}
 .pill-sm{padding:2px 6px;font-size:.75rem}


### PR DESCRIPTION
## Summary
- style progress elements with accent color and rounded borders for a thicker look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a66fe76d48832ebeeb5624d401addd