### PR TITLE
Handle localStorage access errors

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import {
   registerPlayer,
   getPlayers,
@@ -58,6 +59,16 @@ describe('user management', () => {
     localStorage.setItem('players', '{not valid json');
     expect(getPlayers()).toEqual([]);
     expect(localStorage.getItem('players')).toBeNull();
+  });
+
+  test('handles localStorage access errors gracefully', () => {
+    const spy = jest
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(() => {
+        throw new Error('blocked');
+      });
+    expect(getPlayers()).toEqual([]);
+    spy.mockRestore();
   });
 
   test('save fails without login', async () => {

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -7,7 +7,16 @@ const DM_SESSION = 'dm-session';
 const DM_PASSWORD = 'Dragons22!';
 
 function getPlayersRaw() {
-  const raw = localStorage.getItem(PLAYERS_KEY);
+  let raw;
+  try {
+    raw = localStorage.getItem(PLAYERS_KEY);
+  } catch (e) {
+    // Accessing localStorage can fail in some environments (e.g. disabled
+    // storage or privacy modes). Treat this as no data rather than throwing an
+    // uncaught exception that prevents the page from loading.
+    console.error('Failed to access localStorage', e);
+    return {};
+  }
   if (!raw) return {};
   try {
     return JSON.parse(raw);
@@ -16,7 +25,7 @@ function getPlayersRaw() {
     // application can continue operating with a clean slate instead of
     // throwing a runtime error that breaks the page.
     console.error('Failed to parse players from localStorage', e);
-    localStorage.removeItem(PLAYERS_KEY);
+    try { localStorage.removeItem(PLAYERS_KEY); } catch {}
     return {};
   }
 }


### PR DESCRIPTION
## Summary
- Guard localStorage access to avoid crashes when it's unavailable
- Add test ensuring getPlayers handles storage access errors gracefully

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a67222b50c832eb219d51cec950f7b