### PR TITLE
fix: register service worker with absolute URL

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1624,6 +1624,7 @@ setupPerkSelect('power-style','power-style-perks', POWER_STYLE_PERKS);
 setupPerkSelect('origin','origin-perks', ORIGIN_PERKS);
 updateDerived();
 applyDeleteIcons();
-if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('sw.js').catch(e=>console.error('SW reg failed', e));
+if ('serviceWorker' in navigator) {
+  const swUrl = new URL('../sw.js', import.meta.url);
+  navigator.serviceWorker.register(swUrl).catch(e => console.error('SW reg failed', e));
 }


### PR DESCRIPTION
## Summary
- ensure service worker is registered from scripts/main.js using an absolute URL so deployments from subdirectories succeed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a67d230218832e9d7b9f72001b779a