### PR TITLE
Rename Campaign menu button to Campaign Log

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
         <button id="btn-save" class="btn-sm">Save</button>
         <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
-        <button id="btn-campaign" class="btn-sm">Campaign</button>
+        <button id="btn-campaign" class="btn-sm">Campaign Log</button>
         <button id="btn-rules" class="btn-sm">Rules</button>
         <button id="btn-help" class="btn-sm">Help</button>
         <button id="btn-dm" class="btn-sm" hidden>Players</button>
@@ -531,7 +531,7 @@
       <li><b>Encounter tracker:</b> Use the three-line icon to manage encounters and turn order.</li>
       <li><b>Dice rolling &amp; coin flips:</b> Open Roll/Flip Log from the menu to roll dice or flip coins and review results.</li>
       <li><b>Combat stats &amp; status effects:</b> Adjust HP, SP, and conditions directly on the Combat tab.</li>
-      <li><b>Campaign &amp; roll logs:</b> Keep adventure notes and history via Campaign in the menu.</li>
+      <li><b>Campaign &amp; roll logs:</b> Keep adventure notes and history via Campaign Log in the menu.</li>
       <li><b>Gear catalog:</b> Browse equipment from the Gear tab with “Open Gear Catalog.”</li>
       <li><b>Rules reference:</b> Open Rules in the menu to read the Character Creation Guide.</li>
       <li><b>Player &amp; DM login:</b> Use Log In or the DM Login link to access shared tools.</li>


### PR DESCRIPTION
## Summary
- rename "Campaign" menu button to "Campaign Log"
- update help instructions to reference new Campaign Log menu item

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a67ea59e00832eb795fb1e4f39dc8d