### PR TITLE
Add global and DM messaging system

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,12 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
       </svg>
     </button>
+    <button class="tab" id="btn-chat" aria-label="Messages" title="Messages">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12.75h6.75m-6.75-3h6.75m-6.75 6h6.75M21 12c0 4.556-4.03 8.25-9 8.25-.71 0-1.403-.074-2.069-.214L3 21l1.463-4.39C3.535 15.225 3 13.678 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z"/>
+      </svg>
+      <span id="chat-badge" class="badge" hidden></span>
+    </button>
   </div>
 </header>
 
@@ -918,6 +924,27 @@
   </div>
 </div>
 
+<div class="overlay hidden" id="chat-overlay" aria-hidden="true">
+  <div class="modal chat-modal" role="dialog" aria-modal="true" aria-label="Messages" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <div class="chat-tabs">
+      <button class="chat-tab active" data-tab="global">Global</button>
+      <button class="chat-tab" data-tab="dm">DM</button>
+      <select id="dm-select" class="chat-select" style="display:none"></select>
+    </div>
+    <div id="chat-global" class="chat-pane active"></div>
+    <div id="chat-dm" class="chat-pane"></div>
+    <div class="chat-input inline">
+      <input id="chat-text" type="text" placeholder="Message"/>
+      <button id="chat-send" class="btn-sm">Send</button>
+    </div>
+  </div>
+</div>
+
 <footer>
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
   <p>Product of XoVrom industries ® 2025</p>
@@ -933,5 +960,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 <script type="module" src="scripts/users.js"></script>
 <script type="module" src="scripts/main.js"></script>
+<script type="module" src="scripts/chat.js"></script>
 </body>
 </html>

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -1,0 +1,159 @@
+import { currentPlayer, isDM, getPlayers } from './users.js';
+
+const firebaseConfig = {
+  apiKey: "AIzaSyA3DZNONr73L62eERENpVOnujzyxhoiydY",
+  authDomain: "ccccg-7d6b6.firebaseapp.com",
+  databaseURL: "https://ccccg-7d6b6-default-rtdb.firebaseio.com",
+  projectId: "ccccg-7d6b6",
+  storageBucket: "ccccg-7d6b6.firebasestorage.app",
+  messagingSenderId: "705656976850",
+  appId: "1:705656976850:web:eeca63f9f325e33f2b440b",
+  measurementId: "G-DY7J7CNBVR",
+};
+
+let dbPromise = null;
+async function getDb() {
+  if (!dbPromise) {
+    dbPromise = (async () => {
+      const appMod = await import('https://www.gstatic.com/firebasejs/11.0.1/firebase-app.js');
+      const { initializeApp } = appMod;
+      const app = initializeApp(firebaseConfig);
+      try {
+        const analyticsMod = await import('https://www.gstatic.com/firebasejs/11.0.1/firebase-analytics.js');
+        const { getAnalytics } = analyticsMod;
+        getAnalytics(app);
+      } catch (e) {
+        // Analytics optional
+      }
+      const dbMod = await import('https://www.gstatic.com/firebasejs/11.0.1/firebase-database.js');
+      const { getDatabase } = dbMod;
+      return getDatabase(app);
+    })();
+  }
+  return dbPromise;
+}
+
+function appendMessage(container, from, text) {
+  const div = document.createElement('div');
+  div.className = 'chat-msg';
+  div.textContent = `${from}: ${text}`;
+  container.appendChild(div);
+  container.scrollTop = container.scrollHeight;
+}
+
+function switchTab(tab) {
+  document.querySelectorAll('.chat-pane').forEach(p => {
+    p.classList.toggle('active', p.id === `chat-${tab}`);
+  });
+  document.querySelectorAll('.chat-tab').forEach(b => {
+    b.classList.toggle('active', b.dataset.tab === tab);
+  });
+  const sel = document.getElementById('dm-select');
+  if (sel) sel.style.display = (tab === 'dm' && isDM()) ? 'block' : 'none';
+  currentTab = tab;
+}
+
+let currentTab = 'global';
+
+async function initChat() {
+  const btn = document.getElementById('btn-chat');
+  const overlay = document.getElementById('chat-overlay');
+  const closeBtn = overlay ? overlay.querySelector('[data-close]') : null;
+  const badge = document.getElementById('chat-badge');
+  const input = document.getElementById('chat-text');
+  const sendBtn = document.getElementById('chat-send');
+  const globalPane = document.getElementById('chat-global');
+  const dmPane = document.getElementById('chat-dm');
+  const dmSelect = document.getElementById('dm-select');
+  if (!btn || !overlay || !badge || !input || !sendBtn) return;
+
+  let unread = false;
+  const markUnread = () => {
+    if (overlay.classList.contains('hidden')) {
+      unread = true;
+      badge.hidden = false;
+    }
+  };
+  const clearUnread = () => {
+    unread = false;
+    badge.hidden = true;
+  };
+
+  btn.addEventListener('click', () => {
+    overlay.classList.remove('hidden');
+    overlay.setAttribute('aria-hidden', 'false');
+    clearUnread();
+  });
+
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      overlay.classList.add('hidden');
+      overlay.setAttribute('aria-hidden', 'true');
+    });
+  }
+
+  document.querySelectorAll('.chat-tab').forEach(tabBtn => {
+    tabBtn.addEventListener('click', () => switchTab(tabBtn.dataset.tab));
+  });
+
+  const db = await getDb().catch(() => null);
+  if (!db) return;
+  const { ref, push, onChildAdded } = await import('https://www.gstatic.com/firebasejs/11.0.1/firebase-database.js');
+
+  sendBtn.addEventListener('click', async () => {
+    const text = input.value.trim();
+    if (!text) return;
+    const from = isDM() ? 'DM' : (currentPlayer() || 'Anon');
+    try {
+      if (currentTab === 'global') {
+        await push(ref(db, 'chat/global'), { from, text, ts: Date.now() });
+      } else {
+        const target = isDM() ? dmSelect.value : currentPlayer();
+        if (target) {
+          await push(ref(db, 'chat/dm/' + target), { from, text, ts: Date.now() });
+        }
+      }
+    } catch (e) {
+      console.error('Chat send failed', e);
+    }
+    input.value = '';
+  });
+
+  onChildAdded(ref(db, 'chat/global'), snap => {
+    const val = snap.val();
+    appendMessage(globalPane, val.from, val.text);
+    if (currentTab !== 'global') markUnread();
+  });
+
+  if (isDM()) {
+    const players = getPlayers();
+    players.forEach(p => {
+      const opt = document.createElement('option');
+      opt.value = p;
+      opt.textContent = p;
+      dmSelect.appendChild(opt);
+      onChildAdded(ref(db, 'chat/dm/' + p), snap => {
+        const val = snap.val();
+        if (dmSelect.value === p && currentTab === 'dm') {
+          appendMessage(dmPane, val.from, val.text);
+        } else {
+          markUnread();
+        }
+      });
+    });
+  } else {
+    const player = currentPlayer();
+    if (player) {
+      onChildAdded(ref(db, 'chat/dm/' + player), snap => {
+        const val = snap.val();
+        appendMessage(dmPane, val.from, val.text);
+        if (currentTab !== 'dm') markUnread();
+      });
+    }
+  }
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', initChat);
+}
+

--- a/styles/main.css
+++ b/styles/main.css
@@ -428,3 +428,15 @@ select[required]:valid{
 @keyframes wizardFade{to{opacity:1;transform:translateX(0)}}
 .wizard-nav{display:flex;justify-content:space-between;align-items:center;margin-top:16px}
 #wizard-progress{flex:1;text-align:center}
+
+/* chat */
+.tab{position:relative}
+.badge{position:absolute;top:2px;right:2px;width:8px;height:8px;border-radius:50%;background:var(--error)}
+.chat-modal{max-width:400px}
+.chat-tabs{display:flex;gap:4px;margin-bottom:8px}
+.chat-tabs button{flex:1}
+.chat-pane{border:1px solid var(--line);border-radius:var(--radius);padding:8px;max-height:200px;overflow-y:auto;margin-bottom:8px}
+.chat-pane:not(.active){display:none}
+.chat-msg{margin-bottom:4px;font-size:.9rem}
+.chat-input input{flex:1}
+.chat-select{margin-left:4px}


### PR DESCRIPTION
## Summary
- Add messages tab with unread badge in main navigation
- Provide chat overlay supporting global chat and private DM messages
- Implement Firebase-backed chat logic for players and DM

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a689fda0d0832e8526c4b55db2d8c9