### PR TITLE
Embed chat panel into page instead of modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
       </svg>
     </button>
-    <button class="tab" id="btn-chat" aria-label="Messages" title="Messages">
+    <button class="tab" id="btn-chat" data-go="chat" aria-label="Messages" title="Messages">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12.75h6.75m-6.75-3h6.75m-6.75 6h6.75M21 12c0 4.556-4.03 8.25-9 8.25-.71 0-1.403-.074-2.069-.214L3 21l1.463-4.39C3.535 15.225 3 13.678 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z"/>
       </svg>
@@ -414,6 +414,22 @@
       <div class="card"><label for="q-vulnerable">What situation leaves you the most vulnerable—physically, emotionally, or strategically?</label><textarea id="q-vulnerable" rows="2"></textarea></div>
       <div class="card"><label for="q-admire">Which teammate do you admire the most and what do they have that you lack?</label><textarea id="q-admire" rows="2"></textarea></div>
       <div class="card"><label for="q-if-lost">If you lost your powers tomorrow, who would you still be?</label><textarea id="q-if-lost" rows="2"></textarea></div>
+    </div>
+  </section>
+
+  <section data-tab="chat">
+    <div class="chat-modal">
+      <div class="chat-tabs">
+        <button class="chat-tab active" data-tab="global">Global</button>
+        <button class="chat-tab" data-tab="dm">DM</button>
+        <select id="dm-select" class="chat-select" style="display:none"></select>
+      </div>
+      <div id="chat-global" class="chat-pane active"></div>
+      <div id="chat-dm" class="chat-pane"></div>
+      <div class="chat-input inline">
+        <input id="chat-text" type="text" placeholder="Message"/>
+        <button id="chat-send" class="btn-sm">Send</button>
+      </div>
     </div>
   </section>
 </main>
@@ -924,26 +940,6 @@
   </div>
 </div>
 
-<div class="overlay hidden" id="chat-overlay" aria-hidden="true">
-  <div class="modal chat-modal" role="dialog" aria-modal="true" aria-label="Messages" tabindex="-1">
-    <button class="x" data-close aria-label="Close">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
-      </svg>
-    </button>
-    <div class="chat-tabs">
-      <button class="chat-tab active" data-tab="global">Global</button>
-      <button class="chat-tab" data-tab="dm">DM</button>
-      <select id="dm-select" class="chat-select" style="display:none"></select>
-    </div>
-    <div id="chat-global" class="chat-pane active"></div>
-    <div id="chat-dm" class="chat-pane"></div>
-    <div class="chat-input inline">
-      <input id="chat-text" type="text" placeholder="Message"/>
-      <button id="chat-send" class="btn-sm">Send</button>
-    </div>
-  </div>
-</div>
 
 <footer>
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -74,19 +74,17 @@ let currentTab = 'global';
 
 async function initChat() {
   const btn = document.getElementById('btn-chat');
-  const overlay = document.getElementById('chat-overlay');
-  const closeBtn = overlay ? overlay.querySelector('[data-close]') : null;
   const badge = document.getElementById('chat-badge');
   const input = document.getElementById('chat-text');
   const sendBtn = document.getElementById('chat-send');
   const globalPane = document.getElementById('chat-global');
   const dmPane = document.getElementById('chat-dm');
   const dmSelect = document.getElementById('dm-select');
-  if (!btn || !overlay || !badge || !input || !sendBtn) return;
+  if (!btn || !badge || !input || !sendBtn) return;
 
   let unread = false;
   const markUnread = () => {
-    if (overlay.classList.contains('hidden')) {
+    if (!btn.classList.contains('active')) {
       unread = true;
       badge.hidden = false;
     }
@@ -96,18 +94,7 @@ async function initChat() {
     badge.hidden = true;
   };
 
-  btn.addEventListener('click', () => {
-    overlay.classList.remove('hidden');
-    overlay.setAttribute('aria-hidden', 'false');
-    clearUnread();
-  });
-
-  if (closeBtn) {
-    closeBtn.addEventListener('click', () => {
-      overlay.classList.add('hidden');
-      overlay.setAttribute('aria-hidden', 'true');
-    });
-  }
+  btn.addEventListener('click', clearUnread);
 
   document.querySelectorAll('.chat-tab').forEach(tabBtn => {
     tabBtn.addEventListener('click', () => switchTab(tabBtn.dataset.tab));

--- a/styles/main.css
+++ b/styles/main.css
@@ -432,7 +432,7 @@ select[required]:valid{
 /* chat */
 .tab{position:relative}
 .badge{position:absolute;top:2px;right:2px;width:8px;height:8px;border-radius:50%;background:var(--error)}
-.chat-modal{max-width:400px}
+.chat-modal{max-width:400px;margin:0 auto}
 .chat-tabs{display:flex;gap:4px;margin-bottom:8px}
 .chat-tabs button{flex:1}
 .chat-pane{border:1px solid var(--line);border-radius:var(--radius);padding:8px;max-height:200px;overflow-y:auto;margin-bottom:8px}


### PR DESCRIPTION
## Summary
- Convert chat from popup modal to in-page tab section
- Adjust chat script to clear unread state when tab is opened
- Center chat panel with updated styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a68ebe4650832e9f94879590678736