### PR TITLE
Allow sending messages with Enter key

### DIFF
--- a/__tests__/chat.test.js
+++ b/__tests__/chat.test.js
@@ -1,0 +1,28 @@
+import { jest } from '@jest/globals';
+
+import { initChat } from '../scripts/chat.js';
+
+describe('chat', () => {
+  test('pressing Enter triggers send button click', async () => {
+    document.body.innerHTML = `
+      <button id="btn-chat"></button>
+      <span id="chat-badge"></span>
+      <div id="chat-global"></div>
+      <div id="chat-dm"></div>
+      <select id="dm-select"></select>
+      <input id="chat-text" />
+      <button id="chat-send"></button>
+    `;
+
+    await initChat();
+
+    const input = document.getElementById('chat-text');
+    const sendBtn = document.getElementById('chat-send');
+    const clickSpy = jest.spyOn(sendBtn, 'click');
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+});
+

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -82,6 +82,13 @@ async function initChat() {
   const dmSelect = document.getElementById('dm-select');
   if (!btn || !badge || !input || !sendBtn) return;
 
+  input.addEventListener('keydown', e => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      sendBtn.click();
+    }
+  });
+
   let unread = false;
   const markUnread = () => {
     if (!btn.classList.contains('active')) {
@@ -157,7 +164,9 @@ async function initChat() {
   }
 }
 
-if (typeof document !== 'undefined') {
-  document.addEventListener('DOMContentLoaded', initChat);
-}
+  if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', initChat);
+  }
+
+export { initChat };
 


### PR DESCRIPTION
## Summary
- Enable sending chat messages by pressing Enter
- Export `initChat` for testing
- Add Jest test covering Enter key behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6926f96dc832ea6363fd45d32ae70