### PR TITLE
Centralize modal handling

### DIFF
--- a/__tests__/modal.test.js
+++ b/__tests__/modal.test.js
@@ -1,0 +1,43 @@
+import { show, hide } from '../scripts/modal.js';
+
+describe('modal show/hide behavior', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button id="outside-btn"></button>
+      <div id="content"></div>
+      <div class="overlay hidden" id="modal-one" aria-hidden="true">
+        <div class="modal"><button id="modal-one-btn">Ok</button></div>
+      </div>
+      <div class="overlay hidden" id="modal-two" aria-hidden="true">
+        <div class="modal"><button id="modal-two-btn">Ok</button></div>
+      </div>
+    `;
+    document.getElementById('outside-btn').focus();
+  });
+
+  test('show and hide a single modal', () => {
+    show('modal-one');
+    const modal = document.getElementById('modal-one');
+    expect(modal.classList.contains('hidden')).toBe(false);
+    expect(modal.getAttribute('aria-hidden')).toBe('false');
+    expect(document.body.classList.contains('modal-open')).toBe(true);
+    expect(document.getElementById('content').hasAttribute('inert')).toBe(true);
+    expect(document.activeElement.id).toBe('modal-one-btn');
+
+    hide('modal-one');
+    expect(modal.classList.contains('hidden')).toBe(true);
+    expect(modal.getAttribute('aria-hidden')).toBe('true');
+    expect(document.body.classList.contains('modal-open')).toBe(false);
+    expect(document.getElementById('content').hasAttribute('inert')).toBe(false);
+    expect(document.activeElement.id).toBe('outside-btn');
+  });
+
+  test('multiple modals keep body locked until all are closed', () => {
+    show('modal-one');
+    show('modal-two');
+    hide('modal-one');
+    expect(document.body.classList.contains('modal-open')).toBe(true);
+    hide('modal-two');
+    expect(document.body.classList.contains('modal-open')).toBe(false);
+  });
+});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2,9 +2,8 @@
 import { $, qs, qsa, num, mod, calculateArmorBonus, wizardProgress } from './helpers.js';
 import { saveLocal, saveCloud } from './storage.js';
 import { currentPlayer, getPlayers, loadPlayerCharacter, isDM } from './users.js';
+import { show, hide } from './modal.js';
 import confetti from 'https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.module.mjs';
-let lastFocus = null;
-let openModals = 0;
 let cccgPage = 1;
 const cccgCanvas = qs('#cccg-canvas');
 const cccgCtx = cccgCanvas ? cccgCanvas.getContext('2d') : null;
@@ -49,36 +48,6 @@ function applyDeleteIcon(btn){
 
 function applyDeleteIcons(root=document){
   qsa('button[data-del], button[data-act="del"]', root).forEach(applyDeleteIcon);
-}
-function show(id){
-  const el = $(id);
-  if(!el || !el.classList.contains('hidden')) return;
-  lastFocus = document.activeElement;
-  if (openModals === 0) {
-    document.body.classList.add('modal-open');
-    qsa('body > :not(.overlay)').forEach(e => e.setAttribute('inert',''));
-  }
-  openModals++;
-  el.classList.remove('hidden');
-  el.setAttribute('aria-hidden','false');
-  const focusEl = el.querySelector('[autofocus],input,select,textarea,button');
-  if (focusEl && typeof focusEl.focus === 'function') {
-    focusEl.focus();
-  }
-}
-function hide(id){
-  const el = $(id);
-  if(!el || el.classList.contains('hidden')) return;
-  el.classList.add('hidden');
-  el.setAttribute('aria-hidden','true');
-  if (lastFocus && typeof lastFocus.focus === 'function') {
-    lastFocus.focus();
-  }
-  openModals = Math.max(0, openModals - 1);
-  if (openModals === 0) {
-    document.body.classList.remove('modal-open');
-    qsa('body > :not(.overlay)').forEach(e => e.removeAttribute('inert'));
-  }
 }
 let audioCtx = null;
 window.addEventListener('unload', () => {

--- a/scripts/modal.js
+++ b/scripts/modal.js
@@ -1,0 +1,36 @@
+import { $, qsa } from './helpers.js';
+
+let lastFocus = null;
+let openModals = 0;
+
+export function show(id) {
+  const el = $(id);
+  if (!el || !el.classList.contains('hidden')) return;
+  lastFocus = document.activeElement;
+  if (openModals === 0) {
+    document.body.classList.add('modal-open');
+    qsa('body > :not(.overlay)').forEach(e => e.setAttribute('inert', ''));
+  }
+  openModals++;
+  el.classList.remove('hidden');
+  el.setAttribute('aria-hidden', 'false');
+  const focusEl = el.querySelector('[autofocus],input,select,textarea,button');
+  if (focusEl && typeof focusEl.focus === 'function') {
+    focusEl.focus();
+  }
+}
+
+export function hide(id) {
+  const el = $(id);
+  if (!el || el.classList.contains('hidden')) return;
+  el.classList.add('hidden');
+  el.setAttribute('aria-hidden', 'true');
+  if (lastFocus && typeof lastFocus.focus === 'function') {
+    lastFocus.focus();
+  }
+  openModals = Math.max(0, openModals - 1);
+  if (openModals === 0) {
+    document.body.classList.remove('modal-open');
+    qsa('body > :not(.overlay)').forEach(e => e.removeAttribute('inert'));
+  }
+}

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -1,5 +1,6 @@
 import { saveLocal, loadLocal, loadCloud } from './storage.js';
 import { $ } from './helpers.js';
+import { show as showModal, hide as hideModal } from './modal.js';
 
 const PLAYERS_KEY = 'players';
 const PLAYER_SESSION = 'player-session';
@@ -127,22 +128,6 @@ function toast(msg, type = 'info') {
   t.className = `toast ${type}`;
   t.classList.add('show');
   setTimeout(() => t.classList.remove('show'), 1200);
-}
-
-function showModal(id) {
-  const m = $(id);
-  if (m) {
-    m.classList.remove('hidden');
-    m.setAttribute('aria-hidden', 'false');
-  }
-}
-
-function hideModal(id) {
-  const m = $(id);
-  if (m) {
-    m.classList.add('hidden');
-    m.setAttribute('aria-hidden', 'true');
-  }
 }
 
 function updatePlayerButton() {


### PR DESCRIPTION
## Summary
- centralize modal show/hide logic in a shared module
- use shared modal helpers throughout main and user scripts
- add tests validating modal behavior with stacked overlays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6fb754c10832e801ad54f64118526