### PR TITLE
Improve chat message display with timestamps and per-user DM routing

### DIFF
--- a/scripts/users.js
+++ b/scripts/users.js
@@ -84,6 +84,9 @@ export function logoutPlayer() {
 export function loginDM(password) {
   if (password === DM_PASSWORD) {
     localStorage.setItem(DM_SESSION, '1');
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('playerChanged'));
+    }
     return true;
   }
   return false;
@@ -95,6 +98,9 @@ export function isDM() {
 
 export function logoutDM() {
   localStorage.removeItem(DM_SESSION);
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('playerChanged'));
+  }
 }
 
 export async function savePlayerCharacter(player, data) {


### PR DESCRIPTION
## Summary
- Display chat messages with short date/time and keep only 10 most recent
- Reload global and DM chat on login; DM conversations stored per user
- Notify chat system on DM login/logout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6fce394e0832e8271e06c79734281