### PR TITLE
Add compact faction XP trackers

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,6 +400,33 @@
         </div>
         <ul id="faction-perks" class="perk-list"></ul>
       </div>
+
+      <div class="card">
+        <label>Faction XP</label>
+        <div class="grid grid-1 faction-xp">
+          <div class="inline">
+            <span class="pill pill-sm">Aegis Initiative</span>
+            <progress id="aegis-xp-bar" max="100" value="0" style="flex:1"></progress>
+            <input type="hidden" id="aegis-xp" value="0"/>
+            <button id="aegis-xp-gain" class="btn-sm">Gain</button>
+            <button id="aegis-xp-lose" class="btn-sm">Lose</button>
+          </div>
+          <div class="inline">
+            <span class="pill pill-sm">Shadow Syndicate</span>
+            <progress id="shadow-xp-bar" max="100" value="0" style="flex:1"></progress>
+            <input type="hidden" id="shadow-xp" value="0"/>
+            <button id="shadow-xp-gain" class="btn-sm">Gain</button>
+            <button id="shadow-xp-lose" class="btn-sm">Lose</button>
+          </div>
+          <div class="inline">
+            <span class="pill pill-sm">Arcane Council</span>
+            <progress id="arcane-xp-bar" max="100" value="0" style="flex:1"></progress>
+            <input type="hidden" id="arcane-xp" value="0"/>
+            <button id="arcane-xp-gain" class="btn-sm">Gain</button>
+            <button id="arcane-xp-lose" class="btn-sm">Lose</button>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div class="card">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -611,6 +611,7 @@ const elXP = $('xp');
 const elXPBar = $('xp-bar');
 const elXPPill = $('xp-pill');
 const elTier = $('tier');
+const FACTIONS = ['aegis','shadow','arcane'];
 
 let hpRolls = [];
 if (elHPRoll) {
@@ -719,6 +720,7 @@ function updateDerived(){
     $('skill-'+i).textContent = (val>=0?'+':'') + val;
   });
   updateXP();
+  updateFactionXP();
 }
 ABILS.forEach(a=> $(a).addEventListener('change', updateDerived));
 ['hp-temp','origin-bonus','prof-bonus','power-save-ability'].forEach(id=> $(id).addEventListener('input', updateDerived));
@@ -738,6 +740,34 @@ $('xp-submit').addEventListener('click', ()=>{
   const mode = $('xp-mode').value;
   setXP(num(elXP.value) + (mode==='add'? amt : -amt));
 });
+
+function updateFactionXP(){
+  FACTIONS.forEach(f=>{
+    const input = $(`${f}-xp`);
+    const bar = $(`${f}-xp-bar`);
+    if(!input || !bar) return;
+    const val = Math.max(0, num(input.value));
+    bar.value = val % 100;
+  });
+}
+
+function setupFactionXP(){
+  FACTIONS.forEach(f=>{
+    const input = $(`${f}-xp`);
+    const gain = $(`${f}-xp-gain`);
+    const lose = $(`${f}-xp-lose`);
+    if(!input || !gain || !lose) return;
+    gain.addEventListener('click', ()=>{
+      input.value = Math.max(0, num(input.value) + 5);
+      updateFactionXP();
+    });
+    lose.addEventListener('click', ()=>{
+      input.value = Math.max(0, num(input.value) - 5);
+      updateFactionXP();
+    });
+  });
+  updateFactionXP();
+}
 
 /* ========= HP/SP controls ========= */
 function setHP(v){
@@ -1701,6 +1731,7 @@ setupPerkSelect('classification','classification-perks', CLASSIFICATION_PERKS);
 setupPerkSelect('power-style','power-style-perks', POWER_STYLE_PERKS);
 setupPerkSelect('origin','origin-perks', ORIGIN_PERKS);
 setupFactionRep('faction','faction-rep','faction-perks', FACTION_REP_PERKS);
+setupFactionXP();
 updateDerived();
 applyDeleteIcons();
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -142,6 +142,9 @@ progress::-moz-progress-bar{
   .roll-flip-grid .inline>select{flex:1;width:auto;}
   .roll-flip-grid .inline>button{flex:0 0 auto;width:auto;}
 }
+.faction-xp .inline{gap:4px;}
+.faction-xp progress{height:20px;}
+.faction-xp .btn-sm{min-height:28px;padding:4px 6px;}
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:32px;justify-content:center;}
 .death-saves input[type="checkbox"]{margin:0;width:20px;height:20px;max-width:20px;max-height:20px;}
 #death-animation{


### PR DESCRIPTION
## Summary
- Add faction XP card with gain/lose buttons for all factions
- Track faction XP and update progress bars in main script
- Style faction XP UI to keep controls compact

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7511f57ec832e83f58bb3543dfe56