### PR TITLE
Add new factions and reputation scale to tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,9 +390,10 @@
         <div class="inline">
           <select id="faction">
             <option value="">Select faction</option>
-            <option>Aegis Initiative</option>
-            <option>Shadow Syndicate</option>
-            <option>Arcane Council</option>
+            <option>O.M.N.I.</option>
+            <option>P.F.V.</option>
+            <option>Cosmic Conclave</option>
+            <option>Greyline PMC</option>
           </select>
           <select id="faction-rep">
             <option value="">Select reputation</option>
@@ -405,25 +406,32 @@
         <label>Faction XP</label>
         <div class="grid grid-1 faction-xp">
           <div class="inline">
-            <span class="pill pill-sm">Aegis Initiative</span>
-            <progress id="aegis-xp-bar" max="100" value="0" style="flex:1"></progress>
-            <input type="hidden" id="aegis-xp" value="0"/>
-            <button id="aegis-xp-gain" class="btn-sm">Gain</button>
-            <button id="aegis-xp-lose" class="btn-sm">Lose</button>
+            <span class="pill pill-sm">O.M.N.I.</span>
+            <progress id="omni-xp-bar" max="100" value="0" style="flex:1"></progress>
+            <input type="hidden" id="omni-xp" value="0"/>
+            <button id="omni-xp-gain" class="btn-sm">Gain</button>
+            <button id="omni-xp-lose" class="btn-sm">Lose</button>
           </div>
           <div class="inline">
-            <span class="pill pill-sm">Shadow Syndicate</span>
-            <progress id="shadow-xp-bar" max="100" value="0" style="flex:1"></progress>
-            <input type="hidden" id="shadow-xp" value="0"/>
-            <button id="shadow-xp-gain" class="btn-sm">Gain</button>
-            <button id="shadow-xp-lose" class="btn-sm">Lose</button>
+            <span class="pill pill-sm">P.F.V.</span>
+            <progress id="pfv-xp-bar" max="100" value="0" style="flex:1"></progress>
+            <input type="hidden" id="pfv-xp" value="0"/>
+            <button id="pfv-xp-gain" class="btn-sm">Gain</button>
+            <button id="pfv-xp-lose" class="btn-sm">Lose</button>
           </div>
           <div class="inline">
-            <span class="pill pill-sm">Arcane Council</span>
-            <progress id="arcane-xp-bar" max="100" value="0" style="flex:1"></progress>
-            <input type="hidden" id="arcane-xp" value="0"/>
-            <button id="arcane-xp-gain" class="btn-sm">Gain</button>
-            <button id="arcane-xp-lose" class="btn-sm">Lose</button>
+            <span class="pill pill-sm">Cosmic Conclave</span>
+            <progress id="conclave-xp-bar" max="100" value="0" style="flex:1"></progress>
+            <input type="hidden" id="conclave-xp" value="0"/>
+            <button id="conclave-xp-gain" class="btn-sm">Gain</button>
+            <button id="conclave-xp-lose" class="btn-sm">Lose</button>
+          </div>
+          <div class="inline">
+            <span class="pill pill-sm">Greyline PMC</span>
+            <progress id="greyline-xp-bar" max="100" value="0" style="flex:1"></progress>
+            <input type="hidden" id="greyline-xp" value="0"/>
+            <button id="greyline-xp-gain" class="btn-sm">Gain</button>
+            <button id="greyline-xp-lose" class="btn-sm">Lose</button>
           </div>
         </div>
       </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -410,22 +410,21 @@ const ORIGIN_PERKS = {
   'The Redemption': ['Advantage on persuasion checks for second chances.']
 };
 
+const COMMON_REP_TIERS = {
+  Hostile: ['You are hunted, sabotaged, or attacked on sight.'],
+  Untrusted: ['Faction denies you resources, spreads bad PR.'],
+  Neutral: ['No strong opinion—standard interactions only.'],
+  Recognized: ['Minor perks, small-scale favors.'],
+  Trusted: ['Reliable allies, access to mid-tier resources.'],
+  Favored: ['Priority treatment, elite support, story leverage.'],
+  Champion: ['Icon status, legendary backing, may call in major faction powers.'],
+};
+
 const FACTION_REP_PERKS = {
-  'Aegis Initiative': {
-    Allied: ['Once per session, call in agency support.'],
-    Neutral: ['Access to public records and safe houses.'],
-    Hostile: ['Tracked by agency drones.']
-  },
-  'Shadow Syndicate': {
-    Allied: ['Discounts on black market goods.'],
-    Neutral: ['Occasional tips from smugglers.'],
-    Hostile: ['Bounty placed on your head.']
-  },
-  'Arcane Council': {
-    Allied: ['Borrow minor magical items between missions.'],
-    Neutral: ['Consultation with apprentice mages.'],
-    Hostile: ['Marked as an enemy of the arcane.']
-  }
+  'O.M.N.I.': { ...COMMON_REP_TIERS },
+  'P.F.V.': { ...COMMON_REP_TIERS },
+  'Cosmic Conclave': { ...COMMON_REP_TIERS },
+  'Greyline PMC': { ...COMMON_REP_TIERS },
 };
 
 // handle special perk behavior (stat boosts, initiative mods, etc.)
@@ -611,7 +610,7 @@ const elXP = $('xp');
 const elXPBar = $('xp-bar');
 const elXPPill = $('xp-pill');
 const elTier = $('tier');
-const FACTIONS = ['aegis','shadow','arcane'];
+const FACTIONS = ['omni','pfv','conclave','greyline'];
 
 let hpRolls = [];
 if (elHPRoll) {


### PR DESCRIPTION
## Summary
- Replace placeholder factions with O.M.N.I., P.F.V., Cosmic Conclave, and Greyline PMC
- Expand reputation system to shared Hostile–Champion tiers
- Update faction XP tracker and scripts to handle new factions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a756b855dc832ea45f37ee4617f438