### PR TITLE
Cache background images for offline use

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'cccg-cache-v5';
+const CACHE = 'cccg-cache-v6';
 const ASSETS = [
   './',
   './index.html',
@@ -7,7 +7,19 @@ const ASSETS = [
   './scripts/helpers.js',
   './scripts/storage.js',
   './scripts/users.js',
-  './ccccg.pdf'
+  './ccccg.pdf',
+  // background and other images
+  './images/Dark.PNG',
+  './images/Light.PNG',
+  './images/High Contrast.PNG',
+  './images/Forest.PNG',
+  './images/Ocean.PNG',
+  './images/Mutant.PNG',
+  './images/Enhanced Human.PNG',
+  './images/Magic User.PNG',
+  './images/Alien:Extraterrestrial.PNG',
+  './images/Mystical Being.PNG',
+  './images/Logo.png'
 ];
 self.addEventListener('install', e => {
   self.skipWaiting();


### PR DESCRIPTION
## Summary
- cache theme background images and logo in the service worker
- bump cache version to refresh assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a762084ce8832e9ac76b25a410a27d