### PR TITLE
Align tab bar with compact header

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,12 @@
 
 <header>
   <div class="top">
+    <div class="title-group">
+      <img src="images/Logo.png" alt="Vigilante Dossier logo" class="logo"/>
+      <h1>Vigilante Dossier</h1>
+    </div>
+  </div>
+  <div class="tabs">
     <button id="btn-theme" class="icon" aria-label="Toggle Theme">
       <svg id="icon-dark" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/>
@@ -51,30 +57,6 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
       </svg>
     </button>
-    <div class="title-group">
-      <img src="images/Logo.png" alt="Vigilante Dossier logo" class="logo"/>
-      <h1>Vigilante Dossier</h1>
-    </div>
-    <div class="dropdown">
-      <button id="btn-menu" class="icon" aria-label="Menu" title="Menu">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15m-15 5.25h15m-15 5.25h15"/>
-        </svg>
-      </button>
-      <div id="menu-actions" class="menu">
-        <button id="btn-player" class="btn-sm">Log In</button>
-        <button id="btn-wizard" class="btn-sm" aria-label="Character creation wizard" title="Character creation wizard">Character wizard</button>
-        <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
-        <button id="btn-save" class="btn-sm">Save</button>
-        <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
-        <button id="btn-campaign" class="btn-sm">Campaign Log</button>
-        <button id="btn-rules" class="btn-sm">Rules</button>
-        <button id="btn-help" class="btn-sm">Help</button>
-        <button id="btn-dm" class="btn-sm" hidden>Players</button>
-      </div>
-    </div>
-  </div>
-  <div class="tabs">
     <button class="tab active" data-go="combat" aria-label="Combat" title="Combat">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <polyline stroke-linecap="round" stroke-linejoin="round" points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/>
@@ -105,6 +87,24 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
       </svg>
     </button>
+    <div class="dropdown">
+      <button id="btn-menu" class="icon" aria-label="Menu" title="Menu">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15m-15 5.25h15m-15 5.25h15"/>
+        </svg>
+      </button>
+      <div id="menu-actions" class="menu">
+        <button id="btn-player" class="btn-sm">Log In</button>
+        <button id="btn-wizard" class="btn-sm" aria-label="Character creation wizard" title="Character creation wizard">Character wizard</button>
+        <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
+        <button id="btn-save" class="btn-sm">Save</button>
+        <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
+        <button id="btn-campaign" class="btn-sm">Campaign Log</button>
+        <button id="btn-rules" class="btn-sm">Rules</button>
+        <button id="btn-help" class="btn-sm">Help</button>
+        <button id="btn-dm" class="btn-sm" hidden>Players</button>
+      </div>
+    </div>
   </div>
 </header>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -21,10 +21,10 @@ h2{font-size:1.5rem;font-weight:600;color:var(--accent)}
 h3{font-size:1.25rem;font-weight:600}
 header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(8px + env(safe-area-inset-top)) 10px 8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;flex-direction:column;transition:padding .3s ease-in-out}
 header.compact{flex-direction:row;align-items:center;justify-content:flex-end;padding:4px 10px}
-header #btn-theme,header .title-group{transition:opacity .3s ease-in-out,max-width .3s ease-in-out,margin .3s ease-in-out,padding .3s ease-in-out;overflow:hidden}
-header.compact #btn-theme,header.compact .title-group{opacity:0;max-width:0;margin:0;padding:0;pointer-events:none;visibility:hidden}
-header.compact .top{margin-left:8px;margin-right:0;flex:0 0 auto;order:2}
-header.compact .tabs{margin-top:0;flex:1;order:1;justify-content:space-evenly}
+header .title-group{transition:opacity .3s ease-in-out,max-width .3s ease-in-out,margin .3s ease-in-out,padding .3s ease-in-out;overflow:hidden}
+header.compact .title-group{opacity:0;max-width:0;margin:0;padding:0;pointer-events:none;visibility:hidden}
+header.compact .top{display:none}
+header.compact .tabs{margin-top:0;flex:1;order:1}
 header.hide-tabs .tabs{opacity:0;pointer-events:none}
 .top{display:flex;align-items:center;justify-content:center;gap:8px;transition:var(--transition)}
 .title-group{display:flex;align-items:center;gap:6px}
@@ -48,7 +48,13 @@ header.hide-tabs .tabs{opacity:0;pointer-events:none}
 .icon:focus-visible,.tab:focus-visible,.modal .x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 [data-tip]{position:relative;cursor:help}
 [data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
-.tabs{margin-top:6px;display:flex;flex-wrap:nowrap;justify-content:space-evenly;width:100%;gap:0;transition:var(--transition)}
+.tabs{margin-top:6px;display:flex;align-items:center;flex-wrap:nowrap;gap:6px;width:100%;transition:var(--transition)}
+.tabs .dropdown{margin-left:auto}
+
+header .tabs .icon,header .tabs .tab{width:40px;height:40px}
+header .tabs .icon svg,header .tabs .tab svg{width:40px;height:40px}
+header.compact .tabs .icon,header.compact .tabs .tab{width:27px;height:27px}
+header.compact .tabs .icon svg,header.compact .tabs .tab svg{width:27px;height:27px}
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{max-width:65ch;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}
 section{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:14px;margin-bottom:14px;box-shadow:var(--shadow)}


### PR DESCRIPTION
## Summary
- Display only the logo and title in the main header
- Move theme toggle and menu into the tab bar and size it up for the full header
- Animate tab icons to smoothly transition between full and compact headers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78e7c0618832e8ba67044aec7ceee