### PR TITLE
Remove obsolete Faction XP modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,39 +435,6 @@
         </div>
       </div>
 
-      <div class="card">
-        <label>Faction XP</label>
-        <div class="grid grid-1 faction-xp">
-          <div class="inline">
-            <span class="pill pill-sm">O.M.N.I.</span>
-            <progress id="omni-xp-bar" max="100" value="0" style="flex:1"></progress>
-            <input type="hidden" id="omni-xp" value="0"/>
-            <button id="omni-xp-gain" class="btn-sm">Gain</button>
-            <button id="omni-xp-lose" class="btn-sm">Lose</button>
-          </div>
-          <div class="inline">
-            <span class="pill pill-sm">P.F.V.</span>
-            <progress id="pfv-xp-bar" max="100" value="0" style="flex:1"></progress>
-            <input type="hidden" id="pfv-xp" value="0"/>
-            <button id="pfv-xp-gain" class="btn-sm">Gain</button>
-            <button id="pfv-xp-lose" class="btn-sm">Lose</button>
-          </div>
-          <div class="inline">
-            <span class="pill pill-sm">Cosmic Conclave</span>
-            <progress id="conclave-xp-bar" max="100" value="0" style="flex:1"></progress>
-            <input type="hidden" id="conclave-xp" value="0"/>
-            <button id="conclave-xp-gain" class="btn-sm">Gain</button>
-            <button id="conclave-xp-lose" class="btn-sm">Lose</button>
-          </div>
-          <div class="inline">
-            <span class="pill pill-sm">Greyline PMC</span>
-            <progress id="greyline-xp-bar" max="100" value="0" style="flex:1"></progress>
-            <input type="hidden" id="greyline-xp" value="0"/>
-            <button id="greyline-xp-gain" class="btn-sm">Gain</button>
-            <button id="greyline-xp-lose" class="btn-sm">Lose</button>
-          </div>
-        </div>
-      </div>
     </div>
 
     <div class="card">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -677,7 +677,6 @@ function updateDerived(){
     $('skill-'+i).textContent = (val>=0?'+':'') + val;
   });
   updateXP();
-  updateFactionXP();
 }
 ABILS.forEach(a=> $(a).addEventListener('change', updateDerived));
 ['hp-temp','origin-bonus','prof-bonus','power-save-ability'].forEach(id=> $(id).addEventListener('input', updateDerived));
@@ -697,34 +696,6 @@ $('xp-submit').addEventListener('click', ()=>{
   const mode = $('xp-mode').value;
   setXP(num(elXP.value) + (mode==='add'? amt : -amt));
 });
-
-function updateFactionXP(){
-  FACTIONS.forEach(f=>{
-    const input = $(`${f}-xp`);
-    const bar = $(`${f}-xp-bar`);
-    if(!input || !bar) return;
-    const val = Math.max(0, num(input.value));
-    bar.value = val % 100;
-  });
-}
-
-function setupFactionXP(){
-  FACTIONS.forEach(f=>{
-    const input = $(`${f}-xp`);
-    const gain = $(`${f}-xp-gain`);
-    const lose = $(`${f}-xp-lose`);
-    if(!input || !gain || !lose) return;
-    gain.addEventListener('click', ()=>{
-      input.value = Math.max(0, num(input.value) + 5);
-      updateFactionXP();
-    });
-    lose.addEventListener('click', ()=>{
-      input.value = Math.max(0, num(input.value) - 5);
-      updateFactionXP();
-    });
-  });
-  updateFactionXP();
-}
 
 function updateFactionRep(){
   FACTIONS.forEach(f=>{
@@ -1744,7 +1715,6 @@ setupPerkSelect('classification','classification-perks', CLASSIFICATION_PERKS);
 setupPerkSelect('power-style','power-style-perks', POWER_STYLE_PERKS);
 setupPerkSelect('origin','origin-perks', ORIGIN_PERKS);
 setupFactionRepTracker();
-setupFactionXP();
 updateDerived();
 applyDeleteIcons();
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -148,9 +148,6 @@ progress::-moz-progress-bar{
   .roll-flip-grid .inline>select{flex:1;width:auto;}
   .roll-flip-grid .inline>button{flex:0 0 auto;width:auto;}
 }
-.faction-xp .inline{gap:4px;}
-.faction-xp progress{height:20px;}
-.faction-xp .btn-sm{min-height:28px;padding:4px 6px;}
 .faction-rep .inline{gap:4px;}
 .faction-rep progress{height:20px;}
 .faction-rep .btn-sm{min-height:28px;padding:4px 6px;}


### PR DESCRIPTION
## Summary
- remove Faction XP tracker card
- drop Faction XP styles and scripts so only reputation is tracked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7b117402c832eb974ccc68e7e7ccf