### PR TITLE
Enlarge main header and smooth shrink to compact view

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -16,19 +16,21 @@ html{height:100%;background:var(--bg);transition:var(--transition)}
 body{min-height:100%;margin:0;background:transparent;color:var(--text);font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased;overflow-x:hidden;line-height:1.6;font-size:16px;transition:var(--transition)}
 h1,h2,h3,h4{font-family:inherit;line-height:1.25;margin:0 0 .5em}
 h1{font-size:2rem;font-weight:700;color:var(--accent)}
-header h1{font-size:1rem}
+header h1{font-size:2rem}
+header.compact h1{font-size:1rem}
 h2{font-size:1.5rem;font-weight:600;color:var(--accent)}
 h3{font-size:1.25rem;font-weight:600}
-header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(8px + env(safe-area-inset-top)) 10px 8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;flex-direction:column;transition:padding .3s ease-in-out}
+header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(20px + env(safe-area-inset-top)) 10px 20px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;flex-direction:column;transition:padding .3s ease-in-out}
 header.compact{flex-direction:row;align-items:center;justify-content:flex-end;padding:4px 10px}
 header .title-group{transition:opacity .3s ease-in-out,max-width .3s ease-in-out,margin .3s ease-in-out,padding .3s ease-in-out;overflow:hidden}
 header.compact .title-group{opacity:0;max-width:0;margin:0;padding:0;pointer-events:none;visibility:hidden}
 header.compact .top{max-height:0;opacity:0;margin:0;padding:0;overflow:hidden}
 header.compact .tabs{margin-top:0;flex:1;order:1}
 header.hide-tabs .tabs{opacity:0;pointer-events:none}
-.top{display:flex;align-items:center;justify-content:center;gap:8px;transition:var(--transition);overflow:hidden;max-height:60px}
+.top{display:flex;align-items:center;justify-content:center;gap:8px;transition:var(--transition);overflow:hidden;max-height:80px}
 .title-group{display:flex;align-items:center;gap:6px}
-.logo{width:40px;height:40px;display:block}
+.logo{width:60px;height:60px;display:block}
+header.compact .logo{width:40px;height:40px}
 .actions{display:flex;gap:6px}
 .dropdown{position:relative;display:flex;align-items:center}
 .menu{position:absolute;top:calc(100% + 4px);right:0;display:none;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50}
@@ -51,8 +53,8 @@ header.hide-tabs .tabs{opacity:0;pointer-events:none}
 .tabs{margin-top:6px;display:flex;align-items:center;flex-wrap:nowrap;gap:6px;width:100%;transition:var(--transition)}
 .tabs .dropdown{margin-left:auto}
 
-header .tabs .icon,header .tabs .tab{width:40px;height:40px}
-header .tabs .icon svg,header .tabs .tab svg{width:40px;height:40px}
+header .tabs .icon,header .tabs .tab{width:60px;height:60px}
+header .tabs .icon svg,header .tabs .tab svg{width:60px;height:60px}
 header.compact .tabs .icon,header.compact .tabs .tab{width:27px;height:27px}
 header.compact .tabs .icon svg,header.compact .tabs .tab svg{width:27px;height:27px}
 .tab.active{background:var(--accent);color:var(--text-on-accent)}


### PR DESCRIPTION
## Summary
- Expand default header padding and title font size
- Increase logo and tab icon dimensions for a larger starting header
- Preserve compact styles so header smoothly shrinks to minimal state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7b1e6ea90832eab0dcc492838827b