### PR TITLE
Track cinematic action point usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
     </fieldset>
     <fieldset class="card">
       <legend>Cinematic Action Point</legend>
-      <label class="inline" for="cap-check"><input type="checkbox" id="cap-check"/> Available</label>
+      <label class="inline" for="cap-check"><input type="checkbox" id="cap-check"/> <span id="cap-status">Available</span></label>
       <p>A Cinematic Action Point lets a hero perform an extraordinary, story-driven action. Check the box when one is available and uncheck it once spent.</p>
     </fieldset>
   </section>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -554,6 +554,8 @@ const elXP = $('xp');
 const elXPBar = $('xp-bar');
 const elXPPill = $('xp-pill');
 const elTier = $('tier');
+const elCAPCheck = $('cap-check');
+const elCAPStatus = $('cap-status');
 const FACTIONS = ['omni','pfv','conclave','greyline'];
 const FACTION_NAME_MAP = {
   omni: 'O.M.N.I.',
@@ -566,6 +568,12 @@ let hpRolls = [];
 if (elHPRoll) {
   const initial = num(elHPRoll.value);
   if (initial) hpRolls = [initial];
+}
+
+if (elCAPCheck && elCAPStatus) {
+  elCAPCheck.addEventListener('change', () => {
+    elCAPStatus.textContent = elCAPCheck.checked ? 'Used' : 'Available';
+  });
 }
 
 const XP_TIERS = [
@@ -796,6 +804,7 @@ $('long-rest').addEventListener('click', ()=>{
   elHPTemp.value='';
   const spTemp=$('sp-temp'); if(spTemp) spTemp.value='';
   qsa('input[type="checkbox"]').forEach(cb=> cb.checked=false);
+  if (elCAPStatus) elCAPStatus.textContent = 'Available';
   activeStatuses.clear();
 });
 function renderHPRollList(){


### PR DESCRIPTION
## Summary
- Show Cinematic Action Point status as "Available" or "Used"
- Reset Cinematic Action Point on Long Rest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a809b05e94832ea2890c75218b931f