### PR TITLE
Reset checkboxes on long rest

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -803,7 +803,11 @@ $('long-rest').addEventListener('click', ()=>{
   setSP(num(elSPBar.max));
   elHPTemp.value='';
   const spTemp=$('sp-temp'); if(spTemp) spTemp.value='';
-  qsa('input[type="checkbox"]').forEach(cb=> cb.checked=false);
+  // clear all checkbox states on the page
+  qsa('input[type="checkbox"]').forEach(cb=>{
+    cb.checked = false;
+    cb.removeAttribute('checked');
+  });
   if (elCAPStatus) elCAPStatus.textContent = 'Available';
   activeStatuses.clear();
 });


### PR DESCRIPTION
## Summary
- Clear all checkbox states when long rest is triggered
- Maintain existing behavior of fully restoring HP and SP

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a80ac9b5c8832e89840ae38df48744