### PR TITLE
feat: add long rest confirmation

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -799,6 +799,7 @@ $('hp-full').addEventListener('click', async ()=>{
 $('sp-full').addEventListener('click', ()=> setSP(num(elSPBar.max)));
 qsa('[data-sp]').forEach(b=> b.addEventListener('click', ()=> setSP(num(elSPBar.value) + num(b.dataset.sp)||0) ));
 $('long-rest').addEventListener('click', ()=>{
+  if(!confirm('Take a long rest?')) return;
   setHP(num(elHPBar.max));
   setSP(num(elSPBar.max));
   elHPTemp.value='';


### PR DESCRIPTION
## Summary
- require confirmation before performing a long rest to avoid accidental resets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a80c0a5bf4832ebc525abc3acb817a