### PR TITLE
Fix SP bar reset to max

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -616,7 +616,7 @@ if(elTier){
 function updateSP(){
   const spMax = 5 + mod(elCon.value);
   elSPBar.max = spMax;
-  if (!num(elSPBar.value)) elSPBar.value = spMax;
+  if (elSPBar.value === '' || Number.isNaN(Number(elSPBar.value))) elSPBar.value = spMax;
   elSPPill.textContent = `${num(elSPBar.value)}/${spMax}`;
 }
 


### PR DESCRIPTION
## Summary
- prevent SP bar from defaulting to max when a saved value exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a80cfae154832e9bbed9274c08fb08