### PR TITLE
Remove breadcrumbs and align titles with theme accent

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -38,12 +38,15 @@ header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(-10px)
 .icon:focus-visible,.tab:focus-visible,.modal .x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 [data-tip]{position:relative;cursor:help}
 [data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
+.breadcrumb,.breadcrumbs{display:none}
 .tabs{display:flex;align-items:center;flex-wrap:nowrap;gap:6px;width:100%;transition:opacity .4s ease,transform .4s ease}
 .tabs .dropdown{margin-left:auto}
 .tabs-title{
   padding:0 8px;
   font-size:clamp(.75rem,4vw,1rem);
   white-space:nowrap;
+  color:var(--accent);
+  font-weight:700;
 }
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{max-width:65ch;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}


### PR DESCRIPTION
## Summary
- Hide breadcrumb navigation elements
- Style header titles with accent color for all themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81104f08c832e8362ba0926c60916