### PR TITLE
Improve accessibility and polish UI interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,12 @@
 <body>
 <noscript>This app requires JavaScript to run properly.</noscript>
 
+<a href="#main" class="skip-link">Skip to main content</a>
+
 
 <header>
-  <div class="tabs">
-    <button id="btn-theme" class="icon" aria-label="Toggle Theme">
+  <div class="tabs" role="tablist">
+    <button id="btn-theme" class="icon" aria-label="Toggle Theme" type="button">
       <svg id="icon-dark" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/>
       </svg>
@@ -56,7 +58,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
       </svg>
     </button>
-    <button class="tab active" data-go="combat" aria-label="Combat" title="Combat">
+    <button class="tab active" data-go="combat" aria-label="Combat" title="Combat" role="tab" aria-current="page" type="button">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <polyline stroke-linecap="round" stroke-linejoin="round" points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/>
         <line stroke-linecap="round" stroke-linejoin="round" x1="13" y1="19" x2="19" y2="13"/>
@@ -64,31 +66,31 @@
         <line stroke-linecap="round" stroke-linejoin="round" x1="19" y1="21" x2="21" y2="19"/>
       </svg>
     </button>
-    <button class="tab" data-go="abilities" aria-label="Abilities" title="Abilities">
+    <button class="tab" data-go="abilities" aria-label="Abilities" title="Abilities" role="tab" type="button">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.8132 15.9038L9 18.75L8.1868 15.9038C7.75968 14.4089 6.59112 13.2403 5.09619 12.8132L2.25 12L5.09619 11.1868C6.59113 10.7597 7.75968 9.59112 8.1868 8.09619L9 5.25L9.8132 8.09619C10.2403 9.59113 11.4089 10.7597 12.9038 11.1868L15.75 12L12.9038 12.8132C11.4089 13.2403 10.2403 14.4089 9.8132 15.9038Z"/>
         <path stroke-linecap="round" stroke-linejoin="round" d="M18.2589 8.71454L18 9.75L17.7411 8.71454C17.4388 7.50533 16.4947 6.56117 15.2855 6.25887L14.25 6L15.2855 5.74113C16.4947 5.43883 17.4388 4.49467 17.7411 3.28546L18 2.25L18.2589 3.28546C18.5612 4.49467 19.5053 5.43883 20.7145 5.74113L21.75 6L20.7145 6.25887C19.5053 6.56117 18.5612 7.50533 18.2589 8.71454Z"/>
         <path stroke-linecap="round" stroke-linejoin="round" d="M16.8942 20.5673L16.5 21.75L16.1058 20.5673C15.8818 19.8954 15.3546 19.3682 14.6827 19.1442L13.5 18.75L14.6827 18.3558C15.3546 18.1318 15.8818 17.6046 16.1058 16.9327L16.5 15.75L16.8942 16.9327C17.1182 17.6046 17.6454 18.1318 18.3173 18.3558L19.5 18.75L18.3173 19.1442C17.6454 19.3682 17.1182 19.8954 16.8942 20.5673Z"/>
       </svg>
     </button>
-    <button class="tab" data-go="powers" aria-label="Powers" title="Powers">
+    <button class="tab" data-go="powers" aria-label="Powers" title="Powers" role="tab" type="button">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5L14.25 2.25L12 10.5H20.25L9.75 21.75L12 13.5H3.75Z"/>
       </svg>
     </button>
-    <button class="tab" data-go="gear" aria-label="Gear" title="Gear">
+    <button class="tab" data-go="gear" aria-label="Gear" title="Gear" role="tab" type="button">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M20.38 3.46 16 2a4 4 0 0 1-8 0L3.62 3.46a2 2 0 0 0-1.34 2.23l.58 3.47a1 1 0 0 0 .99.84H6v10c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V10h2.15a1 1 0 0 0 .99-.84l.58-3.47a2 2 0 0 0-1.34-2.23z"/>
       </svg>
     </button>
-    <button class="tab" data-go="story" aria-label="Story" title="Story">
+    <button class="tab" data-go="story" aria-label="Story" title="Story" role="tab" type="button">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
       </svg>
     </button>
     <span class="tabs-title">The Catalyst Core</span>
     <div class="dropdown">
-      <button id="btn-menu" class="icon" aria-label="Menu" title="Menu">
+      <button id="btn-menu" class="icon" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" type="button">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15m-15 5.25h15m-15 5.25h15"/>
         </svg>
@@ -108,7 +110,7 @@
   </div>
 </header>
 
-<main>
+<main id="main">
   <!-- COMBAT -->
   <fieldset data-tab="combat" class="card">
     <div class="grid grid-2 roll-flip-grid">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -184,10 +184,18 @@ const menuActions = $('menu-actions');
 if (btnMenu && menuActions) {
   btnMenu.addEventListener('click', () => {
     menuActions.classList.toggle('show');
+    btnMenu.setAttribute('aria-expanded', menuActions.classList.contains('show'));
   });
   document.addEventListener('click', e => {
     if (!btnMenu.contains(e.target) && !menuActions.contains(e.target)) {
       menuActions.classList.remove('show');
+      btnMenu.setAttribute('aria-expanded', 'false');
+    }
+  });
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') {
+      menuActions.classList.remove('show');
+      btnMenu.setAttribute('aria-expanded', 'false');
     }
   });
 }
@@ -198,7 +206,12 @@ const headerEl = qs('header');
 /* ========= tabs ========= */
 function setTab(name){
   qsa('fieldset[data-tab]').forEach(s=> s.style.display = s.getAttribute('data-tab')===name ? 'block':'none');
-  qsa('.tab').forEach(b=> b.classList.toggle('active', b.getAttribute('data-go')===name));
+  qsa('.tab').forEach(b=> {
+    const active = b.getAttribute('data-go')===name;
+    b.classList.toggle('active', active);
+    if (active) b.setAttribute('aria-current', 'page');
+    else b.removeAttribute('aria-current');
+  });
   try {
     localStorage.setItem('active-tab', name);
   } catch (e) {}
@@ -603,6 +616,9 @@ if (elXP) {
 }
 
 function launchConfetti(){
+  if (typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return;
+  }
   confetti({
     particleCount: 100,
     spread: 70,

--- a/scripts/modal.js
+++ b/scripts/modal.js
@@ -6,6 +6,21 @@ let openModals = 0;
 // Ensure hidden overlays are not focusable on load
 qsa('.overlay.hidden').forEach(ov => { ov.style.display = 'none'; });
 
+// Close modal on overlay click
+qsa('.overlay').forEach(ov => {
+  ov.addEventListener('click', e => {
+    if (e.target === ov) hide(ov.id);
+  });
+});
+
+// Allow closing with Escape key
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape' && openModals > 0) {
+    const open = qsa('.overlay').find(o => !o.classList.contains('hidden'));
+    if (open) hide(open.id);
+  }
+});
+
 export function show(id) {
   const el = $(id);
   if (!el || !el.classList.contains('hidden')) return;

--- a/styles/main.css
+++ b/styles/main.css
@@ -36,6 +36,8 @@ header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(-10px)
 .icon:hover,.tab:hover{background:var(--accent);color:var(--text-on-accent)}
 .icon:active{transform:translateY(1px)}
 .icon:focus-visible,.tab:focus-visible,.modal .x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.skip-link{position:absolute;left:-999px;top:auto;width:1px;height:1px;overflow:hidden;}
+.skip-link:focus{left:8px;top:8px;width:auto;height:auto;background:var(--accent);color:var(--text-on-accent);padding:8px;border-radius:var(--radius);z-index:1000;}
 [data-tip]{position:relative;cursor:help}
 [data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
 .breadcrumb,.breadcrumbs{display:none}


### PR DESCRIPTION
## Summary
- Add skip link and tab roles for better navigation
- Toggle menu `aria-expanded` and close on Escape
- Allow closing modals via overlay click or Escape and respect reduced motion for confetti

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a833740338832e90fd5903b425d03e