### PR TITLE
Improve UI polish

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -35,12 +35,16 @@ header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(-10px)
 .icon svg,.tab svg{width:23px;height:23px}
 .modal .x svg{width:20px;height:20px}
 .icon svg{transition:transform .3s ease}
+#back-to-top svg{transition:transform .3s ease}
 #btn-menu.open svg{transform:rotate(90deg)}
 .icon:hover,.tab:hover{background:var(--accent);color:var(--text-on-accent);transform:translateY(-1px)}
 .icon:active{transform:translateY(1px)}
 .icon:focus-visible,.tab:focus-visible,.modal .x:focus-visible,a:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+a{color:var(--accent);text-decoration:none}
+a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 .back-to-top{position:fixed;bottom:20px;right:20px;opacity:0;transform:translateY(10px);transition:opacity .3s ease,transform .3s ease;z-index:100}
 .back-to-top.show{opacity:1;transform:translateY(0)}
+#back-to-top:hover svg{transform:translateY(-3px)}
 .skip-link{position:absolute;left:-999px;top:auto;width:1px;height:1px;overflow:hidden;}
 .skip-link:focus{left:8px;top:8px;width:auto;height:auto;background:var(--accent);color:var(--text-on-accent);padding:8px;border-radius:var(--radius);z-index:1000;}
 [data-tip]{position:relative;cursor:help}
@@ -289,6 +293,7 @@ progress::-moz-progress-bar{
 .sp-grid .btn-sm{width:100%;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .3s ease-in-out,transform .3s ease-in-out}
 .card:hover{box-shadow:0 12px 28px rgba(0,0,0,.45);transform:translateY(-2px)}
+.card:focus-within{box-shadow:0 0 0 2px var(--accent),var(--shadow)}
 .card.dragging{opacity:.5}
 .catalog{max-height:360px;overflow:auto;border:1px dashed var(--line);border-radius:10px;padding:6px}
 .perk-list{margin:0;padding-left:20px;list-style:disc}
@@ -318,10 +323,13 @@ body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
 #modal-rules{align-items:stretch;padding:0}
 #modal-rules .modal-rules{max-width:none;width:100%;height:100%;border-radius:0;border:none;padding:0;max-height:none}
 #modal-rules .modal-rules canvas{width:100%;height:100%;display:block}
-.toast{position:fixed;bottom:18px;right:18px;background:var(--surface);border:1px solid var(--accent);padding:10px 12px;border-radius:var(--radius);opacity:0;transform:translateY(8px);transition:opacity .3s ease-in-out,transform .3s ease-in-out;z-index:2000}
+.toast{position:fixed;bottom:18px;right:18px;background:var(--surface);border:1px solid var(--accent);padding:10px 12px;border-radius:var(--radius);opacity:0;transform:translateY(8px);transition:opacity .3s ease-in-out,transform .3s ease-in-out;z-index:2000;display:flex;align-items:center;gap:6px}
+.toast::before{content:"";width:16px;height:16px;background-size:contain;background-repeat:no-repeat}
 .toast.show{opacity:1;transform:translateY(0)}
 .toast.success{border-color:var(--success);color:var(--success)}
 .toast.error{border-color:var(--error);color:var(--error)}
+.toast.success::before{background-image:var(--icon-success)}
+.toast.error::before{background-image:var(--icon-error)}
 
 /* ability grid */
 .ability-grid{grid-template-columns:repeat(2,1fr)}
@@ -405,6 +413,7 @@ textarea:focus{
   outline-offset:2px;
   box-shadow:0 0 0 2px var(--accent);
 }
+input::placeholder,textarea::placeholder{color:var(--muted);opacity:1}
 
 /* Validation states */
 input:not([type="checkbox"]):invalid,


### PR DESCRIPTION
## Summary
- Add accent-colored link styling and animated back-to-top hover effect
- Highlight focused cards and style form placeholders
- Display success/error icons inside toast notifications for clearer feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a84153e128832e9b2e710fa80365a7