### PR TITLE
Animate player down before alert

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -836,7 +836,10 @@ $('hp-dmg').addEventListener('click', async ()=>{
   }
   const down = setHP(num(elHPBar.value)-d);
   await playDamageAnimation(-d);
-  if(down) alert('Player is down');
+  if(down){
+    await playDeathAnimation();
+    alert('Player is down');
+  }
 });
 $('hp-heal').addEventListener('click', async ()=>{
   const d=num(elHPAmt ? elHPAmt.value : 0)||0;


### PR DESCRIPTION
## Summary
- play death animation when HP drops to zero

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8496f39b8832e9145464319f71273