### PR TITLE
Animate player down before alert

### DIFF
--- a/index.html
+++ b/index.html
@@ -997,6 +997,7 @@
   <p>Product of XoVrom industries ® 2025</p>
  <p><a href="#" id="dm-login-link" title="Dungeon Master login">DM Login</a></p>
 </footer>
+<div id="down-animation" aria-hidden="true">🩸</div>
 <div id="death-animation" aria-hidden="true">💀</div>
 <div id="damage-animation" aria-hidden="true"></div>
 <div id="heal-animation" aria-hidden="true"></div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -836,7 +836,10 @@ $('hp-dmg').addEventListener('click', async ()=>{
   }
   const down = setHP(num(elHPBar.value)-d);
   await playDamageAnimation(-d);
-  if(down) alert('Player is down');
+  if(down){
+    await playDownAnimation();
+    alert('Player is down');
+  }
 });
 $('hp-heal').addEventListener('click', async ()=>{
   const d=num(elHPAmt ? elHPAmt.value : 0)||0;
@@ -962,6 +965,20 @@ function playDamageAnimation(amount){
   const anim=$('damage-animation');
   if(!anim) return Promise.resolve();
   anim.textContent=`${amount}`;
+  return new Promise(res=>{
+    anim.classList.add('show');
+    const done=()=>{
+      anim.classList.remove('show');
+      anim.removeEventListener('animationend', done);
+      res();
+    };
+    anim.addEventListener('animationend', done);
+  });
+}
+
+function playDownAnimation(){
+  const anim = $('down-animation');
+  if(!anim) return Promise.resolve();
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{

--- a/styles/main.css
+++ b/styles/main.css
@@ -169,6 +169,26 @@ progress::-moz-progress-bar{
 .faction-rep .btn-sm{min-height:28px;padding:4px 6px;}
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:32px;justify-content:center;}
 .death-saves input[type="checkbox"]{margin:0;width:20px;height:20px;max-width:20px;max-height:20px;}
+#down-animation{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:8rem;
+  color:var(--error);
+  pointer-events:none;
+  opacity:0;
+  z-index:3000;
+}
+#down-animation.show{
+  animation:downPulse 1.5s ease-in-out forwards;
+}
+@keyframes downPulse{
+  0%{transform:scale(0);opacity:0;}
+  30%{transform:scale(1.2);opacity:1;}
+  100%{transform:scale(1);opacity:0;}
+}
 #death-animation{
   position:fixed;
   inset:0;


### PR DESCRIPTION
## Summary
- play death animation when HP drops to zero
- use distinct animation when death saves fail

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8496f39b8832e9145464319f71273