### PR TITLE
Fix clipping section titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,13 +220,13 @@
   </fieldset>
 
   <fieldset data-tab="combat" class="card">
-    <legend>Status Effects</legend>
+    <h2 class="card-title">Status Effects</h2>
     <div id="statuses" class="grid grid-2"></div>
   </fieldset>
 
   <!-- ABILITIES -->
   <fieldset data-tab="abilities" class="card">
-    <legend>Ability Scores</legend>
+    <h2 class="card-title">Ability Scores</h2>
     <div id="abil-grid" class="grid ability-grid"></div>
     <fieldset class="card">
       <legend>Proficiency &amp; Power</legend>
@@ -260,14 +260,14 @@
 
   <!-- POWERS -->
   <fieldset data-tab="powers" class="card">
-    <legend>Powers</legend>
+    <h2 class="card-title">Powers</h2>
     <div class="inline" style="justify-content:flex-end">
       <button id="add-power" style="max-width:180px">Add Power</button>
     </div>
     <div class="grid grid-2" id="powers"></div>
 
     <div class="inline" style="justify-content:space-between;margin-top:8px">
-      <h2>Signature Moves</h2>
+      <h3 style="margin:0">Signature Moves</h3>
       <button id="add-sig" style="max-width:200px">Add Signature Move</button>
     </div>
     <div class="grid grid-2" id="sigs"></div>
@@ -275,7 +275,7 @@
 
   <!-- GEAR -->
   <fieldset data-tab="gear" class="card">
-    <legend>Gear</legend>
+    <h2 class="card-title">Gear</h2>
     <div class="grid grid-2">
       <div class="card">
         <div class="inline" style="justify-content:space-between">
@@ -304,7 +304,7 @@
 
   <!-- STORY -->
   <fieldset data-tab="story" class="card">
-    <legend>Character & Story</legend>
+    <h2 class="card-title">Character & Story</h2>
     <div class="grid grid-2">
       <div class="card"><label for="superhero">Superhero Identity</label><input id="superhero" placeholder="Vigilante Name"/></div>
       <div class="card"><label for="secret">Secret Identity</label><input id="secret" placeholder="Real name"/></div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -64,6 +64,7 @@ main{max-width:65ch;margin:16px auto;padding:0 12px calc(16px + env(safe-area-in
 fieldset[data-tab].card{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:14px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translateX(10px);cursor:default;transition:opacity .3s ease,transform .3s ease}
 fieldset[data-tab].card.active{display:block;opacity:1;transform:translateX(0)}
 fieldset[data-tab].card>legend{font-size:1.5rem;font-weight:600;color:var(--accent);margin:0 0 10px}
+.card-title{font-size:1.5rem;font-weight:600;color:var(--accent);margin:0 0 10px}
 p{max-width:65ch}
 footer{text-align:center;font-size:9pt;margin-top:24px;padding:12px 0;color:var(--muted)}
 footer p{max-width:none}


### PR DESCRIPTION
## Summary
- Replace clipping fieldset legends with styled headings for Status Effects, Ability Scores, Powers, Gear, and Character & Story
- Restyle Signature Moves heading to match gear titles
- Introduce shared `.card-title` style for consistent section headers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a857adc9fc832ebf0211910298ca25