### PR TITLE
Scale navigation bars and icons by 15%

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -19,9 +19,9 @@ h1,h2,h3,h4{font-family:inherit;line-height:1.25;margin:0 0 .5em}
 h1{font-size:2rem;font-weight:700;color:var(--accent)}
 h2{font-size:1.5rem;font-weight:600;color:var(--accent)}
 h3{font-size:1.25rem;font-weight:600}
-header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(4px + env(safe-area-inset-top)) 10px 4px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;justify-content:flex-end}
-header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(-10px)}
-.actions{display:flex;gap:6px;flex-wrap:wrap}
+header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(4px * 1.15 + env(safe-area-inset-top)) calc(10px * 1.15) calc(4px * 1.15);-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;justify-content:flex-end}
+header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(calc(-10px * 1.15))}
+.actions{display:flex;gap:calc(6px * 1.15);flex-wrap:wrap}
 .dropdown{position:relative;display:flex;align-items:center}
 .menu{position:absolute;top:calc(100% + 4px);right:0;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50;opacity:0;transform:translateY(-10px);visibility:hidden;transition:opacity .3s ease,transform .3s ease;pointer-events:none}
 .menu.show{opacity:1;transform:translateY(0);visibility:visible;pointer-events:auto}
@@ -31,8 +31,8 @@ header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(-10px)
   .actions{justify-content:center}
   .tabs{justify-content:space-evenly}
 }
-.icon,.tab{padding:2px;width:23px;height:23px;min-height:27px;aspect-ratio:1/1;border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition);cursor:pointer}
-.icon svg,.tab svg{width:23px;height:23px}
+.icon,.tab{padding:calc(2px * 1.15);width:calc(23px * 1.15);height:calc(23px * 1.15);min-height:calc(27px * 1.15);aspect-ratio:1/1;border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition);cursor:pointer}
+.icon svg,.tab svg{width:calc(23px * 1.15);height:calc(23px * 1.15)}
 .modal .x svg{width:20px;height:20px}
 .icon svg{transition:transform .3s ease}
 #back-to-top svg{transition:transform .3s ease}
@@ -50,7 +50,7 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 [data-tip]{position:relative;cursor:help}
 [data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
 .breadcrumb,.breadcrumbs{display:none}
-.tabs{display:flex;align-items:center;flex-wrap:wrap;gap:6px;width:100%;transition:opacity .4s ease,transform .4s ease}
+.tabs{display:flex;align-items:center;flex-wrap:wrap;gap:calc(6px * 1.15);width:100%;transition:opacity .4s ease,transform .4s ease}
 .tabs .dropdown{margin-left:auto}
 .tabs-title{
   padding:0 8px;


### PR DESCRIPTION
## Summary
- expand header padding and spacing to make top and minimal bars 15% larger
- scale tab and icon dimensions and SVGs by 15% for larger visuals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8c231fa50832eb56a4cb1de5eb584