### PR TITLE
Rename title to Catalyst Core and shrink navbar text

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <link rel="icon" href="images/Logo.png" type="image/png"/>
 <meta name="theme-color" content="#0e1117"/>
 <meta name="color-scheme" content="dark light"/>
-<title>Vigilante Dossier</title>
+<title>Catalyst Core</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"/>
 <link rel="stylesheet" href="styles/main.css"/>
 </head>
@@ -88,7 +88,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
       </svg>
     </button>
-    <span class="tabs-title">The Catalyst Core</span>
+      <span class="tabs-title">Catalyst Core</span>
     <div class="dropdown">
       <button id="btn-menu" class="icon" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">

--- a/styles/main.css
+++ b/styles/main.css
@@ -54,7 +54,7 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 .tabs .dropdown{margin-left:auto}
 .tabs-title{
   padding:0 8px;
-  font-size:clamp(.75rem,4vw,1rem);
+  font-size:clamp(.675rem,3.6vw,.9rem);
   white-space:nowrap;
   color:var(--accent);
   font-weight:700;


### PR DESCRIPTION
## Summary
- Change page title and header text to "Catalyst Core"
- Reduce `.tabs-title` font-size by 10% so menu fits on a single line

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8c3dd5378832e8e09a9d369470878