### PR TITLE
Add AI assistant menu option

### DIFF
--- a/__tests__/ai_button.test.js
+++ b/__tests__/ai_button.test.js
@@ -1,0 +1,23 @@
+import { jest } from '@jest/globals';
+
+describe('AI Assistant button', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div class="dropdown">
+        <div id="menu-actions" class="menu">
+          <button id="btn-ai" class="btn-sm">AI Assistant</button>
+        </div>
+      </div>
+      <div class="overlay hidden" id="modal-ai" aria-hidden="true"><div class="modal"></div></div>
+    `;
+    await import('../scripts/ai.js');
+  });
+
+  test('opens AI modal when clicked', () => {
+    const modal = document.getElementById('modal-ai');
+    expect(modal.classList.contains('hidden')).toBe(true);
+    document.getElementById('btn-ai').click();
+    expect(modal.classList.contains('hidden')).toBe(false);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -104,6 +104,7 @@
         <button id="btn-campaign" class="btn-sm">Campaign Log</button>
         <button id="btn-rules" class="btn-sm">Rules</button>
         <button id="btn-help" class="btn-sm">Help</button>
+        <button id="btn-ai" class="btn-sm">AI Assistant</button>
         <button id="btn-dm" class="btn-sm" hidden>Players</button>
       </div>
     </div>
@@ -602,6 +603,21 @@
   </div>
 </div>
 
+<!-- AI ASSISTANT MODAL -->
+<div class="overlay hidden" id="modal-ai" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>AI Assistant</h3>
+    <textarea id="ai-input" rows="3" placeholder="Ask the AI about game rules or lore..."></textarea>
+    <div class="actions"><button id="ai-send" class="btn-sm">Ask</button></div>
+    <div id="ai-output" class="ai-output"></div>
+  </div>
+</div>
+
 <!-- HELP MODAL -->
 <div class="overlay hidden" id="modal-help" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
@@ -1008,5 +1024,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" defer></script>
 <script type="module" src="scripts/users.js"></script>
 <script type="module" src="scripts/main.js"></script>
+<script type="module" src="scripts/ai.js"></script>
 </body>
 </html>

--- a/scripts/ai.js
+++ b/scripts/ai.js
@@ -1,0 +1,42 @@
+import { $ } from './helpers.js';
+import { show } from './modal.js';
+
+const btnAI = $('btn-ai');
+if (btnAI) {
+  btnAI.addEventListener('click', () => {
+    show('modal-ai');
+  });
+}
+
+const sendBtn = $('ai-send');
+if (sendBtn) {
+  sendBtn.addEventListener('click', async () => {
+    const prompt = $('ai-input').value.trim();
+    if (!prompt) return;
+    let key = localStorage.getItem('openai-key');
+    if (!key) {
+      key = window.prompt('Enter OpenAI API Key:');
+      if (!key) return;
+      localStorage.setItem('openai-key', key);
+    }
+    const output = $('ai-output');
+    output.textContent = 'Thinking...';
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${key}`
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [{ role: 'user', content: prompt }]
+        })
+      });
+      const data = await res.json();
+      output.textContent = data.choices?.[0]?.message?.content?.trim() || 'No response';
+    } catch (err) {
+      output.textContent = 'Error: ' + err.message;
+    }
+  });
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -481,3 +481,6 @@ select[required]:valid{
 .wizard-nav{display:flex;justify-content:space-between;align-items:center;margin-top:16px}
 #wizard-progress{flex:1;text-align:center}
 
+/* AI assistant */
+.ai-output{margin-top:16px;white-space:pre-wrap}
+


### PR DESCRIPTION
## Summary
- add AI Assistant button and modal for in-game help
- implement OpenAI chat integration with local API key storage
- style AI output and test modal behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e1d1ed60832eb73b8a84af8d1714