### PR TITLE
feat: allow persistent ai api key

### DIFF
--- a/__tests__/ai_button.test.js
+++ b/__tests__/ai_button.test.js
@@ -20,4 +20,25 @@ describe('AI Assistant button', () => {
     document.getElementById('btn-ai').click();
     expect(modal.classList.contains('hidden')).toBe(false);
   });
+
+  test('uses global key without prompting', async () => {
+    jest.resetModules();
+    // Minimal DOM for sending a prompt
+    document.body.innerHTML = `
+      <input id="ai-input" value="hi" />
+      <div id="ai-output"></div>
+      <button id="ai-send">Send</button>
+    `;
+    // Provide a global key and stub prompt/fetch
+    window.openaiKey = 'test-key';
+    window.prompt = jest.fn();
+    global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+
+    await import('../scripts/ai.js');
+    document.getElementById('ai-send').click();
+
+    expect(window.prompt).not.toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalled();
+    expect(localStorage.getItem('openai-key')).toBe('test-key');
+  });
 });

--- a/scripts/ai.js
+++ b/scripts/ai.js
@@ -15,8 +15,16 @@ if (sendBtn) {
     if (!prompt) return;
     let key = localStorage.getItem('openai-key');
     if (!key) {
-      key = window.prompt('Enter OpenAI API Key:');
+      // Allow setting a global or environment-based API key so users aren't
+      // repeatedly prompted every session. This checks, in order:
+      //  1. a global `openaiKey` variable that can be injected by the page
+      //  2. the Node-style `process.env.OPENAI_API_KEY` when running tests
+      //  3. a manual prompt as a final fallback
+      key = (typeof window !== 'undefined' && window.openaiKey) ||
+            (typeof process !== 'undefined' && process.env && process.env.OPENAI_API_KEY) ||
+            window.prompt('Enter OpenAI API Key:');
       if (!key) return;
+      // Persist the key so the user isn't asked again on subsequent calls.
       localStorage.setItem('openai-key', key);
     }
     const output = $('ai-output');


### PR DESCRIPTION
## Summary
- allow AI assistant to accept API key from global variable or env var so users aren't prompted each time
- test that a provided global key is used without prompting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e4d35a2c832e9b77eb9e52f36f2f