### PR TITLE
Handle OpenAI API errors

### DIFF
--- a/__tests__/ai_button.test.js
+++ b/__tests__/ai_button.test.js
@@ -41,4 +41,26 @@ describe('AI Assistant button', () => {
     expect(global.fetch).toHaveBeenCalled();
     expect(localStorage.getItem('openai-key')).toBe('test-key');
   });
+
+  test('shows API error messages', async () => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <input id="ai-input" value="hi" />
+      <div id="ai-output"></div>
+      <button id="ai-send">Send</button>
+    `;
+    localStorage.setItem('openai-key', 'test-key');
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({ error: { message: 'Invalid API key' } }),
+      }),
+    );
+
+    await import('../scripts/ai.js');
+    document.getElementById('ai-send').click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(document.getElementById('ai-output').textContent).toBe('Error: Invalid API key');
+  });
 });

--- a/scripts/ai.js
+++ b/scripts/ai.js
@@ -42,6 +42,9 @@ if (sendBtn) {
         })
       });
       const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error?.message || res.statusText);
+      }
       output.textContent = data.choices?.[0]?.message?.content?.trim() || 'No response';
     } catch (err) {
       output.textContent = 'Error: ' + err.message;


### PR DESCRIPTION
## Summary
- Display API error messages when the AI assistant request fails
- Add Jest test for API error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e66e8540832ebcf84fe7d4f70afd