### PR TITLE
feat: open CCAI in modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -993,8 +993,17 @@
 </div>
 
 
-<!-- Catalyst Core Assistant -->
-<cc-assistant-widget></cc-assistant-widget>
+<!-- Catalyst Core Assistant Modal -->
+<div class="overlay hidden" id="modal-ccai" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" aria-label="Catalyst Core Assistant" tabindex="-1" style="max-width:900px">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <cc-assistant-widget></cc-assistant-widget>
+  </div>
+</div>
   <footer>
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
   <p>Product of XoVrom industries ® 2025</p>
@@ -1011,11 +1020,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" defer></script>
 <script type="module" src="scripts/users.js"></script>
   <script type="module" src="scripts/main.js"></script>
-  <script type="module">
-    document.getElementById('btn-ccai')?.addEventListener('click', () => {
-      document.querySelector('cc-assistant-widget')?.scrollIntoView({ behavior: 'smooth' });
-    });
-  </script>
 <!-- Catalyst Core — Assistant Widget (Local AI via WebGPU, no server) -->
 <script type="module">
   // Requires a modern browser with WebGPU. First load caches the chosen model.

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1130,6 +1130,10 @@ const btnHelp = $('btn-help');
 if (btnHelp) {
   btnHelp.addEventListener('click', ()=>{ show('modal-help'); });
 }
+const btnCCAI = $('btn-ccai');
+if (btnCCAI) {
+  btnCCAI.addEventListener('click', ()=>{ show('modal-ccai'); });
+}
 const btnPlayer = $('btn-player');
 if (btnPlayer) {
   btnPlayer.addEventListener('click', ()=>{ show('modal-player'); });


### PR DESCRIPTION
## Summary
- display CCAI assistant inside its own modal popup
- show the modal when selecting CCAI from the menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a94f004d5c832ebc9a238a01f4b51c