### PR TITLE
fix: handle offline loading for CCAI modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -1023,7 +1023,7 @@
 <!-- Catalyst Core — Assistant Widget (Local AI via WebGPU, no server) -->
 <script type="module">
   // Requires a modern browser with WebGPU. First load caches the chosen model.
-  import * as webllm from "https://esm.run/@mlc-ai/web-llm";
+  let webllm = null;
 
   // ===== Custom Element =====
   class CCAssistant extends HTMLElement {
@@ -1286,6 +1286,9 @@
         loadBtn.disabled = true;
         append("sys", `Loading model: ${modelSel.value}. This caches after first load.`);
         try {
+          if(!webllm){
+            webllm = await import("https://esm.run/@mlc-ai/web-llm");
+          }
           engine = await webllm.CreateMLCEngine({ model: modelSel.value });
           append("sys","Model ready.");
         } catch (e){


### PR DESCRIPTION
## Summary
- load CCAI WebLLM module dynamically so modal UI always renders
- ensure model import errors fail gracefully

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a95430b24c832ead1d50749688ed58