### PR TITLE
Improve faction reputation layout

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -163,7 +163,9 @@ progress::-moz-progress-bar{
   .roll-flip-grid .inline>select{flex:1;width:auto;}
   .roll-flip-grid .inline>button{flex:0 0 auto;width:auto;}
 }
-.faction-rep .inline{gap:4px;}
+.faction-rep .inline{gap:4px;flex-wrap:nowrap;}
+.faction-rep .inline>progress{flex:1;}
+.faction-rep .inline>button{flex:0 0 auto;width:auto;}
 .faction-rep progress{height:20px;}
 .faction-rep .btn-sm{min-height:28px;padding:4px 6px;}
 .death-saves{display:grid;grid-template-columns:repeat(3,auto);gap:32px;justify-content:center;}


### PR DESCRIPTION
## Summary
- Prevent faction reputation buttons from stretching and keep rows on a single line

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a963ed88ac832eb7caac48155fe1e5