### PR TITLE
feat: add worker proxy and inline codex

### DIFF
--- a/cc-assistant-proxy/worker.js
+++ b/cc-assistant-proxy/worker.js
@@ -2,10 +2,9 @@ export default {
   async fetch(req, env) {
     const url = new URL(req.url);
 
-    // Replace with my domains
     const ORIGINS = [
-      "https://your-domain.com",
-      "https://your-site.web.app"
+      "https://mycampaignsite.com", // replace with my real domain(s)
+      "http://localhost:3000"
     ];
     const origin = req.headers.get("Origin") || "";
     const allow = ORIGINS.includes(origin) ? origin : ORIGINS[0];
@@ -14,31 +13,37 @@ export default {
       "Access-Control-Allow-Origin": allow,
       "Access-Control-Allow-Methods": "POST, OPTIONS",
       "Access-Control-Allow-Headers": "Content-Type, Authorization",
-      "Cache-Control": "no-store"
+      "Access-Control-Expose-Headers": "Content-Type",
+      "Cache-Control": "no-store",
+      "Vary": "Origin"
     };
 
     if (req.method === "OPTIONS") {
       return new Response(null, { headers: CORS });
     }
     if (url.pathname !== "/chat" || req.method !== "POST") {
-      return new Response("Not found", { status: 404, headers: CORS });
+      return new Response(JSON.stringify({error:"Not found"}), {
+        status: 404,
+        headers: { ...CORS, "Content-Type": "application/json" }
+      });
     }
 
-    const body = await req.json().catch(() => ({}));
-    const {
-      messages = [],
-      system = "",
-      model = env.OPENROUTER_MODEL,
-      stream = true,
-      max_tokens,
-      temperature
-    } = body;
+    let body; try { body = await req.json(); } catch { body = {}; }
+    const { messages=[], system="", model=env.OPENROUTER_MODEL, stream=true, max_tokens, temperature } = body;
+
+    if (!env.OPENROUTER_API_KEY) {
+      return new Response(JSON.stringify({ error: "OPENROUTER_API_KEY not set" }), {
+        status: 500,
+        headers: { ...CORS, "Content-Type": "application/json" }
+      });
+    }
 
     const headers = {
       "Authorization": `Bearer ${env.OPENROUTER_API_KEY}`,
       "HTTP-Referer": allow,
       "X-Title": "Catalyst Core Assistant",
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      "Accept": "text/event-stream"
     };
 
     const payload = {
@@ -49,14 +54,35 @@ export default {
       ...(temperature ? { temperature } : {})
     };
 
-    const r = await fetch("https://openrouter.ai/api/v1/chat/completions", {
-      method: "POST",
-      headers,
-      body: JSON.stringify(payload)
-    });
+    let upstream;
+    try {
+      upstream = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+        method: "POST", headers, body: JSON.stringify(payload)
+      });
+    } catch (e) {
+      return new Response(JSON.stringify({ error: "Network error", detail: String(e) }), {
+        status: 502,
+        headers: { ...CORS, "Content-Type": "application/json" }
+      });
+    }
 
-    const respHeaders = new Headers(r.headers);
-    for (const [k, v] of Object.entries(CORS)) respHeaders.set(k, v);
-    return new Response(r.body, { status: r.status, headers: respHeaders });
+    const ct = upstream.headers.get("Content-Type") || "";
+    if (!upstream.ok) {
+      let text = await upstream.text();
+      return new Response(text, { status: upstream.status, headers: { ...CORS, "Content-Type": "application/json" }});
+    }
+
+    if (ct.includes("text/event-stream")) {
+      const headersSSE = new Headers(upstream.headers);
+      for (const [k,v] of Object.entries(CORS)) headersSSE.set(k,v);
+      headersSSE.set("Content-Type","text/event-stream; charset=utf-8");
+      headersSSE.set("Cache-Control","no-store");
+      headersSSE.set("Connection","keep-alive");
+      return new Response(upstream.body, { status:200, headers:headersSSE });
+    }
+
+    const json = await upstream.text();
+    return new Response(json, { status:200, headers:{ ...CORS, "Content-Type":"application/json" }});
   }
 };
+

--- a/cc-assistant-proxy/wrangler.toml
+++ b/cc-assistant-proxy/wrangler.toml
@@ -4,6 +4,3 @@ compatibility_date = "2025-08-01"
 
 [vars]
 OPENROUTER_MODEL = "openai/gpt-oss-20b:free"
-
-# I will add the secret after you set this up:
-# wrangler secret put OPENROUTER_API_KEY

--- a/index.html
+++ b/index.html
@@ -1061,7 +1061,7 @@
 </div>
 
 <script type="module">
-  const PROXY_URL = "https://cc-assistant-proxy.<your-subdomain>.workers.dev/chat"; // set to your Worker URL
+  const PROXY_URL = "https://cc-assistant-proxy.<subdomain>.workers.dev/chat"; // set to your Worker URL
 
   const $ = (s)=>document.querySelector(s);
   const openBtn=$("#cc-open"), modal=$("#cc-modal"), closeBtn=$("#cc-close"), menuAI=$("#btn-ai");
@@ -1075,14 +1075,1857 @@ Use concise, plain language. No emojis. If Spoiler Safe is ON, avoid hidden twis
 When helpful, format with: Summary; Steps; Examples; GM Tips (GM only).
 Prefer citing Codex keys in square brackets when present: [mechanic:sp], [gear:armor.tactical_mesh_undersuit], [classgear:speedster.armor.kinetic_glide_suit].`;
 
-  // Merge multiple Codex files (character + universal gear + class gear)
-  async function fetchJSON(url){ try{ const r=await fetch(url,{cache:"no-store"}); return r.ok? await r.json():[]; }catch{return[];} }
-  const [CHAR, UNI, CLASS] = await Promise.all([
-    fetchJSON("/codex-character.json"),
-    fetchJSON("/codex-gear-universal.json"),
-    fetchJSON("/codex-gear-class.json")
-  ]);
-  const CODEX = [...CHAR, ...UNI, ...CLASS];
+  const CODEX = [
+  {
+    "type": "classification",
+    "key": "mutant",
+    "text": "Reroll one failed saving throw per long rest."
+  },
+  {
+    "type": "classification",
+    "key": "enhanced_human",
+    "text": "Gain advantage on all Technology-related checks."
+  },
+  {
+    "type": "classification",
+    "key": "magic_user",
+    "text": "Cast one minor magical effect (prestidigitation) per long rest."
+  },
+  {
+    "type": "classification",
+    "key": "alien",
+    "text": "Immune to environmental hazards; no penalty to movement in rough terrain."
+  },
+  {
+    "type": "classification",
+    "key": "mystical_being",
+    "text": "+2 to Persuasion or Intimidation checks."
+  },
+  {
+    "type": "powerstyle",
+    "key": "physical_powerhouse",
+    "text": "Cut one attack by half once per combat encounter."
+  },
+  {
+    "type": "powerstyle",
+    "key": "energy_manipulator",
+    "text": "Reroll 1s once per turn."
+  },
+  {
+    "type": "powerstyle",
+    "key": "speedster",
+    "text": "+10 ft movement and +1 AC while moving 20+ ft."
+  },
+  {
+    "type": "powerstyle",
+    "key": "telekinetic_psychic",
+    "text": "For one turn force enemies to reroll all rolls above a 17 once per rest."
+  },
+  {
+    "type": "powerstyle",
+    "key": "illusionist",
+    "text": "Create a 1-minute decoy once per combat encounter."
+  },
+  {
+    "type": "powerstyle",
+    "key": "shape_shifter",
+    "text": "Advantage on Deception; disguise freely."
+  },
+  {
+    "type": "powerstyle",
+    "key": "elemental_controller",
+    "text": "+2 to hit and +5 to damage once per turn when using elemental powers."
+  },
+  {
+    "type": "origin",
+    "key": "accident",
+    "text": "Resistance to one damage type."
+  },
+  {
+    "type": "origin",
+    "key": "experiment",
+    "text": "Reroll a failed CON or INT save once per long rest."
+  },
+  {
+    "type": "origin",
+    "key": "legacy",
+    "text": "Use the powers of one other character you’ve met or are related to once per long rest."
+  },
+  {
+    "type": "origin",
+    "key": "awakening",
+    "text": "+5 to hit and +10 to damage when below ½ HP."
+  },
+  {
+    "type": "origin",
+    "key": "pact",
+    "text": "Auto-success on one save or +10 to any roll once per long rest."
+  },
+  {
+    "type": "origin",
+    "key": "lost_time",
+    "text": "Once per combat, when using a power, roll a d20 (DC 17). On a success it becomes a “Skill Move”: no SP cost and +1d6 bonus."
+  },
+  {
+    "type": "origin",
+    "key": "exposure",
+    "text": "+5 elemental damage once per round."
+  },
+  {
+    "type": "origin",
+    "key": "rebirth",
+    "text": "If knocked out, stand; gain 1 HP and resistance to all damage for 1 round."
+  },
+  {
+    "type": "origin",
+    "key": "vigil",
+    "text": "Create a shield once per combat reducing incoming damage for all allies to 0 for 1 turn."
+  },
+  {
+    "type": "origin",
+    "key": "redemption",
+    "text": "Once/day take damage for an ally within move range; they heal 1d6 HP and gain advantage; after combat you gain advantage on all saves until dawn."
+  },
+  {
+    "type": "mechanic",
+    "key": "tc",
+    "text": "Base TC = 10 + DEX modifier + Armor/Shield bonuses + Power/Origin bonuses."
+  },
+  {
+    "type": "mechanic",
+    "key": "hp",
+    "text": "HP = 30 + CON modifier + (Tier Bonus × 1d10). Heroic tiers add +1d10 to +5d10."
+  },
+  {
+    "type": "mechanic",
+    "key": "sp",
+    "text": "SP = 5 + CON modifier; fully regenerates at the start of each combat round; powers cost 1–5 SP."
+  },
+  {
+    "type": "mechanic",
+    "key": "sp_costs",
+    "text": "1 SP basic; 2 SP core/status; 3 SP AoE/enhanced/heal; 4 SP strong AoE/hard CC; 5 SP ultimate (10-round cooldown)."
+  },
+  {
+    "type": "mechanic",
+    "key": "initiative",
+    "text": "1d20 + DEX modifier."
+  },
+  {
+    "type": "mechanic",
+    "key": "action_economy",
+    "text": "Each turn: 1 Action, 1 Movement, 1 Reaction; some features grant a Bonus Action."
+  },
+  {
+    "type": "mechanic",
+    "key": "crit",
+    "text": "Natural 20: double the damage dice."
+  },
+  {
+    "type": "alignment",
+    "key": "paragon",
+    "text": "Auto-succeed one Charisma check with civilians or allies per session."
+  },
+  {
+    "type": "alignment",
+    "key": "guardian",
+    "text": "Once per session, restore 1d6 HP or 1 SP to an ally as a bonus action."
+  },
+  {
+    "type": "alignment",
+    "key": "vigilante",
+    "text": "Ignore opportunity attacks when moving toward a threat or hostage."
+  },
+  {
+    "type": "alignment",
+    "key": "sentinel",
+    "text": "+1 to all saves when acting on orders or directives."
+  },
+  {
+    "type": "alignment",
+    "key": "outsider",
+    "text": "Once per session, reroll any roll OR remove one condition from yourself."
+  },
+  {
+    "type": "alignment",
+    "key": "wildcard",
+    "text": "Advantage on Initiative and Deception once per combat."
+  },
+  {
+    "type": "alignment",
+    "key": "inquisitor",
+    "text": "Once per session, deal maximum damage to enemies the GM labels “criminal.”"
+  },
+  {
+    "type": "alignment",
+    "key": "anti_hero",
+    "text": "Heal 1d6 HP when defeating an enemy while no allies are within 10 ft."
+  },
+  {
+    "type": "alignment",
+    "key": "renegade",
+    "text": "Once per combat, add +1d6 damage when attacking from stealth or surprise."
+  },
+  {
+    "type": "glossary",
+    "key": "sp_def",
+    "text": "Stamina Points; regenerate fully at the start of each round."
+  },
+  {
+    "type": "glossary",
+    "key": "per_session",
+    "text": "Usable once during a full play session."
+  },
+  {
+    "type": "glossary",
+    "key": "per_combat",
+    "text": "Resets each new combat."
+  },
+  {
+    "type": "glossary",
+    "key": "per_long_rest",
+    "text": "Equivalent to per session unless longer rest rules are used."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "common",
+    "key": "tactical_mesh_undersuit",
+    "text": "+1 TC. Lightweight and breathable."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "common",
+    "key": "utility_combat_jacket",
+    "text": "+1 TC; +1 to Stealth checks."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "common",
+    "key": "synthetic_kevlayer_vest",
+    "text": "+1 TC; reduce fall damage by 5."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "common",
+    "key": "friction_lined_undersuit",
+    "text": "+1 TC; ignore heat environmental penalties."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "uncommon",
+    "key": "guardian_field_plate",
+    "text": "+2 TC; +1 to STR or DEX saves."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "uncommon",
+    "key": "enviro_matched_armor",
+    "text": "+2 TC; advantage on saves vs weather/environment."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "uncommon",
+    "key": "hardened_utility_armor",
+    "text": "+2 TC; resist slashing once/day."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "uncommon",
+    "key": "impact_sensor_vest",
+    "text": "+2 TC; warns before surprise rounds (no flat-footed penalty)."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "rare",
+    "key": "reflex_reinforced_vest",
+    "text": "+3 TC; advantage vs being knocked prone."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "rare",
+    "key": "haztech_core_plating",
+    "text": "+3 TC; resistance to poison, acid, or radiation (choose one)."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "rare",
+    "key": "tactical_absorption_lining",
+    "text": "+3 TC; +1 SP if hit by an AoE."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "rare",
+    "key": "servo_spine_rig",
+    "text": "+3 TC; +5 ft movement."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "elite",
+    "key": "kinetic_nullifier_suit",
+    "text": "+3 TC; +1 SP regen when not hit during a round."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "elite",
+    "key": "omni_response_mesh",
+    "text": "+3 TC; ignore difficult terrain."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "elite",
+    "key": "deflection_halo_exosuit",
+    "text": "+3 TC; first hit each encounter is reduced by 5."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "elite",
+    "key": "phase_shield_bodysuit",
+    "text": "+3 TC; +1 DEX save and resistance to psychic."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "aegis_core_cuirass",
+    "text": "+4 TC; once/session auto-block one physical hit."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "temporal_fold_plating",
+    "text": "+3 TC; +2 Initiative while worn."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "astral_guard_harness",
+    "text": "+3 TC; resistance to force and psychic."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "echoweave_armor",
+    "text": "+4 TC; if an attacker misses once, they take −1 to hit thereafter."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "dimensional_layered_vest",
+    "text": "+3 TC; when hit, teleport 10 ft once/short rest."
+  },
+  {
+    "type": "gear",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "star_tether_harness",
+    "text": "+4 TC; immunity to the first critical hit against you each day."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "common",
+    "key": "polysteel_riot_plate",
+    "text": "+1 TC vs melee."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "common",
+    "key": "deflector_ring_gauntlet",
+    "text": "+1 TC; +1 INT saves."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "common",
+    "key": "kiteboard_bracer",
+    "text": "+1 TC while moving."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "common",
+    "key": "magseal_wrist_guard",
+    "text": "+1 TC; resistance to grappling."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "uncommon",
+    "key": "echo_deflector_disk",
+    "text": "+2 TC vs ranged attacks."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "uncommon",
+    "key": "reactive_feedback_guard",
+    "text": "+2 TC; attacker takes 1 lightning damage on a miss."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "uncommon",
+    "key": "tuned_kinetic_bracer",
+    "text": "+2 TC vs blunt/force."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "uncommon",
+    "key": "thermal_diffuser_plate",
+    "text": "+2 TC vs fire/cold-based powers."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "rare",
+    "key": "surge_buffer_barrier",
+    "text": "+2 TC; negate one elemental attack per day."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "rare",
+    "key": "quantum_stitch_bracer",
+    "text": "+2 TC; phase through one AoE per combat."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "rare",
+    "key": "displacement_arc_shield",
+    "text": "+2 TC; 50% miss chance once/day for enemies."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "rare",
+    "key": "aether_circuit_shard",
+    "text": "+2 TC; recharge 1 SP when you roll a natural 20."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "elite",
+    "key": "adaptive_reflex_wall",
+    "text": "+3 TC; reactive +1 TC boost if hit."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "elite",
+    "key": "mirror_field_buckler",
+    "text": "+3 TC; reflect one ranged hit per encounter."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "elite",
+    "key": "titan_barrier_cuff",
+    "text": "+3 TC; +1 CON save when resisting critical hits."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "elite",
+    "key": "phase_dome_generator",
+    "text": "+3 TC; adjacent allies gain +1 TC."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "nova_dome_projector",
+    "text": "Once/day, allies within 10 ft gain +2 TC for 1 round."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "quantum_fold_bracer",
+    "text": "+2 TC; teleport 5 ft as a reaction to being targeted."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "sentinel_sigil_shield",
+    "text": "+3 TC; store 1 blocked hit and unleash it as force damage next turn."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "temporal_rift_shield",
+    "text": "+3 TC; once/round shift damage to the next round."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "eclipse_generator",
+    "text": "+3 TC; grant total concealment once/day."
+  },
+  {
+    "type": "gear",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "fortress_light_beacon",
+    "text": "+3 TC; allies within 15 ft cannot be surprised."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "common",
+    "key": "combat_reflex_enhancer",
+    "text": "+1 TC during the first round."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "common",
+    "key": "emergency_blink_chip",
+    "text": "+1 TC; teleport 5 ft as a bonus action once/long rest."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "common",
+    "key": "optic_flash_spike",
+    "text": "+1 TC; blind one adjacent attacker as a reaction (1/day)."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "common",
+    "key": "thermal_regulation_patch",
+    "text": "+1 TC vs elemental terrain effects."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "uncommon",
+    "key": "adrenaline_booster_patch",
+    "text": "+2 TC while under 50% HP."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "uncommon",
+    "key": "pulse_guard_band",
+    "text": "+2 TC for 1 round after spending 3+ SP."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "uncommon",
+    "key": "reflex_timer_loop",
+    "text": "+2 TC vs AoE effects."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "uncommon",
+    "key": "hazard_compensation_implant",
+    "text": "+2 TC; ignore environment conditions for 1 hour."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "rare",
+    "key": "perception_sync_visor",
+    "text": "+1 TC and +1 Passive Perception."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "rare",
+    "key": "directional_flux_beacon",
+    "text": "Once/day, reroute one ranged power away from you."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "rare",
+    "key": "kinetic_assist_boots",
+    "text": "+2 TC when moving more than 15 ft."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "rare",
+    "key": "echo_reversal_node",
+    "text": "Once/day, negate one condition on yourself."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "elite",
+    "key": "phase_step_belt",
+    "text": "+2 TC; ignore difficult terrain while active."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "elite",
+    "key": "temporal_leech_ring",
+    "text": "+2 TC; steal 1 SP when you dodge."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "elite",
+    "key": "nullskin_emitter",
+    "text": "+2 TC; immune to Burn, Freeze, or Stun (choose each day)."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "elite",
+    "key": "aegis_burst_pack",
+    "text": "+3 TC for 1 turn when hit (1/short rest)."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "chrono_anchor_locket",
+    "text": "Once/day reset position & TC to start of turn."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "null_pulse_core",
+    "text": "Emit a wave that gives all allies +2 TC for 1 round."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "omniguard_relay_matrix",
+    "text": "+2 TC; allies within 5 ft gain +1 TC."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "loopfield_projector",
+    "text": "Reflect a failed attack once per scene."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "heartsync_signal_band",
+    "text": "Share your TC with an ally within 10 ft for 1 round."
+  },
+  {
+    "type": "gear",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "dimensional_safeguard_disk",
+    "text": "Immune to critical hits and one chosen damage type for 1 turn."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "armor",
+    "rarity": "common",
+    "key": "combat_vest_mk_i",
+    "text": "+1 TC."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "armor",
+    "rarity": "uncommon",
+    "key": "shockframe_bodysuit",
+    "text": "+2 TC; +1 STR saves."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "armor",
+    "rarity": "rare",
+    "key": "tectonic_armor_rig",
+    "text": "+3 TC; immune to knockback."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "armor",
+    "rarity": "elite",
+    "key": "ironspike_chassis",
+    "text": "+3 TC; +1 SP regen when stationary."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "goliath_core_plate",
+    "text": "+4 TC; once/day reduce one attack to 0."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "unbreakable_frame",
+    "text": "+3 TC; immune to stun and restraint."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "craterwalker_shell",
+    "text": "+3 TC; ignore damage under 5."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "shield",
+    "rarity": "common",
+    "key": "bunker_bracer",
+    "text": "+1 TC vs melee."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "shield",
+    "rarity": "uncommon",
+    "key": "mag_pulse_forearm",
+    "text": "+2 TC vs bludgeoning."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "shield",
+    "rarity": "rare",
+    "key": "spinal_lock_wall",
+    "text": "+2 TC; cannot be moved."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "shield",
+    "rarity": "elite",
+    "key": "g_force_displacer",
+    "text": "+3 TC vs charges."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "atlas_aegis",
+    "text": "+3 TC; auto-block one melee hit/encounter."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "anchor_guard",
+    "text": "+2 TC; adjacent allies gain +1 TC."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "nullwave_core_shield",
+    "text": "+2 TC; crits against you become normal hits."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "utility",
+    "rarity": "common",
+    "key": "steel_boots",
+    "text": "+1 TC while stationary."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "utility",
+    "rarity": "uncommon",
+    "key": "momentum_harness",
+    "text": "+2 TC if immobile."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "utility",
+    "rarity": "rare",
+    "key": "titan_reinforcers",
+    "text": "+2 TC when under half HP."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "utility",
+    "rarity": "elite",
+    "key": "seismic_stabilizers",
+    "text": "On hit, ground shock (DEX 15 or fall prone)."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "graviton_stompers",
+    "text": "+2 TC; creates tremor zone."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "battle_cry_driver",
+    "text": "+2 TC; nearby enemies −1 to hit."
+  },
+  {
+    "type": "classgear",
+    "class": "physical_powerhouse",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "overrun_barrier_core",
+    "text": "Reflect melee damage once per round."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "armor",
+    "rarity": "common",
+    "key": "insulated_undersuit",
+    "text": "+1 TC vs electric."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "armor",
+    "rarity": "uncommon",
+    "key": "livewire_vest",
+    "text": "+2 TC vs energy."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "armor",
+    "rarity": "rare",
+    "key": "overload_plate",
+    "text": "+3 TC; causes feedback when hit."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "armor",
+    "rarity": "elite",
+    "key": "powernet_mesh",
+    "text": "Absorb 1 SP on the first hit each round."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "stormcell_frame",
+    "text": "+3 TC; gain 1 SP when hit."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "voltage_cradle",
+    "text": "+4 TC vs energy; immune to Burn."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "sparkforge_armor",
+    "text": "Melee attackers take 1d6 lightning."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "shield",
+    "rarity": "common",
+    "key": "arc_bracer",
+    "text": "+1 TC vs ranged."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "shield",
+    "rarity": "uncommon",
+    "key": "plasma_flicker_disk",
+    "text": "+2 TC vs ranged powers."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "shield",
+    "rarity": "rare",
+    "key": "amp_reflect_array",
+    "text": "Reflect 1 energy attack/day."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "shield",
+    "rarity": "elite",
+    "key": "phase_capacitor_barrier",
+    "text": "+2 TC; attackers reroll max damage."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "electro_veil_dome",
+    "text": "+2 TC; pulses 1d4 lightning on miss."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "containment_prism",
+    "text": "Nullify 1 AoE attack per day."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "aurora_field_generator",
+    "text": "+1 TC to all allies."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "utility",
+    "rarity": "common",
+    "key": "battery_loop",
+    "text": "+1 TC after spending 5+ SP."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "utility",
+    "rarity": "uncommon",
+    "key": "charge_filter_mod",
+    "text": "Recharge 1 SP when hit by energy."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "utility",
+    "rarity": "rare",
+    "key": "amplifier_ring",
+    "text": "+2 TC after using a 4+ SP power."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "utility",
+    "rarity": "elite",
+    "key": "core_resistor_relay",
+    "text": "Steal 1 SP from attacker on hit."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "quantum_pulse_array",
+    "text": "+2 TC while channeling."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "shockwave_cloak",
+    "text": "Pulse all enemies back 10 ft once/day."
+  },
+  {
+    "type": "classgear",
+    "class": "energy_manipulator",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "static_soul_engine",
+    "text": "Bank unused SP and apply it later."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "armor",
+    "rarity": "common",
+    "key": "aerodynamic_skinsuit",
+    "text": "+1 TC; +10 ft movement."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "armor",
+    "rarity": "uncommon",
+    "key": "vibra_lining_weave",
+    "text": "+2 TC; +1 DEX save."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "armor",
+    "rarity": "rare",
+    "key": "kinetic_glide_suit",
+    "text": "+3 TC while moving 20+ ft."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "armor",
+    "rarity": "elite",
+    "key": "reactive_velocity_mesh",
+    "text": "+2 TC; +2 Initiative."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "flashphase_armor",
+    "text": "+3 TC; once/day teleport 30 ft when hit."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "chrono_surge_shell",
+    "text": "+3 TC; attackers reroll hits when you Dash."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "slipstream_frame",
+    "text": "+3 TC; Dash as a free action once/turn."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "shield",
+    "rarity": "common",
+    "key": "momentum_redirector",
+    "text": "+2 TC if moved 10+ ft."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "shield",
+    "rarity": "uncommon",
+    "key": "mirrorstep_band",
+    "text": "+1 TC; if you dashed last turn, attacker rolls twice and takes lower."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "shield",
+    "rarity": "rare",
+    "key": "temporal_slip_device",
+    "text": "Reroll 1 failed TC save per round."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "shield",
+    "rarity": "elite",
+    "key": "phase_echo_shroud",
+    "text": "+2 TC; phase through one attack/day."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "velocity_ward_matrix",
+    "text": "+3 TC while moving; enemies −1 to hit."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "slip_trace_halo",
+    "text": "Once/day you become untargetable for 1 round."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "kaleidoshift_generator",
+    "text": "+2 TC; appear in multiple places."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "utility",
+    "rarity": "common",
+    "key": "reflex_anchor_boots",
+    "text": "+2 TC on opportunity attacks."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "utility",
+    "rarity": "uncommon",
+    "key": "stutter_blink_harness",
+    "text": "+1 TC; reaction teleport 5 ft once/combat."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "utility",
+    "rarity": "rare",
+    "key": "vortex_runner_pads",
+    "text": "If you sprint 40+ ft, +3 TC next turn."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "utility",
+    "rarity": "elite",
+    "key": "hyperstep_treads",
+    "text": "+2 TC; ignore difficult terrain."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "timefract_jetboots",
+    "text": "+2 TC & extra movement when you win Initiative."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "sonic_dash_loops",
+    "text": "Create afterimage; enemies may hit illusion on miss."
+  },
+  {
+    "type": "classgear",
+    "class": "speedster",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "momentum_prism_core",
+    "text": "Reflect incoming damage if you dashed last turn."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "armor",
+    "rarity": "common",
+    "key": "neuro_sync_bodysuit",
+    "text": "+1 TC; +1 INT save."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "armor",
+    "rarity": "uncommon",
+    "key": "psionic_feedback_mesh",
+    "text": "+2 TC; attacker takes 1 psychic on a miss."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "armor",
+    "rarity": "rare",
+    "key": "thoughtweave_lining",
+    "text": "+3 TC; +1 vs psychic attacks."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "armor",
+    "rarity": "elite",
+    "key": "willsteel_harness",
+    "text": "+2 TC; immune to Confused."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "mindlock_vestment",
+    "text": "+3 TC; all WIS saves at advantage."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "neuron_mirror_shell",
+    "text": "+3 TC; reflect 1 mind power/day."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "etherial_cortex_plate",
+    "text": "+4 TC; cannot be targeted by telepathy."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "shield",
+    "rarity": "common",
+    "key": "mind_ward_halo",
+    "text": "+2 TC vs mental effects."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "shield",
+    "rarity": "uncommon",
+    "key": "kinetic_catch_gauntlet",
+    "text": "+2 TC; catch 1 thrown item/round."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "shield",
+    "rarity": "rare",
+    "key": "psy_bond_mirror",
+    "text": "+2 TC; attacker may save or hit themselves once/day."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "shield",
+    "rarity": "elite",
+    "key": "synaptic_repulsion_field",
+    "text": "+3 TC vs psychic."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "astral_reflection_screen",
+    "text": "Auto-deflect 1 psychic attack/day."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "ego_barrier_core",
+    "text": "+2 TC; suppress all emotion-based effects."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "empathic_shunt_dome",
+    "text": "Redirect emotional powers to a nearby target."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "utility",
+    "rarity": "common",
+    "key": "telekinetic_aegis",
+    "text": "Spend 1 SP for +2 TC for 1 round."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "utility",
+    "rarity": "uncommon",
+    "key": "predictive_focus_lens",
+    "text": "+1 TC if attacker is visible."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "utility",
+    "rarity": "rare",
+    "key": "cognitive_anchor_crystal",
+    "text": "+2 TC when stunned/confused."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "utility",
+    "rarity": "elite",
+    "key": "psi_loop_amplifier",
+    "text": "+2 TC; recharge 1 SP if you succeed a save."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "clarity_pulse_node",
+    "text": "Auto-save vs charm/confuse once/scene."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "chrono_mental_bracer",
+    "text": "Delay incoming mind-effect by 1 round."
+  },
+  {
+    "type": "classgear",
+    "class": "telekinetic_psychic",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "quantum_intuition_harness",
+    "text": "Always act first in surprise rounds."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "armor",
+    "rarity": "common",
+    "key": "refraction_cloak",
+    "text": "+2 TC vs first attack each round."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "armor",
+    "rarity": "uncommon",
+    "key": "prism_mesh_bodysuit",
+    "text": "+1 TC; advantage on Stealth."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "armor",
+    "rarity": "rare",
+    "key": "camouflage_lattice",
+    "text": "+1 TC in cover; +1 DEX saves."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "armor",
+    "rarity": "elite",
+    "key": "lightbend_mantle",
+    "text": "+2 TC; cannot be targeted by reaction attacks."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "cloak_of_vanishing_echoes",
+    "text": "+3 TC; vanish as reaction once/scene."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "spectrum_mirage_veil",
+    "text": "+3 TC; if you move, enemies have disadvantage to target you."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "eidolon_weave_suit",
+    "text": "+3 TC; appear as multiple illusions; disadvantage for attackers."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "shield",
+    "rarity": "common",
+    "key": "phantom_ward_disk",
+    "text": "+2 TC vs AoE."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "shield",
+    "rarity": "uncommon",
+    "key": "displacer_shell",
+    "text": "+1 TC; +1 DEX saves."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "shield",
+    "rarity": "rare",
+    "key": "glimmer_halo_field",
+    "text": "+1 TC; 50% miss chance if you used a power this round."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "shield",
+    "rarity": "elite",
+    "key": "shadowlight_barrier",
+    "text": "+2 TC; redirect one ranged attack/combat."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "spectral_dome_projector",
+    "text": "+2 TC; party within 10 ft gains +1 TC."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "afterimage_guard",
+    "text": "+3 TC; attackers auto-miss on natural 1–4."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "veil_of_the_false_self",
+    "text": "+3 TC; DC 15 WIS or attacker hits illusion instead."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "utility",
+    "rarity": "common",
+    "key": "decoy_pack",
+    "text": "Once/scene, attacker hits your illusion instead."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "utility",
+    "rarity": "uncommon",
+    "key": "hallucinogenic_pulse",
+    "text": "+2 TC; attacker −1 to hit for 1 round."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "utility",
+    "rarity": "rare",
+    "key": "vanishing_step_locket",
+    "text": "Turn invisible as a reaction to being targeted."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "utility",
+    "rarity": "elite",
+    "key": "cognitive_distorter",
+    "text": "+2 TC; nearby enemies WIS save or become disoriented."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "mindveil_disruptor",
+    "text": "Confuse attackers who miss (WIS DC 16 or skip next attack)."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "dreamcloak_injector",
+    "text": "Reaction: mirror an ally’s TC for 1 round."
+  },
+  {
+    "type": "classgear",
+    "class": "illusionist",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "infinite_mirror_core",
+    "text": "Auto-duplicate once/day to absorb one full attack."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "armor",
+    "rarity": "common",
+    "key": "morphweave_skin",
+    "text": "+1 TC; alter form as bonus action."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "armor",
+    "rarity": "uncommon",
+    "key": "fluidform_carapace",
+    "text": "+2 TC vs grapple/restrain."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "armor",
+    "rarity": "rare",
+    "key": "biocoded_shell",
+    "text": "+1 TC; +1 CON saves."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "armor",
+    "rarity": "elite",
+    "key": "phaseform_hide",
+    "text": "+3 TC; enter semi-liquid state."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "mimics_mantle",
+    "text": "Copy target’s TC for 1 round."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "amorphous_vestige",
+    "text": "Immune to critical hits."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "gene_veil_plates",
+    "text": "+3 TC; immune to shape detection/identity magic."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "shield",
+    "rarity": "common",
+    "key": "chitin_flex_shield",
+    "text": "+1 TC; +1 AC if attacking/defending same turn."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "shield",
+    "rarity": "uncommon",
+    "key": "clone_aura_matrix",
+    "text": "+2 TC if a clone is active."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "shield",
+    "rarity": "rare",
+    "key": "reactive_copy_skin",
+    "text": "Once/day gain attacker’s TC for 1 round."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "shield",
+    "rarity": "elite",
+    "key": "molten_shell_projection",
+    "text": "Create duplicate to block one incoming attack."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "shifting_scale_dome",
+    "text": "+3 TC; attacker −2 to hit next round."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "skinshard_deflector",
+    "text": "Redirect one attack to another target once/day."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "mutamask_guard",
+    "text": "Appear as attacker’s ally; attacker has disadvantage."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "utility",
+    "rarity": "common",
+    "key": "mimic_reflex_gland",
+    "text": "+2 TC vs repeat attacks."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "utility",
+    "rarity": "uncommon",
+    "key": "amorphous_escape_nodes",
+    "text": "+2 TC; slither away."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "utility",
+    "rarity": "rare",
+    "key": "second_self_implant",
+    "text": "Create a false version with your TC."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "utility",
+    "rarity": "elite",
+    "key": "shedskin_matrix",
+    "text": "+3 TC; leave behind a skin clone as decoy."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "evo_regen_coil",
+    "text": "Shift form to regain 1d6 SP and +2 TC."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "bio_reflex_prism",
+    "text": "+2 TC; auto-evade 1 melee attack/day."
+  },
+  {
+    "type": "classgear",
+    "class": "shape_shifter",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "echo_soul_fragment",
+    "text": "Clone acts with your TC and mimics one ability."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "armor",
+    "rarity": "common",
+    "key": "flameproof_mantle",
+    "text": "+2 TC vs fire."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "armor",
+    "rarity": "uncommon",
+    "key": "cryo_insulated_shell",
+    "text": "+2 TC vs cold."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "armor",
+    "rarity": "rare",
+    "key": "stormbreaker_harness",
+    "text": "+1 TC; resist lightning."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "armor",
+    "rarity": "elite",
+    "key": "stoneguard_core",
+    "text": "+3 TC; immunity to knockdown."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "terra_wardframe",
+    "text": "+3 TC; +2 TC while on natural terrain."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "voltaic_veinsuit",
+    "text": "Reflect a lightning attack once/day."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "armor",
+    "rarity": "legendary",
+    "key": "cinderguard_sheath",
+    "text": "Ignore all Burn; +2 TC vs fire."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "shield",
+    "rarity": "common",
+    "key": "elemental_ward_totem",
+    "text": "+1 TC vs elemental."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "shield",
+    "rarity": "uncommon",
+    "key": "volcanic_shell_plate",
+    "text": "+2 TC; 1 fire damage to melee attackers."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "shield",
+    "rarity": "rare",
+    "key": "tempest_veil_sigil",
+    "text": "+2 TC for 1 round (spend 1 SP)."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "shield",
+    "rarity": "elite",
+    "key": "galehalo_barrier",
+    "text": "+3 TC vs ranged; deflects projectiles."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "frostwall_core",
+    "text": "+2 TC; slows melee attackers."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "wildfire_halo",
+    "text": "All enemies within 5 ft take 1d4 fire when you’re hit."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "shield",
+    "rarity": "legendary",
+    "key": "planar_barrier_cloak",
+    "text": "Immunity to one chosen element per long rest."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "utility",
+    "rarity": "common",
+    "key": "living_ember_core",
+    "text": "+2 TC when hit by elemental power."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "utility",
+    "rarity": "uncommon",
+    "key": "earthbind_grips",
+    "text": "+2 TC while grounded."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "utility",
+    "rarity": "rare",
+    "key": "stormstep_cloak",
+    "text": "+2 TC in elemental terrain."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "utility",
+    "rarity": "elite",
+    "key": "cyclone_core_belt",
+    "text": "Spend 1 SP to become immune to AoE for 1 turn."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "heart_of_the_infernaut",
+    "text": "Spend SP to ignite: +3 TC and fire damage aura."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "aetherflow_gauntlet",
+    "text": "Float/fly; +2 TC while airborne."
+  },
+  {
+    "type": "classgear",
+    "class": "elemental_controller",
+    "gear": "utility",
+    "rarity": "legendary",
+    "key": "oceans_calm_pendant",
+    "text": "Auto-nullify 1 elemental power/day."
+  }
+]
+;
 
   // Simple retrieval by keyword overlap
   function retrieve(q, k=14){


### PR DESCRIPTION
## Summary
- add Cloudflare Worker proxy config and implementation for OpenRouter model
- inline Codex data in assistant page and remove external JSON fetches
- point assistant to worker /chat endpoint via PROXY_URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9863e71a0832eb5f81b154f54b640