### PR TITLE
Remove redundant users script reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -1014,7 +1014,6 @@
 <div id="sp-animation" aria-hidden="true"></div>
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" defer></script>
-<script type="module" src="scripts/users.js"></script>
 <script type="module" src="scripts/main.js"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- Remove unused `users.js` script tag from index to avoid loading module twice

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a1549e8c832ebea8afdce0efdf3b