### PR TITLE
Remove card hover elevation

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -314,8 +314,7 @@ progress::-moz-progress-bar{
 }
 .sp-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;flex:1;}
 .sp-grid .btn-sm{width:100%;}
-.card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .3s ease-in-out,transform .3s ease-in-out}
-.card:hover{box-shadow:0 12px 28px rgba(0,0,0,.45);transform:translateY(-2px)}
+.card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .3s ease-in-out}
 .card:focus-within{box-shadow:0 0 0 2px var(--accent),var(--shadow)}
 .card.dragging{opacity:.5}
 .catalog{max-height:360px;overflow:auto;border:1px dashed var(--line);border-radius:10px;padding:6px}


### PR DESCRIPTION
## Summary
- prevent card components from elevating with a shadow on hover

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a2f7bf94832ebc68ecdc671cbb07