### PR TITLE
Optimize viewport updates and streamline styling

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -27,10 +27,6 @@ function setVh(){
   document.documentElement.style.setProperty('--vh', `${window.innerHeight * 0.01}px`);
 }
 setVh();
-window.addEventListener('resize', setVh);
-if (window.visualViewport) {
-  window.visualViewport.addEventListener('resize', setVh);
-}
 if (typeof pdfjsLib !== 'undefined') {
   pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
 }
@@ -65,11 +61,13 @@ function applyDeleteIcon(btn){
   if(!btn) return;
   btn.innerHTML = ICON_TRASH;
   btn.setAttribute('aria-label','Delete');
-  btn.style.width = '15px';
-  btn.style.height = '15px';
-  btn.style.minHeight = '15px';
-  btn.style.padding = '0';
-  btn.style.flex = '0 0 auto';
+  Object.assign(btn.style, {
+    width: '15px',
+    height: '15px',
+    minHeight: '15px',
+    padding: '0',
+    flex: '0 0 auto'
+  });
 }
 
 function applyDeleteIcons(root=document){
@@ -110,6 +108,12 @@ function debounce(fn, delay){
     clearTimeout(t);
     t = setTimeout(()=>fn(...args), delay);
   };
+}
+
+const debouncedSetVh = debounce(setVh, 100);
+window.addEventListener('resize', debouncedSetVh, { passive: true });
+if (window.visualViewport) {
+  window.visualViewport.addEventListener('resize', debouncedSetVh);
 }
 
 // prevent negative numbers in numeric inputs


### PR DESCRIPTION
## Summary
- Debounce viewport height calculations and use passive resize listeners for smoother window resizing
- Replace repeated delete button style assignments with a single Object.assign for tidier, faster updates

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a9b0ef5458832e9c9bc67c6544ae6a