### PR TITLE
prevent duplicate player registration

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -18,8 +18,9 @@ describe('user management', () => {
   });
 
   test('registers players and lists them', () => {
-    registerPlayer('Alice', 'a', 'pet?', 'cat');
-    registerPlayer('Bob', 'b', 'pet?', 'dog');
+    expect(registerPlayer('Alice', 'a', 'pet?', 'cat')).toBe(true);
+    expect(registerPlayer('Bob', 'b', 'pet?', 'dog')).toBe(true);
+    expect(registerPlayer('Alice', 'c', 'pet?', 'cat')).toBe(false);
     expect(getPlayers()).toEqual(['Alice', 'Bob']);
   });
 

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -65,11 +65,12 @@ export function getPlayers() {
 
 export function registerPlayer(name, password, question, answer) {
   const players = getPlayersRaw();
-  if (name && password && question && answer && !players[name]) {
-    players[name] = { password, question, answer };
-    setPlayersRaw(players);
+  if (!name || !password || !question || !answer || players[name]) {
+    return false;
   }
-  return Object.keys(players);
+  players[name] = { password, question, answer };
+  setPlayersRaw(players);
+  return true;
 }
 
 export function getPlayerQuestion(name) {
@@ -238,7 +239,10 @@ if (typeof document !== 'undefined') {
           toast('Security answer required','error');
           return;
         }
-        registerPlayer(name, pass, question, answer);
+        if (!registerPlayer(name, pass, question, answer)) {
+          toast('Player already exists','error');
+          return;
+        }
         nameInput.value = '';
         passInput.value = '';
         questionInput.value = '';


### PR DESCRIPTION
## Summary
- ensure registerPlayer reports failure for duplicate names
- display an error when attempting to register an existing player
- test duplicate registration handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9f85a4fd0832e9301372694c44ee5