### PR TITLE
feat: trap focus inside modals

### DIFF
--- a/__tests__/modal.test.js
+++ b/__tests__/modal.test.js
@@ -6,7 +6,10 @@ describe('modal show/hide behavior', () => {
       <button id="outside-btn"></button>
       <div id="content"></div>
       <div class="overlay hidden" id="modal-one" aria-hidden="true">
-        <div class="modal"><button id="modal-one-btn">Ok</button></div>
+        <div class="modal">
+          <button id="modal-one-btn">Ok</button>
+          <button id="modal-one-btn2">Cancel</button>
+        </div>
       </div>
       <div class="overlay hidden" id="modal-two" aria-hidden="true">
         <div class="modal"><button id="modal-two-btn">Ok</button></div>
@@ -30,6 +33,19 @@ describe('modal show/hide behavior', () => {
     expect(document.body.classList.contains('modal-open')).toBe(false);
     expect(document.getElementById('content').hasAttribute('inert')).toBe(false);
     expect(document.activeElement.id).toBe('outside-btn');
+  });
+
+  test('focus is trapped within modal', () => {
+    show('modal-one');
+    const btn1 = document.getElementById('modal-one-btn');
+    const btn2 = document.getElementById('modal-one-btn2');
+    // shift+Tab on the first element wraps to the last
+    btn1.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }));
+    expect(document.activeElement).toBe(btn2);
+    // Tab on the last element wraps back to the first
+    btn2.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(document.activeElement).toBe(btn1);
+    hide('modal-one');
   });
 
   test('multiple modals keep body locked until all are closed', () => {


### PR DESCRIPTION
## Summary
- keep keyboard navigation inside open modals
- add unit test for modal focus trapping

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a9fa35c0c0832e97595fc83fddac18