### PR TITLE
feat: sort player list alphabetically

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -17,12 +17,14 @@ describe('user management', () => {
     localStorage.clear();
   });
 
-  test('registers players and lists them', () => {
-    expect(registerPlayer('Alice', 'a', 'pet?', 'cat')).toBe(true);
-    expect(registerPlayer('Bob', 'b', 'pet?', 'dog')).toBe(true);
-    expect(registerPlayer('Alice', 'c', 'pet?', 'cat')).toBe(false);
-    expect(getPlayers()).toEqual(['Alice', 'Bob']);
-  });
+    test('registers players and lists them alphabetically', () => {
+      // Register out of order to ensure getPlayers sorts names
+      expect(registerPlayer('Bob', 'b', 'pet?', 'dog')).toBe(true);
+      expect(registerPlayer('Alice', 'a', 'pet?', 'cat')).toBe(true);
+      expect(registerPlayer('Alice', 'c', 'pet?', 'cat')).toBe(false);
+      // Should return names sorted alphabetically despite insertion order
+      expect(getPlayers()).toEqual(['Alice', 'Bob']);
+    });
 
   test('registration requires name and password', () => {
     registerPlayer('', 'pw', 'q', 'a');

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -60,7 +60,11 @@ function setPlayersRaw(players) {
 }
 
 export function getPlayers() {
-  return Object.keys(getPlayersRaw());
+  // Return player names in a consistent alphabetical order so that UI
+  // lists remain stable regardless of the registration sequence. Sorting
+  // also makes unit tests deterministic when using Object keys which
+  // otherwise preserve insertion order.
+  return Object.keys(getPlayersRaw()).sort((a, b) => a.localeCompare(b));
 }
 
 export function registerPlayer(name, password, question, answer) {


### PR DESCRIPTION
## Summary
- keep players list sorted regardless of registration order
- test that sorting is applied

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9fb19ee4c832ebee2330aa52104c4