### PR TITLE
Display rules from ruleshelp.txt in modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -975,27 +975,15 @@
   </div>
 </div>
 
-<!-- RULES (CCCG PDF) -->
+<!-- RULES -->
 <div class="overlay hidden" id="modal-rules" aria-hidden="true">
-  <div class="modal modal-rules" role="dialog" aria-modal="true" aria-label="CCCG — Character Creation Guide" tabindex="-1">
+  <div class="modal modal-rules" role="dialog" aria-modal="true" aria-label="Rules Help" tabindex="-1">
     <button class="x" data-close aria-label="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
-    <div class="pdf-controls">
-      <button id="cccg-page-up" class="icon" aria-label="Previous Page">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 19V5m0 0-7 7m7-7 7 7"/>
-        </svg>
-      </button>
-      <button id="cccg-page-down" class="icon" aria-label="Next Page">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m0 0 7-7m-7 7-7-7"/>
-        </svg>
-      </button>
-    </div>
-    <canvas id="cccg-canvas"></canvas>
+    <pre id="rules-text"></pre>
   </div>
 </div>
 
@@ -1013,7 +1001,6 @@
 <div id="coin-animation" aria-hidden="true"></div>
 <div id="sp-animation" aria-hidden="true"></div>
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" defer></script>
 <script type="module" src="scripts/main.js"></script>
 
 </body>

--- a/styles/main.css
+++ b/styles/main.css
@@ -326,7 +326,6 @@ progress::-moz-progress-bar{
 .catalog-item.active{background:var(--accent);color:var(--text-on-accent)}
 .catalog-item.active .pill{border-color:var(--text-on-accent);color:var(--text-on-accent)}
 .small{font-size:.9rem;color:var(--muted)}
-#modal-rules .pdf-controls{position:absolute;bottom:16px;right:16px;display:flex;flex-direction:column;gap:8px;z-index:1}
 .overlay{position:fixed;top:0;left:0;right:0;height:calc(var(--vh,1vh)*100);display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.6);backdrop-filter:blur(2px);z-index:1000;padding:16px 16px calc(16px + env(safe-area-inset-bottom));opacity:1;pointer-events:auto;transition:opacity .3s ease-in-out;will-change:opacity}
 .overlay.hidden{opacity:0;pointer-events:none}
 .modal{background:var(--surface);border:1px solid var(--accent);border-radius:var(--radius);max-width:720px;width:100%;padding:16px;box-shadow:var(--shadow);position:relative;max-height:calc(var(--vh,1vh)*100 - 32px - env(safe-area-inset-bottom));overflow:auto;transform:scale(1);opacity:1;transition:transform .3s ease-in-out,opacity .3s ease-in-out;will-change:transform,opacity}
@@ -343,9 +342,9 @@ body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
 #modal-help .feature-list li{display:flex;align-items:flex-start;gap:8px}
 #modal-help .feature-list .icon-group{display:flex;gap:4px}
 #modal-help .feature-list svg{width:20px;height:20px;flex-shrink:0}
-#modal-rules{align-items:stretch;padding:0}
-#modal-rules .modal-rules{max-width:none;width:100%;height:100%;border-radius:0;border:none;padding:0;max-height:none}
-#modal-rules .modal-rules canvas{width:100%;height:100%;display:block}
+#modal-rules{padding:16px}
+#modal-rules .modal-rules{max-width:720px}
+#rules-text{white-space:pre-wrap}
 .toast{position:fixed;bottom:18px;right:18px;background:var(--surface);border:1px solid var(--accent);padding:10px 12px;border-radius:var(--radius);opacity:0;transform:translateY(8px);transition:opacity .3s ease-in-out,transform .3s ease-in-out;z-index:2000;display:flex;align-items:center;gap:6px}
 .toast::before{content:"";width:16px;height:16px;background-size:contain;background-repeat:no-repeat}
 .toast.show{opacity:1;transform:translateY(0)}


### PR DESCRIPTION
## Summary
- replace PDF-based rules modal with preformatted text from ruleshelp.txt
- load rules text on demand and remove pdf.js dependency
- style rules modal for readable scrolling text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa178cb534832ea4a67f574df1023b