### PR TITLE
Rename initiative stat to initiative bonus with sign

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,9 +199,9 @@
 
     <div class="grid grid-2">
       <fieldset class="card">
-        <legend>Initiative &amp; Speed</legend>
-        <label for="initiative">Initiative</label>
-        <input id="initiative" type="number" inputmode="numeric" placeholder="auto from DEX + bonuses" readonly/>
+        <legend>Initiative Bonus &amp; Speed</legend>
+        <label for="initiative">Initiative Bonus</label>
+        <input id="initiative" type="text" inputmode="numeric" placeholder="auto from DEX + bonuses" readonly/>
         <label for="speed">Speed (ft)</label>
         <input id="speed" type="number" inputmode="numeric" placeholder="30"/>
       </fieldset>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -722,7 +722,8 @@ function updateDerived(){
   elTC.value = 10 + mod(elDex.value) + armorAuto + num(elOriginBonus.value||0);
   updateSP();
   updateHP();
-  elInitiative.value = mod(elDex.value) + (addWisToInitiative ? mod(elWis.value) : 0);
+  const initiative = mod(elDex.value) + (addWisToInitiative ? mod(elWis.value) : 0);
+  elInitiative.value = (initiative >= 0 ? '+' : '') + initiative;
   elPowerSaveDC.value = 8 + pb + mod($( elPowerSaveAbility.value ).value);
   ABILS.forEach(a=>{
     const m = mod($(a).value);


### PR DESCRIPTION
## Summary
- rename Initiative stat to Initiative Bonus in UI
- show initiative bonus with plus sign when positive

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa21ada5f4832eb62daa617f70f0e7