### PR TITLE
Remove auto note from Armor/Shield Bonus label

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
         <legend>Defense Stats</legend>
         <label for="pp">Passive Perception</label>
         <input id="pp" type="number" readonly/>
-        <label for="armor-bonus">Armor/Shield Bonus (auto)</label>
+        <label for="armor-bonus">Armor/Shield Bonus</label>
         <input id="armor-bonus" type="number" readonly/>
         <label for="origin-bonus">Power/Origin Bonus</label>
         <input id="origin-bonus" type="number" inputmode="numeric" value="0"/>


### PR DESCRIPTION
## Summary
- remove '(auto)' from the Armor/Shield Bonus label in Defense Stats section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa254fb80c832ea7562b6fa05881e3