### PR TITLE
Adjust dice and coin flip layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,7 @@
     <div class="grid grid-2 roll-flip-grid">
       <fieldset class="card">
         <legend>Dice Roll</legend>
+        <span class="pill result" id="dice-out" data-placeholder="000"></span>
         <div class="inline">
           <label for="dice-sides" class="sr-only">Sides</label>
           <select id="dice-sides">
@@ -125,14 +126,13 @@
           <input id="dice-count" type="number" inputmode="numeric" min="1" value="1"/>
           <button id="roll-dice" class="btn-sm">Roll</button>
         </div>
-        <span class="pill result" id="dice-out" data-placeholder="000"></span>
       </fieldset>
       <fieldset class="card">
         <legend>Coin Flip</legend>
+        <span class="pill result" id="flip-out" data-placeholder="Heads"></span>
         <div class="inline">
           <button id="flip" class="btn-sm">Flip</button>
         </div>
-        <span class="pill result" id="flip-out" data-placeholder="Heads"></span>
       </fieldset>
     </div>
     <fieldset class="card">

--- a/styles/main.css
+++ b/styles/main.css
@@ -154,7 +154,7 @@ progress::-moz-progress-bar{
 .roll-flip-grid input,
 .roll-flip-grid button,
 .roll-flip-grid .pill{padding:4px 6px;min-height:28px;}
-.roll-flip-grid .pill.result{font-size:.85rem;min-width:40px;}
+.roll-flip-grid .pill.result{font-size:.85rem;min-width:40px;width:100%;display:block;text-align:center;margin-bottom:4px;}
 #dice-count{flex:0 0 30px;width:30px;}
 @media(max-width:600px){
   .roll-flip-grid{grid-template-columns:repeat(2,1fr);}
@@ -163,6 +163,7 @@ progress::-moz-progress-bar{
   .roll-flip-grid .inline>select{flex:1;width:auto;}
   .roll-flip-grid .inline>button{flex:0 0 auto;width:auto;}
 }
+#flip{flex:1;width:100%;display:block;}
 .faction-rep>div{display:flex;flex-direction:column;gap:4px;}
 .faction-rep .inline{gap:4px;flex-wrap:nowrap;}
 .faction-rep .faction-header{justify-content:space-between;}


### PR DESCRIPTION
## Summary
- Move dice roll and coin flip outputs above their buttons
- Make coin flip button match output width for consistent layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2710bc08832ebe72abde1c36e641