### PR TITLE
Refine HP controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,23 +157,29 @@
     <div class="grid grid-2">
       <fieldset class="card">
         <legend>HP</legend>
-        <div class="inline">
-          <progress id="hp-bar" max="30" value="30" style="width:100%"></progress>
-          <span class="pill" id="hp-pill">30/30</span>
-        </div>
-        <div class="inline">
-          <input id="hp-roll" type="hidden" value="0"/>
-          <button id="hp-roll-add" class="btn-sm" type="button">Add Tier HP</button>
-        </div>
-        <div class="inline">
-          <label for="hp-temp" class="sr-only">Temp HP</label>
-          <input id="hp-temp" type="number" inputmode="numeric" placeholder="Temp HP"/>
-          <label for="hp-amt" class="sr-only">Amount</label>
-          <input id="hp-amt" type="number" inputmode="numeric" placeholder="Amount"/>
-          <button id="hp-dmg" class="btn-sm">Damage</button>
-          <button id="hp-heal" class="btn-sm">Heal</button>
-          <button id="hp-full" class="btn-sm">Reset HP</button>
-        </div>
+          <div class="inline">
+            <div class="bar-label">
+              <progress id="hp-bar" max="30" value="30"></progress>
+              <span id="hp-pill">30/30</span>
+            </div>
+          </div>
+          <div class="inline">
+            <input id="hp-roll" type="hidden" value="0"/>
+            <button id="hp-roll-add" class="btn-sm" type="button">Add Tier HP</button>
+          </div>
+          <div class="inline">
+            <label for="hp-temp" class="sr-only">Temp HP</label>
+            <input id="hp-temp" type="number" inputmode="numeric" placeholder="Temp HP"/>
+            <label for="hp-amt" class="sr-only">Amount</label>
+            <input id="hp-amt" type="number" inputmode="numeric" placeholder="Amount"/>
+          </div>
+          <div class="inline">
+            <button id="hp-dmg" class="btn-sm">Damage</button>
+            <button id="hp-heal" class="btn-sm">Heal</button>
+          </div>
+          <div class="inline">
+            <button id="hp-full" class="btn-sm">Reset HP</button>
+          </div>
       </fieldset>
       <fieldset class="card">
         <legend>SP</legend>

--- a/styles/main.css
+++ b/styles/main.css
@@ -106,7 +106,8 @@ button:focus-visible{outline:2px solid var(--accent);outline-offset:2px;animatio
 .inline>select,
 .inline>textarea,
 .inline>button,
-.inline>progress{flex:1;width:auto;height:36px}
+.inline>progress,
+.inline>.bar-label{flex:1;width:auto;height:36px}
 .inline>.pill,
 .inline>.sr-only{flex:0;width:auto}
 @media(max-width:600px){
@@ -115,7 +116,8 @@ button:focus-visible{outline:2px solid var(--accent);outline-offset:2px;animatio
   .inline>select,
   .inline>textarea,
   .inline>button,
-  .inline>progress{flex:none;width:100%;height:36px}
+  .inline>progress,
+  .inline>.bar-label{flex:none;width:100%;height:36px}
 }
 progress{
   -webkit-appearance:none;
@@ -138,7 +140,11 @@ progress::-moz-progress-bar{
   transition:width .4s ease;
 }
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
-#hp-pill,#sp-pill{height:36px;padding:0 10px;display:inline-flex;align-items:center}
+#sp-pill{height:36px;padding:0 10px;display:inline-flex;align-items:center}
+
+.bar-label{position:relative}
+.bar-label>progress{width:100%;height:36px}
+.bar-label>#hp-pill{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:.85rem;pointer-events:none;padding:0}
 .pill-sm{padding:2px 6px;font-size:.75rem}
 .pill.result{font-size:1rem;font-weight:700;}
 .pill.result:empty::before{content:attr(data-placeholder);visibility:hidden;}


### PR DESCRIPTION
## Summary
- Overlay HP value inside the HP progress bar
- Reorganize HP controls so temp HP and damage amount align, and damage/heal buttons sit side by side

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa29879500832eaff02a494b3e4c7f