### PR TITLE
Show SP value within SP bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,8 +184,10 @@
       <fieldset class="card">
         <legend>SP</legend>
         <div class="inline">
-          <progress id="sp-bar" max="5" value="5" style="width:100%"></progress>
-          <span class="pill" id="sp-pill">5/5</span>
+          <div class="bar-label">
+            <progress id="sp-bar" max="5" value="5"></progress>
+            <span id="sp-pill">5/5</span>
+          </div>
         </div>
         <div class="inline">
           <label for="sp-temp" class="sr-only">Temp SP</label>

--- a/styles/main.css
+++ b/styles/main.css
@@ -139,12 +139,12 @@ progress::-moz-progress-bar{
   background:var(--accent);
   transition:width .4s ease;
 }
+
 .pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
-#sp-pill{height:36px;padding:0 10px;display:inline-flex;align-items:center}
 
 .bar-label{position:relative}
 .bar-label>progress{width:100%;height:36px}
-.bar-label>#hp-pill{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:.85rem;pointer-events:none;padding:0}
+.bar-label>span{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:.85rem;pointer-events:none;padding:0}
 .pill-sm{padding:2px 6px;font-size:.75rem}
 .pill.result{font-size:1rem;font-weight:700;}
 .pill.result:empty::before{content:attr(data-placeholder);visibility:hidden;}


### PR DESCRIPTION
## Summary
- Embed SP value text directly inside the SP progress bar for a cohesive display
- Style bar overlays generically so both HP and SP pills render within their bars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa2aa8edb4832e902364032224a72d