### PR TITLE
Reorder HP management controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
     <div class="grid grid-2">
       <fieldset class="card">
         <legend>HP</legend>
+          <input id="hp-roll" type="hidden" value="0"/>
           <div class="inline">
             <div class="bar-label">
               <progress id="hp-bar" max="30" value="30"></progress>
@@ -164,15 +165,20 @@
             </div>
           </div>
           <div class="inline">
-            <input id="hp-roll" type="hidden" value="0"/>
             <label for="hp-temp" class="sr-only">Temp HP</label>
             <input id="hp-temp" type="number" inputmode="numeric" placeholder="Temp HP"/>
+            <button id="hp-roll-add" class="btn-sm" type="button">Add Tier HP</button>
+          </div>
+          <div class="inline">
             <label for="hp-amt" class="sr-only">Amount</label>
             <input id="hp-amt" type="number" inputmode="numeric" placeholder="Amount"/>
+          </div>
+          <div class="inline">
             <button id="hp-dmg" class="btn-sm">Damage</button>
             <button id="hp-heal" class="btn-sm">Heal</button>
+          </div>
+          <div class="inline">
             <button id="hp-full" class="btn-sm">Reset HP</button>
-            <button id="hp-roll-add" class="btn-sm" type="button">Add Tier HP</button>
           </div>
       </fieldset>
       <fieldset class="card">


### PR DESCRIPTION
## Summary
- Reorganize HP fieldset layout for improved clarity: HP bar, Temp HP + Add Tier HP row, damage amount field, grouped damage/heal controls, and reset button.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa35a86f90832ea08a4753df84a855