### PR TITLE
Ensure HP field layout consistent on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
 
   <fieldset data-tab="combat" class="card">
     <div class="grid grid-2">
-      <fieldset class="card">
+      <fieldset class="card hp-field">
         <legend>HP</legend>
           <input id="hp-roll" type="hidden" value="0"/>
           <div class="inline">

--- a/styles/main.css
+++ b/styles/main.css
@@ -119,6 +119,23 @@ button:focus-visible{outline:2px solid var(--accent);outline-offset:2px;animatio
   .inline>progress,
   .inline>.bar-label{flex:none;width:100%;height:36px}
 }
+
+@media(max-width:600px){
+  .hp-field .inline{
+    flex-direction:row;
+    align-items:center;
+  }
+  .hp-field .inline>input:not([type="checkbox"]),
+  .hp-field .inline>select,
+  .hp-field .inline>textarea,
+  .hp-field .inline>button,
+  .hp-field .inline>progress,
+  .hp-field .inline>.bar-label{
+    flex:1;
+    width:auto;
+    height:36px;
+  }
+}
 progress{
   -webkit-appearance:none;
   appearance:none;


### PR DESCRIPTION
## Summary
- Keep HP controls horizontal on small screens
- Mark HP fieldset for targeted styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa39268d74832e81ff68b4a7b2366a