### PR TITLE
Reposition SP temp field and long rest control

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,17 +181,17 @@
             <button id="hp-full" class="btn-sm">Reset HP</button>
           </div>
       </fieldset>
-      <fieldset class="card">
+      <fieldset class="card sp-field">
         <legend>SP</legend>
         <div class="inline">
           <div class="bar-label">
             <progress id="sp-bar" max="5" value="5"></progress>
             <span id="sp-pill">5/5</span>
           </div>
-        </div>
-        <div class="inline">
           <label for="sp-temp" class="sr-only">Temp SP</label>
           <input id="sp-temp" type="number" inputmode="numeric" placeholder="Temp SP"/>
+        </div>
+        <div class="inline">
           <div class="sp-grid">
             <button class="btn-sm" data-sp="-1">-1 SP</button>
             <button class="btn-sm" data-sp="-2">-2 SP</button>
@@ -200,8 +200,8 @@
           </div>
           <button class="btn-sm" data-sp="-5">-5 SP</button>
           <button id="sp-full" class="btn-sm">Reset SP</button>
+          <button id="long-rest" class="btn-sm">Long Rest</button>
         </div>
-        <div class="inline"><button id="long-rest" class="btn-sm">Long Rest</button></div>
       </fieldset>
     </div>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -121,7 +121,8 @@ button:focus-visible{outline:2px solid var(--accent);outline-offset:2px;animatio
 }
 
 @media(max-width:600px){
-  .hp-field .inline{
+  .hp-field .inline,
+  .sp-field .inline{
     flex-direction:row;
     align-items:center;
   }
@@ -130,7 +131,13 @@ button:focus-visible{outline:2px solid var(--accent);outline-offset:2px;animatio
   .hp-field .inline>textarea,
   .hp-field .inline>button,
   .hp-field .inline>progress,
-  .hp-field .inline>.bar-label{
+  .hp-field .inline>.bar-label,
+  .sp-field .inline>input:not([type="checkbox"]),
+  .sp-field .inline>select,
+  .sp-field .inline>textarea,
+  .sp-field .inline>button,
+  .sp-field .inline>progress,
+  .sp-field .inline>.bar-label{
     flex:1;
     width:auto;
     height:36px;


### PR DESCRIPTION
## Summary
- Place temporary SP input beside the SP bar
- Show long rest button next to reset SP
- Add responsive styling to keep SP controls aligned on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3a9116a8832ebd43b7355960d56c