### PR TITLE
Improve help modal readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -628,22 +628,22 @@
     </button>
     <h3>How to Use the Tracker</h3>
     <ul class="feature-list">
-      <li><b>Theme toggle:</b> Switch between light, high-contrast, and dark modes using the sun, contrast, or moon icons.</li>
-      <li><b>Main menu:</b> Tap the menu icon to open options—Log&nbsp;In, Character wizard, Encounter tracker, Save, Roll/Flip Log, Campaign Log, Rules, Help, and Players.</li>
-      <li><b>Tab navigation:</b> Use Combat, Abilities, Powers, Gear, and Story icons to move between sections.</li>
-      <li><b>Combat tools:</b> Adjust HP/SP, track death saves, initiative, defenses, and conditions; roll dice or flip coins directly.</li>
-      <li><b>Abilities management:</b> Edit ability scores and proficiency bonuses on the Abilities tab.</li>
-      <li><b>Powers management:</b> Record powers or spells and mark off uses in the Powers tab.</li>
-      <li><b>Gear management &amp; catalog:</b> Track equipment and currency on the Gear tab; open the gear catalog to search items.</li>
-      <li><b>Story notes:</b> Use the Story tab to store background details, quests, and other notes.</li>
-      <li><b>Character creation wizard:</b> Build a new character step by step from the main menu.</li>
-      <li><b>Encounter tracker:</b> Manage combatant lists and turn order with Add, Prev, Next, and Reset controls.</li>
-      <li><b>Dice rolling &amp; coin flips:</b> Use the Roll/Flip Log to perform rolls or flips and review results.</li>
-      <li><b>Campaign &amp; roll logs:</b> Keep adventure notes and roll history in their respective logs.</li>
-      <li><b>Rules reference:</b> Read the Character Creation Guide from the Rules menu.</li>
-      <li><b>Player &amp; DM login:</b> Log in for cloud features or use the DM link to manage shared tools.</li>
-      <li><b>Save characters:</b> Save locally or to the cloud after logging in.</li>
-      <li><b>Offline auto-saving:</b> Changes are stored in your browser and sync when you're back online.</li>
+      <li><b>Theme toggle</b>Switch between light, high-contrast, and dark modes using the sun, contrast, or moon icons.</li>
+      <li><b>Main menu</b>Tap the menu icon to open options—Log&nbsp;In, Character wizard, Encounter tracker, Save, Roll/Flip Log, Campaign Log, Rules, Help, and Players.</li>
+      <li><b>Tab navigation</b>Use Combat, Abilities, Powers, Gear, and Story icons to move between sections.</li>
+      <li><b>Combat tools</b>Adjust HP/SP, track death saves, initiative, defenses, and conditions; roll dice or flip coins directly.</li>
+      <li><b>Abilities management</b>Edit ability scores and proficiency bonuses on the Abilities tab.</li>
+      <li><b>Powers management</b>Record powers or spells and mark off uses in the Powers tab.</li>
+      <li><b>Gear management &amp; catalog</b>Track equipment and currency on the Gear tab; open the gear catalog to search items.</li>
+      <li><b>Story notes</b>Use the Story tab to store background details, quests, and other notes.</li>
+      <li><b>Character creation wizard</b>Build a new character step by step from the main menu.</li>
+      <li><b>Encounter tracker</b>Manage combatant lists and turn order with Add, Prev, Next, and Reset controls.</li>
+      <li><b>Dice rolling &amp; coin flips</b>Use the Roll/Flip Log to perform rolls or flips and review results.</li>
+      <li><b>Campaign &amp; roll logs</b>Keep adventure notes and roll history in their respective logs.</li>
+      <li><b>Rules reference</b>Read the Character Creation Guide from the Rules menu.</li>
+      <li><b>Player &amp; DM login</b>Log in for cloud features or use the DM link to manage shared tools.</li>
+      <li><b>Save characters</b>Save locally or to the cloud after logging in.</li>
+      <li><b>Offline auto-saving</b>Changes are stored in your browser and sync when you're back online.</li>
     </ul>
     <h4>Frequently Asked Questions</h4>
     <ul class="qa-list">

--- a/styles/main.css
+++ b/styles/main.css
@@ -370,8 +370,9 @@ body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
 .modal .actions{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}
 #modal-help{align-items:flex-start;overflow-y:auto}
 #modal-help .modal{max-height:none}
-#modal-help .feature-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px}
-#modal-help .feature-list li{display:flex;align-items:flex-start;gap:8px}
+#modal-help .feature-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px;font-size:90%}
+#modal-help .feature-list li{display:flex;flex-direction:column;align-items:flex-start;gap:2px}
+#modal-help .feature-list b{display:block}
 #modal-help .feature-list .icon-group{display:flex;gap:4px}
 #modal-help .feature-list svg{width:20px;height:20px;flex-shrink:0}
 #modal-rules{padding:16px}


### PR DESCRIPTION
## Summary
- Stack help modal feature titles above their descriptions
- Shrink help feature text by 10% and ensure bullet-free layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab33638da8832ea72b5590015bd25f