### PR TITLE
Refine SP controls layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,9 +197,9 @@
             <button class="btn-sm" data-sp="-2">-2 SP</button>
             <button class="btn-sm" data-sp="-3">-3 SP</button>
             <button class="btn-sm" data-sp="-4">-4 SP</button>
+            <button class="btn-sm" data-sp="-5">-5 SP</button>
+            <button id="sp-full" class="btn-sm">Reset SP</button>
           </div>
-          <button class="btn-sm" data-sp="-5">-5 SP</button>
-          <button id="sp-full" class="btn-sm">Reset SP</button>
           <button id="long-rest" class="btn-sm">Long Rest</button>
         </div>
       </fieldset>

--- a/styles/main.css
+++ b/styles/main.css
@@ -344,8 +344,11 @@ progress::-moz-progress-bar{
   30%{transform:scale(1.2);opacity:1;}
   100%{transform:scale(1);opacity:0;}
 }
-.sp-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;flex:1;}
+.sp-grid{display:grid;grid-auto-flow:column;grid-template-rows:repeat(2,1fr);grid-auto-columns:1fr;gap:8px;flex:1;}
 .sp-grid .btn-sm{width:100%;}
+
+.sp-field #sp-temp{flex:0 0 60px;max-width:60px;}
+.sp-field #long-rest{flex:0 0 auto;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:12px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .3s ease-in-out}
 .card:focus-within{box-shadow:0 0 0 2px var(--accent),var(--shadow)}
 .card.dragging{opacity:.5}


### PR DESCRIPTION
## Summary
- Enlarge SP bar while shrinking temporary SP input
- Evenly distribute SP adjustment buttons and place Reset beneath -5

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab9d35a1b0832eab32765613cc78e7