### PR TITLE
Revamp resonance point controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,12 +170,6 @@
         <button type="button" class="rp-dot" data-rp="5" aria-pressed="false" aria-label="Set RP to 5"></button>
       </div>
 
-      <div class="rp-controls">
-        <button type="button" id="rp-award" aria-label="Award 1 Resonance Point">+1 RP</button>
-        <button type="button" id="rp-remove" aria-label="Remove 1 Resonance Point">-1 RP</button>
-        <button type="button" id="rp-reset" aria-label="Reset Resonance Points">Reset RP</button>
-      </div>
-
       <hr class="rp-divide">
 
       <div class="rp-surge">
@@ -199,7 +193,8 @@
         </details>
 
         <div class="rp-surge-controls">
-          <button type="button" id="rp-clear-aftermath" disabled aria-label="Clear Aftermath">Clear Aftermath</button>
+          <button type="button" id="rp-reset" aria-label="Reset Resonance Points">Reset RP</button>
+          <button type="button" id="rp-clear-aftermath" disabled aria-label="Aftermath">Aftermath</button>
         </div>
 
         <div class="rp-tags">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1827,8 +1827,6 @@ CC.RP = (function () {
 
     els.rpValue = q("rp-value");
     els.rpDots = Array.from(document.querySelectorAll("#resonance-points .rp-dot"));
-    els.btnAward = q("rp-award");
-    els.btnRemove = q("rp-remove");
     els.btnReset = q("rp-reset");
     els.chkSurge = q("rp-trigger");
     els.btnClearAftermath = q("rp-clear-aftermath");
@@ -1846,8 +1844,6 @@ CC.RP = (function () {
   }
 
   function wireEvents() {
-    els.btnAward.addEventListener("click", () => setRP(state.rp + 1));
-    els.btnRemove.addEventListener("click", () => setRP(state.rp - 1));
     els.btnReset.addEventListener("click", () => { endSurge("reset"); setRP(0); });
     els.rpDots.forEach(btn => btn.addEventListener("click", () => setRP(parseInt(btn.dataset.rp, 10))));
     els.chkSurge.addEventListener("change", e => { if (e.target.checked) triggerSurge(); else endSurge("toggle"); });

--- a/styles/main.css
+++ b/styles/main.css
@@ -523,17 +523,14 @@ select[required]:valid{
 #resonance-points .subtext { font-size: 0.9rem; opacity: 0.85; }
 .rp-row { display: flex; justify-content: space-between; align-items: center; margin: 6px 0 10px; }
 .rp-label { font-weight: 600; }
-.rp-track { display: flex; gap: 8px; margin: 6px 0 12px; }
-.rp-dot { inline-size: 28px; block-size: 28px; border-radius: 50%; border: 2px solid var(--line, #bbb); background: var(--bg, #fff); }
+.rp-track { display: flex; justify-content: center; gap: 8px; margin: 6px 0 12px; }
+.rp-dot { inline-size: 14px; block-size: 14px; border-radius: 50%; border: 2px solid var(--line, #bbb); background: var(--bg, #fff); }
 .rp-dot[aria-pressed="true"] { background: var(--accent, #222); border-color: var(--accent, #222); }
-.rp-controls, .rp-surge-controls { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 8px; margin: 10px 0; }
+.rp-surge-controls { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 8px; margin: 10px 0; }
 .rp-divide { margin: 12px 0; }
 .rp-surge-status { margin: 6px 0 8px; }
 .rp-list { margin: 6px 0; padding-left: 18px; }
 .rp-tags { display: flex; gap: 8px; margin-top: 8px; }
 .tag { font-size: 0.8rem; padding: 2px 8px; border-radius: 999px; background: #e9f5ff; color: #0a5; border: 1px solid #bfe6ff; }
 .tag.warn { background: #fff5e5; color: #a65; border-color: #ffd9a1; }
-@media (max-width: 480px) {
-  .rp-controls, .rp-surge-controls { grid-template-columns: repeat(2, minmax(0,1fr)); }
-}
 


### PR DESCRIPTION
## Summary
- Center and shrink resonance point dots
- Remove incremental RP buttons and place reset beside aftermath
- Rename "Clear Aftermath" button to "Aftermath"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0818a008832e9737dcad1d809c13