### PR TITLE
Remove number input spinners

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -88,6 +88,15 @@ label{display:block;font-weight:700;margin-bottom:6px}
 input:not([type="checkbox"]),select,textarea,button{-webkit-appearance:none;-moz-appearance:none;appearance:none;width:auto;max-width:100%;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:12px;transition:var(--transition)}
 input:not([type="checkbox"]),select,textarea{width:100%}
 select{background-image:var(--chevron);background-repeat:no-repeat;background-position:right 12px center;background-size:16px;padding-right:40px}
+/* Hide number input spinners */
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button{
+  -webkit-appearance:none;
+  margin:0;
+}
+input[type="number"]{
+  -moz-appearance:textfield;
+}
 input[type="checkbox"]{\
   -webkit-appearance:none;\
   -moz-appearance:none;\


### PR DESCRIPTION
## Summary
- hide up/down spinner controls for all number inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac0ab10890832e9b27f18c9e00956a