### PR TITLE
Fit resonance points alongside battle stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,71 +201,73 @@
       </fieldset>
     </div>
 
-    <fieldset class="card">
-      <legend>Battle Stats</legend>
-      <label for="initiative">Initiative Bonus</label>
-      <input id="initiative" type="text" inputmode="numeric" placeholder="auto from DEX + bonuses" readonly/>
-      <label for="speed">Speed (ft)</label>
-      <input id="speed" type="number" inputmode="numeric" placeholder="30"/>
-      <label for="pp">Passive Perception</label>
-      <input id="pp" type="number" readonly/>
-      <label for="tc">TC</label>
-      <input id="tc" type="number" readonly/>
-    </fieldset>
+    <div class="grid grid-2">
+      <fieldset class="card">
+        <legend>Battle Stats</legend>
+        <label for="initiative">Initiative Bonus</label>
+        <input id="initiative" type="text" inputmode="numeric" placeholder="auto from DEX + bonuses" readonly/>
+        <label for="speed">Speed (ft)</label>
+        <input id="speed" type="number" inputmode="numeric" placeholder="30"/>
+        <label for="pp">Passive Perception</label>
+        <input id="pp" type="number" readonly/>
+        <label for="tc">TC</label>
+        <input id="tc" type="number" readonly/>
+      </fieldset>
+
+      <fieldset id="resonance-points" class="card">
+        <legend>Resonance Points (RP)</legend>
+        <p>
+          Resonance Points are awarded by the GM for truly heroic acts. At <strong>5 RP</strong>, trigger a Heroic Surge for temporary boosts.
+        </p>
+
+        <div class="rp-row">
+          <label class="rp-label" for="rp-value">Current RP</label>
+          <output id="rp-value" aria-live="polite">0</output>
+        </div>
+
+        <div class="rp-track" role="group" aria-label="Resonance Points Track">
+          <button type="button" class="rp-dot" data-rp="1" aria-pressed="false" aria-label="Set RP to 1"></button>
+          <button type="button" class="rp-dot" data-rp="2" aria-pressed="false" aria-label="Set RP to 2"></button>
+          <button type="button" class="rp-dot" data-rp="3" aria-pressed="false" aria-label="Set RP to 3"></button>
+          <button type="button" class="rp-dot" data-rp="4" aria-pressed="false" aria-label="Set RP to 4"></button>
+          <button type="button" class="rp-dot" data-rp="5" aria-pressed="false" aria-label="Set RP to 5"></button>
+        </div>
+
+        <hr class="rp-divide">
+
+        <div class="rp-surge">
+          <div class="rp-surge-status" aria-live="polite">
+            <label class="inline" for="rp-trigger">
+              <input type="checkbox" id="rp-trigger" disabled aria-label="Activate Heroic Surge"/>
+              <strong>Heroic Surge:</strong> <span id="rp-surge-state">Inactive</span>
+            </label>
+          </div>
+
+          <details id="rp-surge-details">
+            <summary>Heroic Surge Effects</summary>
+            <ul class="rp-list">
+              <li>Roleplay checks: +2 to CHA/WIS/INT (leadership, persuasion, interpretation)</li>
+              <li>Combat: +1d4 to all attack rolls and saving throws</li>
+              <li>SP Flow: +1 SP regenerated per round</li>
+              <li>Bonus XP: grant at session end (GM)</li>
+            </ul>
+            <p class="subtext">Duration: 1 encounter or 10 minutes of narrative time</p>
+            <p class="subtext">Aftermath: first save at disadvantage; first round next combat regenerate 1 fewer SP</p>
+          </details>
+
+          <div class="rp-surge-controls">
+            <button type="button" id="rp-reset" aria-label="Reset Resonance Points">Reset RP</button>
+            <button type="button" id="rp-clear-aftermath" disabled aria-label="Aftermath">Aftermath</button>
+          </div>
+
+          <div class="rp-tags">
+            <span id="rp-tag-active" hidden class="tag">Surge Active</span>
+            <span id="rp-tag-aftermath" hidden class="tag warn">Aftermath Pending</span>
+          </div>
+        </div>
+      </fieldset>
+    </div>
   </fieldset>
-
-  <section data-tab="combat" id="resonance-points" class="card">
-    <h3>Resonance Points (RP)</h3>
-    <p>
-      Resonance Points are awarded by the GM for truly heroic acts. At <strong>5 RP</strong>, trigger a Heroic Surge for temporary boosts.
-    </p>
-
-    <div class="rp-row">
-      <label class="rp-label" for="rp-value">Current RP</label>
-      <output id="rp-value" aria-live="polite">0</output>
-    </div>
-
-    <div class="rp-track" role="group" aria-label="Resonance Points Track">
-      <button type="button" class="rp-dot" data-rp="1" aria-pressed="false" aria-label="Set RP to 1"></button>
-      <button type="button" class="rp-dot" data-rp="2" aria-pressed="false" aria-label="Set RP to 2"></button>
-      <button type="button" class="rp-dot" data-rp="3" aria-pressed="false" aria-label="Set RP to 3"></button>
-      <button type="button" class="rp-dot" data-rp="4" aria-pressed="false" aria-label="Set RP to 4"></button>
-      <button type="button" class="rp-dot" data-rp="5" aria-pressed="false" aria-label="Set RP to 5"></button>
-    </div>
-
-    <hr class="rp-divide">
-
-    <div class="rp-surge">
-      <div class="rp-surge-status" aria-live="polite">
-        <label class="inline" for="rp-trigger">
-          <input type="checkbox" id="rp-trigger" disabled aria-label="Activate Heroic Surge"/>
-          <strong>Heroic Surge:</strong> <span id="rp-surge-state">Inactive</span>
-        </label>
-      </div>
-
-      <details id="rp-surge-details">
-        <summary>Heroic Surge Effects</summary>
-        <ul class="rp-list">
-          <li>Roleplay checks: +2 to CHA/WIS/INT (leadership, persuasion, interpretation)</li>
-          <li>Combat: +1d4 to all attack rolls and saving throws</li>
-          <li>SP Flow: +1 SP regenerated per round</li>
-          <li>Bonus XP: grant at session end (GM)</li>
-        </ul>
-        <p class="subtext">Duration: 1 encounter or 10 minutes of narrative time</p>
-        <p class="subtext">Aftermath: first save at disadvantage; first round next combat regenerate 1 fewer SP</p>
-      </details>
-
-      <div class="rp-surge-controls">
-        <button type="button" id="rp-reset" aria-label="Reset Resonance Points">Reset RP</button>
-        <button type="button" id="rp-clear-aftermath" disabled aria-label="Aftermath">Aftermath</button>
-      </div>
-
-      <div class="rp-tags">
-        <span id="rp-tag-active" hidden class="tag">Surge Active</span>
-        <span id="rp-tag-aftermath" hidden class="tag warn">Aftermath Pending</span>
-      </div>
-    </div>
-  </section>
 
   <fieldset data-tab="combat" class="card">
     <h2 class="card-title">Status Effects</h2>

--- a/styles/main.css
+++ b/styles/main.css
@@ -548,7 +548,6 @@ select[required]:valid{
 .wizard-nav{display:flex;justify-content:space-between;align-items:center;margin-top:16px}
 #wizard-progress{flex:1;text-align:center}
 
-#resonance-points.card { padding: 12px; border: 1px solid var(--line, #ddd); border-radius: 8px; }
 #resonance-points .subtext { font-size: 0.9rem; opacity: 0.85; }
 .rp-row { display: flex; justify-content: space-between; align-items: center; margin: 6px 0 10px; }
 .rp-label { font-weight: 600; }


### PR DESCRIPTION
## Summary
- Place Resonance Points card to the right of Battle Stats in combat layout
- Remove unused standalone resonance styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac20d56834832e9101f223cb897d8a