### PR TITLE
style: render checkboxes as 10px dots

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -97,25 +97,25 @@ input[type="number"]::-webkit-outer-spin-button{
 input[type="number"]{
   -moz-appearance:textfield;
 }
-input[type="checkbox"]{\
-  -webkit-appearance:none;\
-  -moz-appearance:none;\
-  appearance:none;\
-  flex:0 0 auto;\
-  margin:0 4px 0 0;\
-  inline-size:10.5px;\
-  block-size:10.5px;\
-  border-radius:50%;\
-  border:1.5px solid var(--line, #bbb);\
-  background:var(--bg, #fff);\
+input[type="checkbox"]{
+  -webkit-appearance:none;
+  -moz-appearance:none;
+  appearance:none;
+  flex:0 0 auto;
+  margin:0 4px 0 0;
+  width:10px;
+  height:10px;
+  border-radius:50%;
+  border:1.5px solid var(--line, #bbb);
+  background:var(--bg, #fff);
 }
-input[type="checkbox"]:focus-visible{\
-  outline:2px solid var(--accent);\
-  outline-offset:2px;\
+input[type="checkbox"]:focus-visible{
+  outline:2px solid var(--accent);
+  outline-offset:2px;
 }
-input[type="checkbox"]:checked{\
-  background:var(--accent, #222);\
-  border-color:var(--accent, #222);\
+input[type="checkbox"]:checked{
+  background:var(--accent, #222);
+  border-color:var(--accent, #222);
 }
 button{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:var(--text-on-accent);border:none;font-weight:700;min-height:44px;cursor:pointer;box-shadow:0 2px 4px rgba(0,0,0,.2);touch-action:manipulation}
 button:hover{filter:brightness(1.1);transform:translateY(-1px)}


### PR DESCRIPTION
## Summary
- style checkboxes as small 10px circles instead of default boxes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac31209778832ea153595393633ad6