### PR TITLE
Consolidate status effects into battle stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,8 @@
         <input id="pp" type="number" readonly/>
         <label for="tc">TC</label>
         <input id="tc" type="number" readonly/>
+        <h3>Status Effects</h3>
+        <div id="statuses" class="grid grid-2"></div>
       </fieldset>
 
       <fieldset id="resonance-points" class="card">
@@ -243,8 +245,8 @@
             </label>
           </div>
 
-          <details id="rp-surge-details">
-            <summary>Heroic Surge Effects</summary>
+          <div id="rp-surge-details">
+            <h3>Heroic Surge Effects</h3>
             <ul class="rp-list">
               <li>Roleplay checks: +2 to CHA/WIS/INT (leadership, persuasion, interpretation)</li>
               <li>Combat: +1d4 to all attack rolls and saving throws</li>
@@ -253,7 +255,7 @@
             </ul>
             <p class="subtext">Duration: 1 encounter or 10 minutes of narrative time</p>
             <p class="subtext">Aftermath: first save at disadvantage; first round next combat regenerate 1 fewer SP</p>
-          </details>
+          </div>
 
           <div class="rp-surge-controls">
             <button type="button" id="rp-reset" aria-label="Reset Resonance Points">Reset RP</button>
@@ -267,11 +269,6 @@
         </div>
       </fieldset>
     </div>
-  </fieldset>
-
-  <fieldset data-tab="combat" class="card">
-    <h2 class="card-title">Status Effects</h2>
-    <div id="statuses" class="grid grid-2"></div>
   </fieldset>
 
   <!-- ABILITIES -->

--- a/styles/main.css
+++ b/styles/main.css
@@ -83,7 +83,7 @@ footer p{max-width:none}
 .grid-3{grid-template-columns:1fr}
 @media(min-width:600px){.grid-2{grid-template-columns:repeat(2,1fr)}.grid-3{grid-template-columns:repeat(2,1fr)}}
 @media(min-width:900px){.grid-3{grid-template-columns:repeat(3,1fr)}}
-#statuses{grid-template-columns:repeat(2,1fr)}
+#statuses{grid-template-columns:repeat(2,1fr);margin-top:8px}
 label{display:block;font-weight:700;margin-bottom:6px}
 input:not([type="checkbox"]),select,textarea,button{-webkit-appearance:none;-moz-appearance:none;appearance:none;width:auto;max-width:100%;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:12px;transition:var(--transition)}
 input:not([type="checkbox"]),select,textarea{width:100%}
@@ -567,6 +567,7 @@ select[required]:valid{
 .rp-surge-controls { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 8px; margin: 10px 0; }
 .rp-divide { margin: 12px 0; }
 .rp-surge-status { margin: 6px 0 8px; }
+#rp-surge-details { margin: 6px 0 8px; }
 .rp-list { margin: 6px 0; padding-left: 18px; }
 .rp-tags { display: flex; gap: 8px; margin-top: 8px; }
 .tag { font-size: 0.8rem; padding: 2px 8px; border-radius: 999px; background: #e9f5ff; color: #0a5; border: 1px solid #bfe6ff; }


### PR DESCRIPTION
## Summary
- Move Status Effects under Battle Stats after TC
- Show Heroic Surge Effects by default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac333c61fc832eac042e15d23e20e0