### PR TITLE
Rename Battle Stats section and reduce Status Effects text

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
 
     <div class="grid grid-2">
       <fieldset class="card">
-        <legend>Battle Stats</legend>
+        <legend>Stats and Effects</legend>
         <label for="initiative">Initiative Bonus</label>
         <input id="initiative" type="text" inputmode="numeric" placeholder="auto from DEX + bonuses" readonly/>
         <label for="speed">Speed (ft)</label>
@@ -212,8 +212,10 @@
         <input id="pp" type="number" readonly/>
         <label for="tc">TC</label>
         <input id="tc" type="number" readonly/>
-        <h3>Status Effects</h3>
-        <div id="statuses" class="grid grid-2"></div>
+        <div class="status-effects">
+          <h3>Status Effects</h3>
+          <div id="statuses" class="grid grid-2"></div>
+        </div>
       </fieldset>
 
       <fieldset id="resonance-points" class="card">

--- a/styles/main.css
+++ b/styles/main.css
@@ -84,6 +84,7 @@ footer p{max-width:none}
 @media(min-width:600px){.grid-2{grid-template-columns:repeat(2,1fr)}.grid-3{grid-template-columns:repeat(2,1fr)}}
 @media(min-width:900px){.grid-3{grid-template-columns:repeat(3,1fr)}}
 #statuses{grid-template-columns:repeat(2,1fr);margin-top:8px}
+.status-effects{font-size:90%}
 label{display:block;font-weight:700;margin-bottom:6px}
 input:not([type="checkbox"]),select,textarea,button{-webkit-appearance:none;-moz-appearance:none;appearance:none;width:auto;max-width:100%;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:12px;transition:var(--transition)}
 input:not([type="checkbox"]),select,textarea{width:100%}


### PR DESCRIPTION
## Summary
- rename Battle Stats section to Stats and Effects
- shrink Status Effects text by 10%

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac36bf786c832e86ae5b6d929ddb19