### PR TITLE
Fix Enhanced Human perk ability reversion

### DIFF
--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -1,4 +1,4 @@
-import { num, mod, calculateArmorBonus, proficiencyBonus, wizardProgress } from '../scripts/helpers.js';
+import { num, mod, calculateArmorBonus, proficiencyBonus, wizardProgress, revertAbilityScore } from '../scripts/helpers.js';
 
 describe('num', () => {
   test('converts strings to numbers and defaults to 0', () => {
@@ -87,5 +87,12 @@ describe('wizardProgress', () => {
 
   test('handles non-positive totals', () => {
     expect(wizardProgress(0, 0)).toBe('Step 1 of 1 (100%)');
+  });
+});
+
+describe('revertAbilityScore', () => {
+  test('decreases ability score by one without clamping to 10', () => {
+    expect(revertAbilityScore(9)).toBe(8);
+    expect(revertAbilityScore(1)).toBe(0);
   });
 });

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -12,6 +12,11 @@ export const proficiencyBonus = (level) => {
   const lvl = Math.max(1, num(level));
   return Math.floor((lvl - 1) / 4) + 2;
 };
+// When reverting temporary ability score increases, simply subtract the bonus
+// without enforcing a 10-point floor. Ability scores in the system may start
+// below 10, so clamping to that value would incorrectly inflate low abilities
+// when a perk is removed.
+export const revertAbilityScore = (score) => Math.max(0, num(score) - 1);
 export const wizardProgress = (i, total) => {
   const curr = Math.max(1, Math.min(num(i) + 1, num(total)));
   const max = Math.max(num(total), curr);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,5 +1,5 @@
 /* ========= helpers ========= */
-import { $, qs, qsa, num, mod, calculateArmorBonus, wizardProgress } from './helpers.js';
+import { $, qs, qsa, num, mod, calculateArmorBonus, wizardProgress, revertAbilityScore } from './helpers.js';
 import { saveLocal, saveCloud } from './storage.js';
 import { currentPlayer, getPlayers, loadPlayerCharacter, isDM } from './users.js';
 import { show, hide } from './modal.js';
@@ -497,7 +497,7 @@ function handlePerkEffects(li, text){
       if(enhancedAbility && enhancedAbility !== key){
         const elPrev = $(enhancedAbility);
         if(elPrev){
-          const reverted = Math.max(10, Number(elPrev.value) - 1);
+          const reverted = revertAbilityScore(elPrev.value);
           elPrev.value = String(reverted);
           elPrev.dispatchEvent(new Event('change', { bubbles: true }));
         }
@@ -552,7 +552,7 @@ function setupPerkSelect(selId, perkId, data){
     if(selId==='classification' && enhancedAbility){
       const elPrev = $(enhancedAbility);
       if(elPrev){
-        const reverted = Math.max(10, Number(elPrev.value) - 1);
+        const reverted = revertAbilityScore(elPrev.value);
         elPrev.value = String(reverted);
         elPrev.dispatchEvent(new Event('change', { bubbles: true }));
       }


### PR DESCRIPTION
## Summary
- avoid clamping Enhanced Human ability bonus to 10 when switching perks
- add helper to revert temporary ability score boosts
- cover new helper with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac391f1d88832e8fb111bf5f923a4a