### PR TITLE
fix: prevent animations on iOS refresh

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -19,7 +19,7 @@ const enableAnimations = () => { animationsEnabled = true; };
 // interaction.
 document.addEventListener('click', enableAnimations, { once: true, capture: true });
 document.addEventListener('keydown', enableAnimations, { once: true, capture: true });
-document.addEventListener('touchstart', enableAnimations, { once: true, capture: true });
+// Avoid using 'touchstart' so pull-to-refresh on iOS doesn't enable animations
 
 /* ========= viewport ========= */
 function setVh(){


### PR DESCRIPTION
## Summary
- avoid using `touchstart` to unlock animations so iOS pull-to-refresh doesn't trigger them

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac464c7ab8832eab4cc47fcc68c8d7