### PR TITLE
feat: add logo to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
       </svg>
     </button>
-      <span class="tabs-title">Catalyst Core</span>
+      <span class="tabs-title"><img src="images/Logo.png" alt="Catalyst Core logo" class="logo"/>Catalyst Core</span>
     <div class="dropdown">
       <button id="btn-menu" class="icon" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">

--- a/styles/main.css
+++ b/styles/main.css
@@ -57,6 +57,15 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
   font-weight:700;
   flex:1;
   text-align:center;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:8px;
+}
+
+.tabs-title .logo{
+  height:16px;
+  width:auto;
 }
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{max-width:65ch;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}


### PR DESCRIPTION
## Summary
- add the Catalyst Core logo to the navigation header
- ensure the logo is sized and aligned within the header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6d1b281fc832e9baebbe440f303da