### PR TITLE
Restructure header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 
 
 <header>
-  <nav class="tabs" role="tablist" aria-label="Primary">
+  <div class="top">
     <button id="btn-theme" class="icon" aria-label="Toggle Theme" type="button">
       <svg id="icon-dark" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/>
@@ -58,6 +58,27 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
       </svg>
     </button>
+      <span class="tabs-title"><img src="images/Logo.png" alt="Catalyst Core logo" class="logo"/>Catalyst Core</span>
+    <div class="dropdown">
+      <button id="btn-menu" class="icon" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15m-15 5.25h15m-15 5.25h15"/>
+        </svg>
+      </button>
+      <div id="menu-actions" class="menu" hidden>
+        <button id="btn-player" class="btn-sm">Log In</button>
+        <button id="btn-save" class="btn-sm">Save</button>
+        <button id="btn-wizard" class="btn-sm" aria-label="Character creation wizard" title="Character creation wizard">Character wizard</button>
+        <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
+        <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
+        <button id="btn-campaign" class="btn-sm">Campaign Log</button>
+        <button id="btn-rules" class="btn-sm">Rules</button>
+        <button id="btn-help" class="btn-sm">Help</button>
+        <button id="btn-dm" class="btn-sm" hidden>Players</button>
+      </div>
+    </div>
+  </div>
+  <nav class="tabs" role="tablist" aria-label="Primary">
     <button class="tab active" data-go="combat" aria-label="Combat" title="Combat" role="tab" aria-current="page" type="button">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <polyline stroke-linecap="round" stroke-linejoin="round" points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/>
@@ -88,25 +109,6 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
       </svg>
     </button>
-      <span class="tabs-title"><img src="images/Logo.png" alt="Catalyst Core logo" class="logo"/>Catalyst Core</span>
-    <div class="dropdown">
-      <button id="btn-menu" class="icon" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15m-15 5.25h15m-15 5.25h15"/>
-        </svg>
-      </button>
-      <div id="menu-actions" class="menu" hidden>
-        <button id="btn-player" class="btn-sm">Log In</button>
-        <button id="btn-save" class="btn-sm">Save</button>
-        <button id="btn-wizard" class="btn-sm" aria-label="Character creation wizard" title="Character creation wizard">Character wizard</button>
-        <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
-        <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
-        <button id="btn-campaign" class="btn-sm">Campaign Log</button>
-        <button id="btn-rules" class="btn-sm">Rules</button>
-        <button id="btn-help" class="btn-sm">Help</button>
-        <button id="btn-dm" class="btn-sm" hidden>Players</button>
-      </div>
-    </div>
   </nav>
 </header>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -19,7 +19,7 @@ h1,h2,h3,h4{font-family:inherit;line-height:1.25;margin:0 0 .5em}
 h1{font-size:2rem;font-weight:700;color:var(--accent)}
 h2{font-size:1.5rem;font-weight:600;color:var(--accent)}
 h3{font-size:1.25rem;font-weight:600}
-header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(4px * 1.15 + env(safe-area-inset-top)) calc(10px * 1.15) calc(4px * 1.15);-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;justify-content:flex-end}
+header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(4px * 1.15 + env(safe-area-inset-top)) calc(10px * 1.15) calc(4px * 1.15);-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;flex-direction:column;gap:calc(6px * 1.15)}
 header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(calc(-10px * 1.15))}
 .actions{display:flex;gap:calc(6px * 1.15);flex-wrap:wrap}
 .dropdown{position:relative;display:flex;align-items:center}
@@ -30,7 +30,6 @@ header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(calc(-
 .menu .btn-sm{justify-content:flex-start}
 @media(max-width:600px){
   .actions{justify-content:center}
-  .tabs{justify-content:space-evenly}
 }
 .icon,.tab{padding:calc(2px * 1.15);width:calc(23px * 1.15);height:calc(23px * 1.15);min-height:calc(27px * 1.15);aspect-ratio:1/1;border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition);cursor:pointer;touch-action:manipulation}
 .icon svg,.tab svg{width:calc(23px * 1.15);height:calc(23px * 1.15)}
@@ -47,8 +46,8 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 [data-tip]{position:relative;cursor:help}
 [data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
 .breadcrumb,.breadcrumbs{display:none}
-.tabs{display:flex;align-items:center;flex-wrap:wrap;gap:calc(6px * 1.15);width:100%;transition:opacity .4s ease,transform .4s ease}
-.tabs .dropdown{margin-left:auto}
+.top{display:flex;align-items:center;gap:calc(6px * 1.15)}
+.tabs{display:flex;align-items:center;flex-wrap:wrap;gap:calc(6px * 1.15);width:100%;justify-content:space-evenly;transition:opacity .4s ease,transform .4s ease}
 .tabs-title{
   padding:0 8px;
   font-size:clamp(.709rem,3.78vw,.945rem);


### PR DESCRIPTION
## Summary
- split header into top bar with theme toggle, centered logo, and dropdown menu
- move navigation tabs to their own bar below the title
- adjust styles for new stacked header layout and even tab spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6fcdd7468832e8e54c0a1026d2254