### PR TITLE
fix: refresh logo by bumping service worker cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'cccg-cache-v7';
+const CACHE = 'cccg-cache-v8';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- bump service worker cache version to force clients to fetch new assets (logo size updates)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b73a2a0624832e96874cb23d65a585