### PR TITLE
fix: refresh cached button styles

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'cccg-cache-v8';
+const CACHE = 'cccg-cache-v9';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- bump service worker cache name to v9 so header button width changes load for clients

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b73d238238832eb5e2adb01973f2f8