### PR TITLE
Adjust tab widths to fit five buttons on one line

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -31,7 +31,9 @@ header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(calc(-
 @media(max-width:600px){
   .actions{justify-content:center}
 }
-.icon,.tab{padding:calc(2px * 1.15);width:calc(23px * 1.15 * 3);height:calc(23px * 1.15);min-height:calc(27px * 1.15);border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition);cursor:pointer;touch-action:manipulation}
+.icon,.tab{padding:calc(2px * 1.15);height:calc(23px * 1.15);min-height:calc(27px * 1.15);border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition);cursor:pointer;touch-action:manipulation}
+.icon{width:calc(23px * 1.15 * 3)}
+.tab{width:calc(23px * 1.15 * 2)}
 .icon svg,.tab svg{width:calc(23px * 1.15);height:calc(23px * 1.15)}
 .modal .x svg{width:20px;height:20px}
 .icon svg{transition:transform .3s ease}


### PR DESCRIPTION
## Summary
- narrow top navigation tab buttons so all five fit on a single line

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b73f99e970832e9fc746cc956afef3