### PR TITLE
Refresh after DM auth and hide Players menu

### DIFF
--- a/__tests__/dm_button.test.js
+++ b/__tests__/dm_button.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import '../scripts/users.js';
 
 describe('DM Players button visibility', () => {
@@ -9,19 +10,23 @@ describe('DM Players button visibility', () => {
           <button id="btn-dm" class="btn-sm" hidden>Players</button>
         </div>
       </div>
+      <div id="modal-dm-login" class="overlay hidden"></div>
       <input id="dm-password" />
       <button id="login-dm"></button>
+      <button id="logout-dm"></button>
       <div id="toast"></div>
     `;
     document.dispatchEvent(new Event('DOMContentLoaded'));
   });
 
-  test('hidden by default and visible after DM login', () => {
+  test('hidden by default and toggles with DM login/logout', () => {
     const dmBtn = document.getElementById('btn-dm');
     expect(dmBtn.hidden).toBe(true);
     document.getElementById('dm-password').value = 'Dragons22!';
     document.getElementById('login-dm').click();
     expect(dmBtn.hidden).toBe(false);
+    document.getElementById('logout-dm').click();
+    expect(dmBtn.hidden).toBe(true);
   });
 });
 

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -212,6 +212,12 @@ if (typeof document !== 'undefined') {
     updateDMButton();
     updateDMLoginControls();
 
+    window.addEventListener('playerChanged', () => {
+      updatePlayerButton();
+      updateDMButton();
+      updateDMLoginControls();
+    });
+
     const regBtn = $('register-player');
     if (regBtn) {
       regBtn.addEventListener('click', () => {
@@ -333,6 +339,11 @@ if (typeof document !== 'undefined') {
             modalDMLogin.classList.add('hidden');
             modalDMLogin.setAttribute('aria-hidden','true');
           }
+          try {
+            window.location.reload();
+          } catch (e) {
+            // Ignore reload errors (e.g., during tests)
+          }
         } else {
           toast('Invalid credentials','error');
         }
@@ -349,6 +360,11 @@ if (typeof document !== 'undefined') {
         if (modalDMLogin) {
           modalDMLogin.classList.add('hidden');
           modalDMLogin.setAttribute('aria-hidden','true');
+        }
+        try {
+          window.location.reload();
+        } catch (e) {
+          // Ignore reload errors (e.g., during tests)
         }
       });
     }


### PR DESCRIPTION
## Summary
- refresh the page after DM sign in or sign out to clear frozen state
- toggle DM-only controls on player changes to hide Players menu when logged out
- test DM Players button hides again after DM logout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b75c773f6c832eb009ffcc0726c461