### PR TITLE
Ensure player saves use cloud storage

### DIFF
--- a/__tests__/dm_cloud.test.js
+++ b/__tests__/dm_cloud.test.js
@@ -2,8 +2,9 @@ import { jest } from '@jest/globals';
 
 jest.unstable_mockModule('../scripts/storage.js', () => ({
   saveLocal: jest.fn(),
-  loadLocal: jest.fn().mockRejectedValue(new Error('No save found')),
-  loadCloud: jest.fn().mockResolvedValue({ hp: 30 }),
+  loadLocal: jest.fn(),
+  loadCloud: jest.fn(),
+  saveCloud: jest.fn(),
   deleteSave: jest.fn(),
 }));
 
@@ -12,19 +13,33 @@ const storage = await import('../scripts/storage.js');
 
 const { registerPlayer, loginDM, loadPlayerCharacter } = users;
 
-describe('DM cloud fallback', () => {
+describe('DM cloud loading', () => {
   beforeEach(() => {
     localStorage.clear();
-    storage.loadLocal.mockRejectedValue(new Error('No save found'));
-    storage.loadCloud.mockResolvedValue({ hp: 30 });
+    storage.loadLocal.mockReset();
+    storage.loadCloud.mockReset();
+    storage.saveLocal.mockReset();
   });
 
-  test('loads from cloud when local missing', async () => {
+  test('loads from cloud before local', async () => {
     registerPlayer('Eve', 'pw');
+    storage.loadCloud.mockResolvedValue({ hp: 30 });
     expect(loginDM('Dragons22!')).toBe(true);
     const data = await loadPlayerCharacter('Eve');
-    expect(storage.loadLocal).toHaveBeenCalledWith('player:Eve');
     expect(storage.loadCloud).toHaveBeenCalledWith('player:Eve');
+    expect(storage.loadLocal).not.toHaveBeenCalled();
+    expect(storage.saveLocal).toHaveBeenCalledWith('player:Eve', { hp: 30 });
     expect(data.hp).toBe(30);
+  });
+
+  test('falls back to local when cloud fails', async () => {
+    registerPlayer('Eve', 'pw');
+    storage.loadCloud.mockRejectedValue(new Error('No save found'));
+    storage.loadLocal.mockResolvedValue({ hp: 15 });
+    expect(loginDM('Dragons22!')).toBe(true);
+    const data = await loadPlayerCharacter('Eve');
+    expect(storage.loadCloud).toHaveBeenCalledWith('player:Eve');
+    expect(storage.loadLocal).toHaveBeenCalledWith('player:Eve');
+    expect(data.hp).toBe(15);
   });
 });


### PR DESCRIPTION
## Summary
- Load player characters from the cloud first and cache locally
- Save player characters to cloud storage so DM edits sync across devices
- Test cloud-first loading with local fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7b4f73968832e8b12479478b5486a