### PR TITLE
Ensure DM login clears player session and load characters from cloud

### DIFF
--- a/__tests__/dm_cloud.test.js
+++ b/__tests__/dm_cloud.test.js
@@ -6,6 +6,7 @@ jest.unstable_mockModule('../scripts/storage.js', () => ({
   loadCloud: jest.fn(),
   saveCloud: jest.fn(),
   deleteSave: jest.fn(),
+  listCloudSaves: jest.fn(),
 }));
 
 const users = await import('../scripts/users.js');

--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -6,10 +6,12 @@ import {
   loginPlayer,
   logoutPlayer,
   currentPlayer,
+  isDM,
   editPlayerCharacter,
   savePlayerCharacter,
   loadPlayerCharacter,
   recoverPlayerPassword,
+  listCharacters,
 } from '../scripts/users.js';
 
 describe('user management', () => {
@@ -49,6 +51,15 @@ describe('user management', () => {
     expect(currentPlayer()).toBeNull();
   });
 
+  test('dm login logs out current player', () => {
+    registerPlayer('Alice', 'pw', 'pet?', 'cat');
+    expect(loginPlayer('Alice', 'pw')).toBe(true);
+    expect(currentPlayer()).toBe('Alice');
+    expect(loginDM('Dragons22!')).toBe(true);
+    expect(currentPlayer()).toBeNull();
+    expect(isDM()).toBe(true);
+  });
+
   test('dm editing', async () => {
     registerPlayer('Alice', 'pw', 'pet?', 'cat');
     expect(loginDM('Dragons22!')).toBe(true);
@@ -56,6 +67,11 @@ describe('user management', () => {
     await editPlayerCharacter('Alice', { hp: 20 });
     const data = await loadPlayerCharacter('Alice');
     expect(data.hp).toBe(20);
+  });
+
+  test('lists characters from cloud', async () => {
+    const names = await listCharacters(async () => ['player:Bob', 'player:Alice', 'other']);
+    expect(names).toEqual(['Alice', 'Bob']);
   });
 
   test('handles corrupted player storage gracefully', () => {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,7 +1,7 @@
 /* ========= helpers ========= */
 import { $, qs, qsa, num, mod, calculateArmorBonus, wizardProgress, revertAbilityScore } from './helpers.js';
-import { saveLocal, saveCloud, listCloudSaves } from './storage.js';
-import { currentPlayer, getPlayers, loadPlayerCharacter, isDM } from './users.js';
+import { saveLocal, saveCloud } from './storage.js';
+import { currentPlayer, loadPlayerCharacter, isDM, listCharacters } from './users.js';
 import { show, hide } from './modal.js';
 import confetti from 'https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.module.mjs';
 const rulesEl = qs('#rules-text');
@@ -1211,16 +1211,12 @@ async function renderDMList(){
   if(!isDM()) return;
   const list = $('dm-player-list');
   if(!list) return;
-  const players = new Set(getPlayers());
+  let names = [];
   try {
-    const saves = await listCloudSaves();
-    saves.forEach(k => {
-      if (k.startsWith('player:')) players.add(k.slice(7));
-    });
+    names = await listCharacters();
   } catch (e) {
     console.error('Failed to list cloud saves', e);
   }
-  const names = Array.from(players).sort((a, b) => a.localeCompare(b));
   list.innerHTML = names.map(p=>`<div class="catalog-item"><div>${p}</div><div><button class="btn-sm" data-player="${p}">Load</button></div></div>`).join('');
 }
 const dmList = $('dm-player-list');


### PR DESCRIPTION
## Summary
- Log out any current player session when the DM logs in
- Fetch DM character list directly from cloud saves for easy selection
- Add tests covering cloud character listing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c3fc632c832ea23d09d16d2a6345