### PR TITLE
Include local saves when listing characters

### DIFF
--- a/__tests__/dm_cloud.test.js
+++ b/__tests__/dm_cloud.test.js
@@ -7,6 +7,7 @@ jest.unstable_mockModule('../scripts/storage.js', () => ({
   saveCloud: jest.fn(),
   deleteSave: jest.fn(),
   listCloudSaves: jest.fn(),
+  listLocalSaves: jest.fn(),
 }));
 
 const users = await import('../scripts/users.js');

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -1,4 +1,4 @@
-import { saveLocal, loadLocal, deleteSave } from '../scripts/storage.js';
+import { saveLocal, loadLocal, deleteSave, listLocalSaves } from '../scripts/storage.js';
 
 describe('saveLocal/loadLocal', () => {
   beforeEach(() => {
@@ -19,6 +19,12 @@ describe('saveLocal/loadLocal', () => {
     await expect(loadLocal('remove')).rejects.toThrow('No save found');
     expect(localStorage.getItem('save:remove')).toBeNull();
     expect(localStorage.getItem('last-save')).toBeNull();
+  });
+
+  test('lists local saves', async () => {
+    await saveLocal('player:Alpha', {});
+    await saveLocal('player:Beta', {});
+    expect(listLocalSaves()).toEqual(['player:Alpha', 'player:Beta']);
   });
 });
 

--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -13,6 +13,7 @@ import {
   recoverPlayerPassword,
   listCharacters,
 } from '../scripts/users.js';
+import { saveLocal } from '../scripts/storage.js';
 
 describe('user management', () => {
   beforeEach(() => {
@@ -72,6 +73,12 @@ describe('user management', () => {
   test('lists characters from cloud', async () => {
     const names = await listCharacters(async () => ['player:Bob', 'player:Alice', 'other']);
     expect(names).toEqual(['Alice', 'Bob']);
+  });
+
+  test('merges local saves when listing characters', async () => {
+    await saveLocal('player:Eve', {});
+    const names = await listCharacters(async () => ['player:Bob']);
+    expect(names).toEqual(['Bob', 'Eve']);
   });
 
   test('handles corrupted player storage gracefully', () => {

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -29,6 +29,20 @@ export async function deleteSave(name) {
   }
 }
 
+export function listLocalSaves() {
+  try {
+    const keys = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.startsWith('save:')) keys.push(k.slice(5));
+    }
+    return keys.sort((a, b) => a.localeCompare(b));
+  } catch (e) {
+    console.error('Local list failed', e);
+    return [];
+  }
+}
+
 // ===== Firebase Cloud Save =====
 // Lazily load the Firebase SDK modules from the official CDN so tests
 // and environments without Firebase still work.

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -1,4 +1,4 @@
-import { saveLocal, loadLocal, loadCloud, saveCloud, listCloudSaves } from './storage.js';
+import { saveLocal, loadLocal, loadCloud, saveCloud, listCloudSaves, listLocalSaves } from './storage.js';
 import { $ } from './helpers.js';
 import { show as showModal, hide as hideModal } from './modal.js';
 
@@ -166,17 +166,24 @@ export function editPlayerCharacter(player, data) {
   return savePlayerCharacter(player, data);
 }
 
-export async function listCharacters(listFn = listCloudSaves) {
+export async function listCharacters(listFn = listCloudSaves, localFn = listLocalSaves) {
+  let cloud = [];
   try {
-    const saves = await listFn();
-    return saves
-      .filter(k => k.startsWith('player:'))
-      .map(k => k.slice(7))
-      .sort((a, b) => a.localeCompare(b));
+    cloud = await listFn();
   } catch (e) {
     console.error('Failed to list cloud saves', e);
-    return [];
   }
+  let local = [];
+  try {
+    local = await localFn();
+  } catch (e) {
+    console.error('Failed to list local saves', e);
+  }
+  const saves = Array.from(new Set([...cloud, ...local]));
+  return saves
+    .filter(k => k.startsWith('player:'))
+    .map(k => k.slice(7))
+    .sort((a, b) => a.localeCompare(b));
 }
 
 // ===== DOM Wiring =====


### PR DESCRIPTION
## Summary
- Add `listLocalSaves` helper to enumerate local storage save keys
- Merge cloud and local entries in `listCharacters` so DMs see all players
- Test local save listing and merged character list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7cb18be98832e84e0fb5ffd6e2c8a