### PR TITLE
Fix DM player list to include cloud saves

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -20,6 +20,10 @@ describe('user management', () => {
     localStorage.clear();
   });
 
+  afterEach(() => {
+    delete global.fetch;
+  });
+
     test('registers players and lists them alphabetically', () => {
       // Register out of order to ensure getPlayers sorts names
       expect(registerPlayer('Bob', 'b', 'pet?', 'dog')).toBe(true);
@@ -102,6 +106,15 @@ describe('user management', () => {
   test('lists characters from cloud regardless of key casing', async () => {
     const names = await listCharacters(async () => ['PLAYER:Charlie', 'player:alice']);
     expect(names).toEqual(['alice', 'Charlie']);
+  });
+
+  test('lists characters with encoded cloud keys', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ 'player%3ABob': {}, 'player%3AAlice': {} }),
+    });
+    const names = await listCharacters();
+    expect(names).toEqual(['Alice', 'Bob']);
   });
 
   test('handles corrupted player storage gracefully', () => {

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -96,7 +96,9 @@ export async function listCloudSaves() {
     const res = await fetch(`${CLOUD_SAVES_URL}.json`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const val = await res.json();
-    return val ? Object.keys(val) : [];
+    // Keys in the realtime database are URL-encoded because we escape them when
+    // saving. Decode them here so callers receive the original player names.
+    return val ? Object.keys(val).map(k => decodeURIComponent(k)) : [];
   } catch (e) {
     console.error('Cloud list failed', e);
     return [];


### PR DESCRIPTION
## Summary
- Decode URL-encoded Firebase keys so `listCharacters` returns all cloud saves
- Add regression test for encoded cloud keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e2c41d14832e89c6a5335f6748db