### PR TITLE
Decode player save keys for complete character list

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -117,6 +117,12 @@ describe('user management', () => {
     expect(names).toEqual(['Alice', 'Bob']);
   });
 
+
+  test('lists characters with encoded local keys', async () => {
+    const names = await listCharacters(async () => [], async () => ['player%3AEve']);
+    expect(names).toEqual(['Eve']);
+  });
+
   test('handles corrupted player storage gracefully', () => {
     localStorage.setItem('players', '{not valid json');
     expect(getPlayers()).toEqual([]);


### PR DESCRIPTION
## Summary
- Decode and merge cloud/local save keys when listing characters
- Handle name casing and de-duplicate character names
- Test encoded local save keys

## Testing
- `node_modules/.bin/jest` *(fails: `/usr/bin/env: ‘node’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f6207264832ebb28500f7b2a5a5e