### PR TITLE
Fix character list decoding for percent-containing names

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -123,6 +123,16 @@ describe('user management', () => {
     expect(names).toEqual(['Eve']);
   });
 
+  test('lists and loads characters with percent signs in the name', async () => {
+    registerPlayer('A%20B', 'pw', 'pet?', 'cat');
+    expect(loginPlayer('A%20B', 'pw')).toBe(true);
+    await savePlayerCharacter('A%20B', { hp: 7 });
+    const names = await listCharacters();
+    expect(names).toEqual(['A%20B']);
+    const data = await loadPlayerCharacter('A%20B');
+    expect(data.hp).toBe(7);
+  });
+
   test('handles corrupted player storage gracefully', () => {
     localStorage.setItem('players', '{not valid json');
     expect(getPlayers()).toEqual([]);


### PR DESCRIPTION
## Summary
- avoid double-decoding save keys so player names with `%` are preserved
- add regression test verifying characters with `%` in their names list and load correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7fb0ac658832e8c76e854957809ad