### PR TITLE
Trim whitespace during registration

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -41,6 +41,14 @@ describe('user management', () => {
     expect(getPlayers()).toEqual([]);
   });
 
+  test('registration rejects whitespace-only fields', () => {
+    registerPlayer('   ', 'pw', 'q', 'a');
+    registerPlayer('Frank', '   ', 'q', 'a');
+    registerPlayer('Grace', 'pw', '   ', 'a');
+    registerPlayer('Heidi', 'pw', 'q', '   ');
+    expect(getPlayers()).toEqual([]);
+  });
+
   test('player login and save', async () => {
     registerPlayer('Alice', 'pass', 'pet?', 'cat');
     expect(loginPlayer('Alice', 'pass')).toBe(true);

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -68,6 +68,14 @@ export function getPlayers() {
 }
 
 export function registerPlayer(name, password, question, answer) {
+  // Trim inputs to ensure that values consisting solely of whitespace are
+  // treated as empty. This prevents registering accounts with blank names or
+  // other fields that appear empty to users.
+  name = name ? name.trim() : '';
+  password = password ? password.trim() : '';
+  question = question ? question.trim() : '';
+  answer = answer ? answer.trim() : '';
+
   const players = getPlayersRaw();
   if (!name || !password || !question || !answer || players[name]) {
     return false;


### PR DESCRIPTION
## Summary
- Trim and validate registration inputs to reject whitespace-only fields
- Add regression test for whitespace-only registration fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7fd1ed328832e89ec579db421ef88