### PR TITLE
Add Firebase initialization to client

### DIFF
--- a/index.html
+++ b/index.html
@@ -942,6 +942,11 @@
 <div id="coin-animation" aria-hidden="true"></div>
 <div id="sp-animation" aria-hidden="true"></div>
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
+<script src="https://www.gstatic.com/firebasejs/10.12.3/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.3/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.3/firebase-database-compat.js"></script>
+<script src="scripts/firebase-config.js"></script>
+<script src="scripts/firebase-init.js"></script>
 <script type="module" src="scripts/main.js"></script>
 
 </body>

--- a/scripts/firebase-config.js
+++ b/scripts/firebase-config.js
@@ -1,0 +1,8 @@
+// Firebase client configuration for the Catalyst Core app.
+// Values are derived from the provided Firebase project settings.
+window.firebaseConfig = {
+  apiKey: 'AIzaSyA3DZNONr73L62eERENpVOnujzyxhoiydY',
+  authDomain: 'ccccg-7d6b6.firebaseapp.com',
+  databaseURL: 'https://ccccg-7d6b6-default-rtdb.firebaseio.com',
+  projectId: 'ccccg-7d6b6'
+};

--- a/scripts/firebase-init.js
+++ b/scripts/firebase-init.js
@@ -1,0 +1,17 @@
+// Initialize Firebase if the configuration and SDK are available.
+function initFirebase() {
+  if (!window.firebase || !window.firebaseConfig) return;
+  try {
+    if (!window.firebase.apps || !window.firebase.apps.length) {
+      window.firebase.initializeApp(window.firebaseConfig);
+    }
+  } catch (e) {
+    console.error('Firebase initialization failed', e);
+  }
+}
+
+// Automatically initialize when running in the browser.
+if (typeof window !== 'undefined') {
+  window.initFirebase = initFirebase;
+  initFirebase();
+}


### PR DESCRIPTION
## Summary
- load Firebase SDK and config for project `ccccg-7d6b6`
- add helper to initialize Firebase when config is present
- supply real Web API Key and include Realtime Database SDK

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b81fbc73b4832eb45b4ef90b4d8ba0