### PR TITLE
fix: handle Firebase anonymous sign-in credential

### DIFF
--- a/__tests__/storage_cloud.test.js
+++ b/__tests__/storage_cloud.test.js
@@ -1,0 +1,24 @@
+import { jest } from '@jest/globals';
+import { listCloudSaves } from '../scripts/storage.js';
+
+test('listCloudSaves uses id token from anonymous sign in', async () => {
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(null),
+  });
+  global.fetch = fetchMock;
+  const getIdToken = jest.fn().mockResolvedValue('TOKEN123');
+  const signInAnonymously = jest.fn().mockResolvedValue({ user: { getIdToken } });
+  const auth = { currentUser: null, signInAnonymously };
+  window.firebase = { auth: () => auth };
+
+  await listCloudSaves();
+
+  expect(signInAnonymously).toHaveBeenCalled();
+  expect(fetchMock).toHaveBeenCalled();
+  const url = fetchMock.mock.calls[0][0];
+  expect(url).toContain('auth=TOKEN123');
+
+  delete window.firebase;
+});


### PR DESCRIPTION
## Summary
- handle Firebase sign-in returning UserCredential to obtain auth token
- test id token is appended to cloud save requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8223ef5f8832eb0417bc6cd222ba0