### PR TITLE
Handle non-function getIdToken in cloud save auth

### DIFF
--- a/__tests__/storage_cloud.test.js
+++ b/__tests__/storage_cloud.test.js
@@ -1,7 +1,12 @@
 import { jest } from '@jest/globals';
-import { listCloudSaves } from '../scripts/storage.js';
+
+afterEach(() => {
+  delete global.fetch;
+  delete window.firebase;
+});
 
 test('listCloudSaves uses id token from anonymous sign in', async () => {
+  jest.resetModules();
   const fetchMock = jest.fn().mockResolvedValue({
     ok: true,
     status: 200,
@@ -13,12 +18,34 @@ test('listCloudSaves uses id token from anonymous sign in', async () => {
   const auth = { currentUser: null, signInAnonymously };
   window.firebase = { auth: () => auth };
 
+  const { listCloudSaves } = await import('../scripts/storage.js');
+
   await listCloudSaves();
 
   expect(signInAnonymously).toHaveBeenCalled();
   expect(fetchMock).toHaveBeenCalled();
   const url = fetchMock.mock.calls[0][0];
   expect(url).toContain('auth=TOKEN123');
+});
 
-  delete window.firebase;
+test('listCloudSaves skips invalid getIdToken', async () => {
+  jest.resetModules();
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(null),
+  });
+  global.fetch = fetchMock;
+  const signInAnonymously = jest.fn().mockResolvedValue({ user: { getIdToken: 'not-a-function' } });
+  const auth = { currentUser: null, signInAnonymously };
+  window.firebase = { auth: () => auth };
+
+  const { listCloudSaves } = await import('../scripts/storage.js');
+
+  await listCloudSaves();
+
+  expect(signInAnonymously).toHaveBeenCalled();
+  expect(fetchMock).toHaveBeenCalled();
+  const url = fetchMock.mock.calls[0][0];
+  expect(url).not.toContain('auth=');
 });

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -65,7 +65,7 @@ async function getIdToken() {
         const cred = await auth.signInAnonymously();
         user = cred && cred.user ? cred.user : cred;
       }
-      if (user?.getIdToken) {
+      if (typeof user?.getIdToken === 'function') {
         idToken = await user.getIdToken();
         return idToken;
       }


### PR DESCRIPTION
## Summary
- avoid calling getIdToken when it isn't a function
- add regression tests for non-functional getIdToken

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b82427ab8c832ea80b5761a39b0c70