### PR TITLE
Handle case-insensitive cloud player logins

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -108,6 +108,23 @@ describe('user management', () => {
     delete global.fetch;
   });
 
+  test('player login fetches cloud record case-insensitively', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => null })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ 'user%3AZara': { password: 'pw', question: 'q', answer: 'a' } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ password: 'pw', question: 'q', answer: 'a' }),
+      });
+    expect(await loginPlayer('zara', 'pw')).toBe(true);
+    expect(currentPlayer()).toBe('Zara');
+    delete global.fetch;
+  });
+
   test('login verifies credentials against the cloud', async () => {
     localStorage.setItem('players', JSON.stringify({ Hank: { password: 'old', question: 'q', answer: 'a' } }));
     global.fetch = jest.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- Fix cloud player lookup so login works regardless of name casing when the record only exists remotely
- Add regression test for case-insensitive cloud login

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88254cd2c832eb516851fb2684c21