### PR TITLE
Add integration test for RTDB login credentials

### DIFF
--- a/__tests__/login_cloud.test.js
+++ b/__tests__/login_cloud.test.js
@@ -1,0 +1,37 @@
+import { jest } from '@jest/globals';
+import fs from 'fs';
+
+const keyPath = 'serviceAccountKey.json';
+const hasCredentials = fs.existsSync(keyPath);
+const testOrSkip = hasCredentials ? test : test.skip;
+
+beforeAll(async () => {
+  if (!hasCredentials) return;
+  process.env.GOOGLE_APPLICATION_CREDENTIALS = keyPath;
+  if (typeof global.fetch !== 'function') {
+    global.fetch = (await import('node-fetch')).default;
+  }
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+testOrSkip('loginPlayer retrieves credentials from Firebase', async () => {
+  jest.resetModules();
+  const { saveCloud, deleteCloud } = await import('../scripts/storage.js');
+  const { loginPlayer, currentPlayer, logoutPlayer } = await import('../scripts/users.js');
+
+  const name = `LoginTest${Date.now()}`;
+  const record = { password: 'pw', question: 'q', answer: 'a' };
+
+  try {
+    await saveCloud('user:' + name, record);
+    expect(await loginPlayer(name, 'pw')).toBe(true);
+    expect(currentPlayer()).toBe(name);
+  } finally {
+    await deleteCloud('user:' + name);
+    logoutPlayer();
+  }
+});
+


### PR DESCRIPTION
## Summary
- add `login_cloud.test.js` to verify `loginPlayer` can retrieve credentials from Firebase RTDB

## Testing
- `npm test __tests__/save_load_cloud.test.js`
- `npm test __tests__/login_cloud.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88464f870832ebfb851ffd69177c1