### PR TITLE
Cache scripts and player saves for offline support

### DIFF
--- a/scripts/users.js
+++ b/scripts/users.js
@@ -2,6 +2,14 @@ import { saveLocal, loadLocal, loadCloud, saveCloud, listCloudSaves, listLocalSa
 import { $ } from './helpers.js';
 import { show as showModal, hide as hideModal } from './modal.js';
 
+if (typeof navigator !== 'undefined' && navigator.serviceWorker?.addEventListener) {
+  navigator.serviceWorker.addEventListener('message', evt => {
+    if (evt.data === 'cacheCloudSaves') {
+      cacheCloudSaves().catch(e => console.error('Failed to cache cloud saves', e));
+    }
+  });
+}
+
 const PLAYERS_KEY = 'players';
 const PLAYER_SESSION = 'player-session';
 const DM_SESSION = 'dm-session';


### PR DESCRIPTION
## Summary
- Pre-cache user management, modal, and Firebase scripts in the service worker
- Trigger client-side caching of cloud saves on each navigation for offline access
- Listen for service worker messages to store player saves locally and test the behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88553c2bc832ea164a49a2101dd19