### PR TITLE
Check player existence on name input

### DIFF
--- a/__tests__/login_live_lookup.test.js
+++ b/__tests__/login_live_lookup.test.js
@@ -1,0 +1,28 @@
+import { jest } from '@jest/globals';
+import '../scripts/users.js';
+
+describe('live player lookup', () => {
+  let initialCalls;
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = `
+      <input id="login-player-name" />
+      <div id="login-player-status"></div>
+    `;
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => null });
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    initialCalls = global.fetch.mock.calls.length;
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  test('fetches from server on input', async () => {
+    const input = document.getElementById('login-player-name');
+    input.value = 'Alice';
+    input.dispatchEvent(new Event('input'));
+    await new Promise(r => setTimeout(r, 0));
+    expect(global.fetch.mock.calls.length).toBeGreaterThan(initialCalls);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -510,6 +510,7 @@
         <input id="login-player-name" placeholder="Player name"/>
         <input id="login-player-password" type="password" placeholder="Password"/>
       </div>
+      <div id="login-player-status" role="status"></div>
       <div class="inline">
         <button id="login-player" class="btn-sm" type="button">Login</button>
         <a id="open-register" href="#">Register</a>

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -464,6 +464,26 @@ if (typeof document !== 'undefined') {
       updateDMLoginControls();
     });
 
+    const loginNameInput = $('login-player-name');
+    const loginStatus = $('login-player-status');
+    if (loginNameInput) {
+      loginNameInput.addEventListener('input', async () => {
+        const name = loginNameInput.value.trim();
+        if (!name) {
+          if (loginStatus) loginStatus.textContent = '';
+          return;
+        }
+        try {
+          const { record } = await loadPlayerRecord(name);
+          if (loginStatus) {
+            loginStatus.textContent = record ? 'Player found' : 'Player not found';
+          }
+        } catch {
+          if (loginStatus) loginStatus.textContent = 'Player not found';
+        }
+      });
+    }
+
     const regBtn = $('register-player');
     if (regBtn) {
       regBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- fetch player record as a user types their name to verify account existence
- show live status message beside login fields
- add regression test for server lookup when typing player names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b890dc2a88832eb7ac7f2c3709bac9