### PR TITLE
feat: support multiple characters per player

### DIFF
--- a/__tests__/dm_cloud.test.js
+++ b/__tests__/dm_cloud.test.js
@@ -6,6 +6,7 @@ jest.unstable_mockModule('../scripts/storage.js', () => ({
   loadCloud: jest.fn(),
   saveCloud: jest.fn(),
   deleteSave: jest.fn(),
+  deleteCloud: jest.fn(),
   listCloudSaves: jest.fn(),
   listLocalSaves: jest.fn(),
   cacheCloudSaves: jest.fn(),
@@ -29,9 +30,9 @@ describe('DM cloud loading', () => {
     storage.loadCloud.mockResolvedValue({ hp: 30 });
     expect(loginDM('Dragons22!')).toBe(true);
     const data = await loadPlayerCharacter('Eve');
-    expect(storage.loadCloud).toHaveBeenCalledWith('Player :Eve');
+    expect(storage.loadCloud).toHaveBeenCalledWith('Player :Eve/default');
     expect(storage.loadLocal).not.toHaveBeenCalled();
-    expect(storage.saveLocal).toHaveBeenCalledWith('Player :Eve', { hp: 30 });
+    expect(storage.saveLocal).toHaveBeenCalledWith('Player :Eve/default', { hp: 30 });
     expect(data.hp).toBe(30);
   });
 
@@ -41,8 +42,8 @@ describe('DM cloud loading', () => {
     storage.loadLocal.mockResolvedValue({ hp: 15 });
     expect(loginDM('Dragons22!')).toBe(true);
     const data = await loadPlayerCharacter('Eve');
-    expect(storage.loadCloud).toHaveBeenCalledWith('Player :Eve');
-    expect(storage.loadLocal).toHaveBeenCalledWith('Player :Eve');
+    expect(storage.loadCloud).toHaveBeenCalledWith('Player :Eve/default');
+    expect(storage.loadLocal).toHaveBeenCalledWith('Player :Eve/default');
     expect(data.hp).toBe(15);
   });
 });

--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -154,18 +154,18 @@ describe('user management', () => {
 
   test('lists characters from cloud', async () => {
     const names = await listCharacters(async () => ['Player :Bob', 'Player :Alice', 'other']);
-    expect(names).toEqual(['Alice', 'Bob']);
+    expect(names).toEqual(['Alice/default', 'Bob/default']);
   });
 
   test('merges local saves when listing characters', async () => {
     await saveLocal('Player :Eve', {});
     const names = await listCharacters(async () => ['Player :Bob']);
-    expect(names).toEqual(['Bob', 'Eve']);
+    expect(names).toEqual(['Bob/default', 'Eve/default']);
   });
 
   test('lists characters from cloud regardless of key casing', async () => {
     const names = await listCharacters(async () => ['PLAYER :Charlie', 'player :alice']);
-    expect(names).toEqual(['alice', 'Charlie']);
+    expect(names).toEqual(['alice/default', 'Charlie/default']);
   });
 
   test('lists characters with encoded cloud keys', async () => {
@@ -174,13 +174,13 @@ describe('user management', () => {
       json: async () => ({ 'Player%20%3ABob': {}, 'Player%20%3AAlice': {} }),
     });
     const names = await listCharacters();
-    expect(names).toEqual(['Alice', 'Bob']);
+    expect(names).toEqual(['Alice/default', 'Bob/default']);
   });
 
 
   test('lists characters with encoded local keys', async () => {
     const names = await listCharacters(async () => [], async () => ['Player%20%3AEve']);
-    expect(names).toEqual(['Eve']);
+    expect(names).toEqual(['Eve/default']);
   });
 
   test('lists and loads characters with percent signs in the name', async () => {
@@ -188,7 +188,7 @@ describe('user management', () => {
     expect(await loginPlayer('A%20B', 'pw')).toBe(true);
     await savePlayerCharacter('A%20B', { hp: 7 });
     const names = await listCharacters();
-    expect(names).toEqual(['A%20B']);
+    expect(names).toEqual(['A%20B/default']);
     const data = await loadPlayerCharacter('A%20B');
     expect(data.hp).toBe(7);
   });
@@ -222,5 +222,6 @@ describe('user management', () => {
     expect(recoverPlayerPassword('Frank', ' BLUE  ')).toBe('pw');
     expect(recoverPlayerPassword('Frank', 'red')).toBeNull();
   });
+
 });
 

--- a/__tests__/users_cache.test.js
+++ b/__tests__/users_cache.test.js
@@ -17,6 +17,8 @@ jest.unstable_mockModule('../scripts/storage.js', () => ({
   loadLocal: jest.fn(),
   loadCloud: jest.fn(),
   saveCloud: jest.fn(),
+  deleteCloud: jest.fn(),
+  deleteSave: jest.fn(),
   listCloudSaves: jest.fn(),
   listLocalSaves: jest.fn(),
   cacheCloudSaves,

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
         <button id="btn-theme" class="btn-sm">Toggle Theme</button>
         <button id="btn-player" class="btn-sm">Log In</button>
         <button id="btn-save" class="btn-sm">Save</button>
+        <button id="btn-character" class="btn-sm">Characters</button>
         <button id="btn-wizard" class="btn-sm" aria-label="Character creation wizard" title="Character creation wizard">Character wizard</button>
         <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
         <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
@@ -605,6 +606,22 @@
     </button>
     <h3>Player Characters</h3>
     <div id="dm-player-list" class="catalog"></div>
+  </div>
+</div>
+
+<div class="overlay hidden" id="modal-characters" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Your Characters</h3>
+    <div id="player-char-list" class="catalog"></div>
+    <div class="inline">
+      <input id="new-character-name" placeholder="New character name"/>
+      <button id="create-character" class="btn-sm" type="button">Create/Switch</button>
+    </div>
   </div>
 </div>
 

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -124,10 +124,19 @@ async function authedFetch(url, options = {}) {
   return fetch(url, options);
 }
 
+// Encode each path segment separately so callers can supply hierarchical
+// keys like `player:Alice/hero1` without worrying about Firebase escaping.
+function encodePath(name) {
+  return name
+    .split('/')
+    .map((s) => encodeURIComponent(s))
+    .join('/');
+}
+
 export async function saveCloud(name, payload) {
   try {
     if (typeof fetch !== 'function') throw new Error('fetch not supported');
-    const res = await authedFetch(`${CLOUD_SAVES_URL}/${encodeURIComponent(name)}.json`, {
+    const res = await authedFetch(`${CLOUD_SAVES_URL}/${encodePath(name)}.json`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -150,7 +159,7 @@ export async function loadCloud(name) {
   try {
     if (typeof fetch !== 'function') throw new Error('fetch not supported');
     const res = await authedFetch(
-      `${CLOUD_SAVES_URL}/${encodeURIComponent(name)}.json`,
+      `${CLOUD_SAVES_URL}/${encodePath(name)}.json`,
       { method: 'GET' }
     );
     if (res.status === 401 || res.status === 403) return null;
@@ -168,7 +177,7 @@ export async function loadCloud(name) {
 export async function deleteCloud(name) {
   try {
     if (typeof fetch !== 'function') throw new Error('fetch not supported');
-    const res = await authedFetch(`${CLOUD_SAVES_URL}/${encodeURIComponent(name)}.json`, {
+    const res = await authedFetch(`${CLOUD_SAVES_URL}/${encodePath(name)}.json`, {
       method: 'DELETE'
     });
     if (res.status === 401 || res.status === 403) return;


### PR DESCRIPTION
## Summary
- allow each user profile to manage multiple characters and switch between them
- add character manager UI with load and delete options
- encode nested save paths for Firebase RTDB

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b892d9e320832ea01bf025411afe9c