### PR TITLE
Fix faction reputation autosave

### DIFF
--- a/__tests__/faction_rep.test.js
+++ b/__tests__/faction_rep.test.js
@@ -1,0 +1,26 @@
+import { jest } from '@jest/globals';
+import { setupFactionRepTracker } from '../scripts/faction.js';
+
+describe('faction reputation tracker', () => {
+  test('gain button updates value and pushes history', () => {
+    document.body.innerHTML = `
+      <div>
+        <progress id="omni-rep-bar" max="100" value="0"></progress>
+        <span id="omni-rep-tier"></span>
+        <p id="omni-rep-perk"></p>
+        <button id="omni-rep-gain"></button>
+        <button id="omni-rep-lose"></button>
+        <input type="hidden" id="omni-rep" value="200" />
+      </div>
+    `;
+    const pushHistory = jest.fn();
+    const handlePerkEffects = jest.fn();
+
+    setupFactionRepTracker(handlePerkEffects, pushHistory);
+
+    document.getElementById('omni-rep-gain').click();
+
+    expect(document.getElementById('omni-rep').value).toBe('205');
+    expect(pushHistory).toHaveBeenCalled();
+  });
+});

--- a/scripts/faction.js
+++ b/scripts/faction.js
@@ -1,0 +1,99 @@
+import { $, num } from './helpers.js';
+
+export const COMMON_REP_TIERS = {
+  Hostile: ['You are hunted, sabotaged, or attacked on sight.'],
+  Untrusted: ['Faction denies you resources, spreads bad PR.'],
+  Neutral: ['No strong opinion—standard interactions only.'],
+  Recognized: ['Minor perks, small-scale favors.'],
+  Trusted: ['Reliable allies, access to mid-tier resources.'],
+  Favored: ['Priority treatment, elite support, story leverage.'],
+  Champion: ['Icon status, legendary backing, may call in major faction powers.'],
+};
+
+export const FACTION_REP_PERKS = {
+  'O.M.N.I.': { ...COMMON_REP_TIERS },
+  'P.F.V.': { ...COMMON_REP_TIERS },
+  'Cosmic Conclave': { ...COMMON_REP_TIERS },
+  'Greyline PMC': { ...COMMON_REP_TIERS },
+};
+
+export const FACTIONS = ['omni', 'pfv', 'conclave', 'greyline'];
+
+export const FACTION_NAME_MAP = {
+  omni: 'O.M.N.I.',
+  pfv: 'P.F.V.',
+  conclave: 'Cosmic Conclave',
+  greyline: 'Greyline PMC',
+};
+
+export const REP_TIERS = Object.keys(COMMON_REP_TIERS);
+
+export const ACTION_HINTS = [
+  'once per',
+  'per encounter',
+  'per day',
+  'per long rest',
+  'reroll',
+  'call upon',
+  'protect an ally',
+  'gain temporary hit points',
+  'dash as a bonus action',
+  'add +',
+];
+
+export function updateFactionRep(handlePerkEffects = () => {}) {
+  FACTIONS.forEach(f => {
+    const input = $(`${f}-rep`);
+    const bar = $(`${f}-rep-bar`);
+    const tierEl = $(`${f}-rep-tier`);
+    const perkEl = $(`${f}-rep-perk`);
+    if (!input || !bar || !tierEl || !perkEl) return;
+    let val = Math.max(0, num(input.value));
+    const maxVal = REP_TIERS.length * 100 - 1;
+    if (val > maxVal) val = maxVal;
+    input.value = val;
+    const tierIdx = Math.min(REP_TIERS.length - 1, Math.floor(val / 100));
+    const tierName = REP_TIERS[tierIdx];
+    bar.value = val % 100;
+    tierEl.textContent = tierName;
+    perkEl.innerHTML = '';
+    const facName = FACTION_NAME_MAP[f];
+    const perks = (FACTION_REP_PERKS[facName] && FACTION_REP_PERKS[facName][tierName]) || [];
+    const perk = perks[0];
+    if (perk) {
+      const text = typeof perk === 'string' ? perk : String(perk);
+      const lower = text.toLowerCase();
+      const isAction = ACTION_HINTS.some(k => lower.includes(k));
+      if (isAction) {
+        const id = `${f}-rep-perk-act`;
+        perkEl.innerHTML = `<label class="inline"><input type="checkbox" id="${id}"/> ${text}</label>`;
+      } else {
+        perkEl.textContent = text;
+      }
+      handlePerkEffects(perkEl, text);
+      perkEl.style.display = 'block';
+    } else {
+      perkEl.style.display = 'none';
+    }
+  });
+}
+
+export function setupFactionRepTracker(handlePerkEffects = () => {}, pushHistory) {
+  const maxVal = REP_TIERS.length * 100 - 1;
+  FACTIONS.forEach(f => {
+    const input = $(`${f}-rep`);
+    const gain = $(`${f}-rep-gain`);
+    const lose = $(`${f}-rep-lose`);
+    if (!input || !gain || !lose) return;
+    function change(delta) {
+      const next = Math.max(0, Math.min(maxVal, num(input.value) + delta));
+      input.value = next;
+      updateFactionRep(handlePerkEffects);
+      if (typeof pushHistory === 'function') pushHistory();
+    }
+    gain.addEventListener('click', () => change(5));
+    lose.addEventListener('click', () => change(-5));
+  });
+  updateFactionRep(handlePerkEffects);
+}
+


### PR DESCRIPTION
## Summary
- move faction reputation logic into dedicated module
- ensure reputation changes push to history for autosave
- add unit test for faction reputation gains

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8a5be20c4832ea6c21bd89f036577