### PR TITLE
Fix resonance points dots not staying ticked

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1922,7 +1922,9 @@ CC.RP = (function () {
     els.rpValue.textContent = String(state.rp);
     els.rpDots.forEach(btn => {
       const v = parseInt(btn.dataset.rp, 10);
-      btn.setAttribute("aria-pressed", String(v === state.rp));
+      // Highlight all dots up to the current RP value so previously selected
+      // points remain visibly "ticked" rather than only the most recent one.
+      btn.setAttribute("aria-pressed", String(v <= state.rp));
     });
 
     els.surgeState.textContent = state.surgeActive ? "Active" : "Inactive";


### PR DESCRIPTION
## Summary
- ensure resonance point dots remain highlighted up to current point value

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8a8d9cb74832e89c9089a4a90e98c