### PR TITLE
Restrict surge toggle to aftermath reset

### DIFF
--- a/__tests__/rp_value.test.js
+++ b/__tests__/rp_value.test.js
@@ -20,7 +20,6 @@ describe('Resonance Points tracker', () => {
           <button type="button" class="rp-dot" data-rp="4" aria-pressed="false"></button>
           <button type="button" class="rp-dot" data-rp="5" aria-pressed="false"></button>
         </div>
-        <button id="rp-reset"></button>
         <input type="checkbox" id="rp-trigger" />
         <button id="rp-clear-aftermath"></button>
         <span id="rp-surge-state"></span>

--- a/index.html
+++ b/index.html
@@ -227,7 +227,6 @@
           </div>
 
           <div class="rp-surge-controls">
-            <button type="button" id="rp-reset" aria-label="Reset Resonance Points">Reset RP</button>
             <button type="button" id="rp-clear-aftermath" disabled aria-label="Aftermath">Aftermath</button>
           </div>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1856,7 +1856,6 @@ CC.RP = (function () {
 
     els.rpValue = q("rp-value");
     els.rpDots = Array.from(document.querySelectorAll("#resonance-points .rp-dot"));
-    els.btnReset = q("rp-reset");
     els.chkSurge = q("rp-trigger");
     els.btnClearAftermath = q("rp-clear-aftermath");
     els.surgeState = q("rp-surge-state");
@@ -1873,13 +1872,12 @@ CC.RP = (function () {
   }
 
   function wireEvents() {
-    els.btnReset.addEventListener("click", () => { endSurge("reset"); setRP(0); });
     els.rpDots.forEach(btn => btn.addEventListener("click", () => {
       const v = parseInt(btn.dataset.rp, 10);
       setRP(state.rp === v ? 0 : v);
     }));
-    els.chkSurge.addEventListener("change", e => { if (e.target.checked) triggerSurge(); else endSurge("toggle"); });
-    els.btnClearAftermath.addEventListener("click", () => clearAftermath());
+    els.chkSurge.addEventListener("change", e => { if (e.target.checked) triggerSurge(); });
+    els.btnClearAftermath.addEventListener("click", () => { if (state.surgeActive) endSurge("aftermath"); else clearAftermath(); });
   }
 
   // --- State transitions
@@ -1951,8 +1949,8 @@ CC.RP = (function () {
 
     els.surgeState.textContent = state.surgeActive ? "Active" : "Inactive";
     els.chkSurge.checked = state.surgeActive;
-    els.chkSurge.disabled = state.rp < 5 && !state.surgeActive;
-    els.btnClearAftermath.disabled = !state.aftermathPending;
+    els.chkSurge.disabled = state.surgeActive || state.rp < 5;
+    els.btnClearAftermath.disabled = !(state.surgeActive || state.aftermathPending);
 
     els.tagActive.hidden = !state.surgeActive;
     els.tagAfter.hidden = !state.aftermathPending;

--- a/styles/main.css
+++ b/styles/main.css
@@ -579,7 +579,7 @@ select[required]:valid{
   background: var(--accent, #222);
   border-color: var(--accent, #222);
 }
-.rp-surge-controls { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 8px; margin: 10px 0; }
+.rp-surge-controls { display: grid; grid-template-columns: minmax(0,1fr); gap: 8px; margin: 10px 0; }
 .rp-divide { margin: 12px 0; }
 .rp-surge-status { margin: 6px 0 8px; }
 #rp-surge-details { margin: 6px 0 8px; }


### PR DESCRIPTION
## Summary
- Remove Reset RP control and enable Aftermath button during surge
- Disable surge checkbox while active so only Aftermath can end surge
- Adjust layout for single-button surge controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9035409d0832e90a719644937604f