### PR TITLE
Allow banking surges up to 10 resonance points

### DIFF
--- a/__tests__/rp_value.test.js
+++ b/__tests__/rp_value.test.js
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 
 describe('Resonance Points tracker', () => {
-  test('clicking a dot updates the displayed RP value', async () => {
+  test('adjusting RP via buttons updates the displayed value and bank indicator', async () => {
     // Stub fetch to avoid network requests for optional assets like rules text.
     global.fetch = jest.fn().mockResolvedValue({ text: async () => '' });
 
@@ -13,13 +13,21 @@ describe('Resonance Points tracker', () => {
         <div class="rp-row">
           <output id="rp-value" aria-live="polite">0</output>
         </div>
-        <div class="rp-track" role="group">
-          <button type="button" class="rp-dot" data-rp="1" aria-pressed="false"></button>
-          <button type="button" class="rp-dot" data-rp="2" aria-pressed="false"></button>
-          <button type="button" class="rp-dot" data-rp="3" aria-pressed="false"></button>
-          <button type="button" class="rp-dot" data-rp="4" aria-pressed="false"></button>
-          <button type="button" class="rp-dot" data-rp="5" aria-pressed="false"></button>
+      <div class="rp-track" role="group">
+          <button type="button" id="rp-dec">-</button>
+          <button type="button" class="rp-dot" data-rp="1" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="2" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="3" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="4" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="5" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="6" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="7" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="8" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="9" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="10" aria-pressed="false" disabled></button>
+          <button type="button" id="rp-inc">+</button>
         </div>
+        <div id="rp-banked"></div>
         <input type="checkbox" id="rp-trigger" />
         <button id="rp-clear-aftermath"></button>
         <span id="rp-surge-state"></span>
@@ -59,12 +67,23 @@ describe('Resonance Points tracker', () => {
     await import('../scripts/main.js');
     document.dispatchEvent(new Event('DOMContentLoaded'));
 
-    const dot = document.querySelector('.rp-dot[data-rp="3"]');
-    dot.click();
+    const inc = document.getElementById('rp-inc');
+    inc.click();
+    inc.click();
+    inc.click();
 
     const output = document.getElementById('rp-value');
     expect(output.textContent).toBe('3');
     expect(output.value).toBe('3');
+    expect(output.getAttribute('value')).toBe('3');
+
+    const banked = document.getElementById('rp-banked');
+    expect(banked.hidden).toBe(true);
+
+    for (let i = 0; i < 2; i++) inc.click();
+    const indicator = document.getElementById('rp-banked');
+    expect(indicator.hidden).toBe(false);
+    expect(indicator.textContent).toBe('1 Banked Surge');
   });
 });
 

--- a/index.html
+++ b/index.html
@@ -197,12 +197,21 @@
         </div>
 
         <div class="rp-track" role="group" aria-label="Resonance Points Track">
-          <button type="button" class="rp-dot" data-rp="1" aria-pressed="false" aria-label="Set RP to 1"></button>
-          <button type="button" class="rp-dot" data-rp="2" aria-pressed="false" aria-label="Set RP to 2"></button>
-          <button type="button" class="rp-dot" data-rp="3" aria-pressed="false" aria-label="Set RP to 3"></button>
-          <button type="button" class="rp-dot" data-rp="4" aria-pressed="false" aria-label="Set RP to 4"></button>
-          <button type="button" class="rp-dot" data-rp="5" aria-pressed="false" aria-label="Set RP to 5"></button>
+          <button type="button" id="rp-dec" aria-label="Spend Resonance Point">-</button>
+          <button type="button" class="rp-dot" data-rp="1" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="2" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="3" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="4" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="5" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="6" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="7" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="8" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="9" aria-pressed="false" disabled></button>
+          <button type="button" class="rp-dot" data-rp="10" aria-pressed="false" disabled></button>
+          <button type="button" id="rp-inc" aria-label="Gain Resonance Point">+</button>
         </div>
+
+        <div id="rp-banked" class="rp-banked" hidden aria-live="polite"></div>
 
         <hr class="rp-divide">
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -567,7 +567,12 @@ select[required]:valid{
 #resonance-points .subtext { font-size: 0.9rem; opacity: 0.85; }
 .rp-row { display: flex; justify-content: space-between; align-items: center; margin: 6px 0 10px; }
 .rp-label { font-weight: 600; }
-.rp-track { display: flex; justify-content: center; gap: 8px; margin: 6px 0 12px; }
+.rp-track { display: flex; justify-content: center; align-items: center; gap: 8px; margin: 6px 0 12px; }
+#rp-dec,
+#rp-inc {
+  inline-size: 20px;
+  block-size: 20px;
+}
 .rp-dot {
   inline-size: 10.5px;
   block-size: 10.5px;
@@ -578,6 +583,9 @@ select[required]:valid{
 .rp-dot[aria-pressed="true"] {
   background: var(--accent, #222);
   border-color: var(--accent, #222);
+}
+.rp-track.maxed .rp-dot {
+  opacity: 0.5;
 }
 .rp-surge-controls { display: grid; grid-template-columns: minmax(0,1fr); gap: 8px; margin: 10px 0; }
 .rp-divide { margin: 12px 0; }


### PR DESCRIPTION
## Summary
- Expand resonance track to 10 points with new +/− controls and banked surge indicator
- Rework resonance logic to bank surges and disable RP gain at max
- Update styles and tests for new RP controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9068a1cec832ea78c3e7fbaf9902f