### PR TITLE
Reset RP track after banking and center RP controls

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1888,6 +1888,10 @@ CC.RP = (function () {
     const total = Math.max(0, n);
     if (total >= 5) {
       state.banked += Math.floor(total / 5);
+      // Immediately clear the track so the UI reflects the banked point.
+      if (els.rpDots) {
+        els.rpDots.forEach(btn => btn.setAttribute('aria-pressed', 'false'));
+      }
     }
     state.rp = total % 5;
     applyStateToUI();

--- a/styles/main.css
+++ b/styles/main.css
@@ -572,6 +572,11 @@ select[required]:valid{
 #rp-inc {
   inline-size: 20px;
   block-size: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  padding: 0;
 }
 .rp-dot {
   inline-size: 10.5px;


### PR DESCRIPTION
## Summary
- Clear resonance point track when a Heroic Surge is banked so the dots reset to 0
- Center the RP increment/decrement buttons for better alignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b90dcb4800832e90d18f209cf58ac3