### PR TITLE
Avoid cloud save errors when offline

### DIFF
--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -215,6 +215,13 @@ export async function cacheCloudSaves(
   saveFn = saveLocal
 ) {
   try {
+    if (
+      typeof navigator !== 'undefined' &&
+      Object.prototype.hasOwnProperty.call(navigator, 'onLine') &&
+      navigator.onLine === false
+    ) {
+      return;
+    }
     const keys = await listFn();
     // Only cache player character data. Other saves such as user credentials
     // are skipped to avoid polluting local storage with unnecessary entries.

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -38,7 +38,19 @@ let storageBlocked = false;
 // implemented (e.g. during tests or in very old browsers) cloud operations
 // should be skipped silently rather than emitting noisy errors.
 function canUseCloud() {
-  return typeof fetch === 'function';
+  if (typeof fetch !== 'function') return false;
+  // When running in a browser, avoid cloud operations if the network is
+  // reported as offline to prevent redundant fetch attempts that would trigger
+  // console errors. `navigator.onLine` is not universally reliable but provides
+  // a best-effort signal and is ignored when unavailable (e.g. in tests).
+  if (
+    typeof navigator !== 'undefined' &&
+    Object.prototype.hasOwnProperty.call(navigator, 'onLine') &&
+    navigator.onLine === false
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function getPlayersRaw() {


### PR DESCRIPTION
## Summary
- Skip cloud operations when `navigator.onLine` is false
- Avoid caching cloud saves when offline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b90fecf204832ea0a9f63b78d2a0a8