### PR TITLE
Trim player name before cloud lookup

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -108,6 +108,20 @@ describe('user management', () => {
     delete global.fetch;
   });
 
+  test('player login trims name before cloud lookup', async () => {
+    localStorage.clear();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ password: 'pw', question: 'q', answer: 'a' }),
+    });
+    expect(await loginPlayer('  Zara  ', 'pw')).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('user%3AZara.json'),
+      expect.objectContaining({ method: 'GET' })
+    );
+    delete global.fetch;
+  });
+
   test('player login fetches cloud record case-insensitively', async () => {
     global.fetch = jest
       .fn()

--- a/scripts/users.js
+++ b/scripts/users.js
@@ -185,9 +185,10 @@ export function recoverPlayerPassword(name, answer) {
 }
 
 async function loadPlayerRecord(name) {
+  const normalizedName = typeof name === 'string' ? name.trim() : '';
   const players = getPlayersRaw();
-  const lower = name.toLowerCase();
-  let canonical = name;
+  const lower = normalizedName.toLowerCase();
+  let canonical = normalizedName;
   for (const key of Object.keys(players)) {
     if (key.toLowerCase() === lower) {
       canonical = key;
@@ -204,7 +205,7 @@ async function loadPlayerRecord(name) {
         try {
           const keys = await listCloudSaves();
           const match = keys.find(
-            k => k.toLowerCase() === ('user:' + name).toLowerCase()
+            k => k.toLowerCase() === ('user:' + normalizedName).toLowerCase()
           );
           if (match) {
             canonical = match.slice(5);
@@ -232,6 +233,7 @@ async function loadPlayerRecord(name) {
 
 export async function loginPlayer(name, password) {
   const { record: p, canonical } = await loadPlayerRecord(name);
+  if (!canonical) return false;
   if (p && p.password === password) {
     // Logging in as a player should terminate any active DM session to avoid
     // concurrent logins. Use the standard logout helper so events are


### PR DESCRIPTION
## Summary
- normalize player names by trimming whitespace before cloud lookups
- avoid logins with empty player names
- test cloud login with whitespace-padded names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b911929498832ea57d0e09860cae67