### PR TITLE
Ensure RP tracker initializes after load

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1835,6 +1835,7 @@ if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
 // == Resonance Points (RP) Module ============================================
 window.CC = window.CC || {};
 CC.RP = (function () {
+  const api = {};
   // --- Internal state
   let state = {
     rp: 0,                    // 0..4
@@ -2034,12 +2035,12 @@ CC.RP = (function () {
 
   // --- Public API (for GM buttons/macros, etc.)
   function exposeHooks() {
-    CC.RP.get = () => ({ ...state });
-    CC.RP.setRP = setRP;
-    CC.RP.trigger = triggerSurge;
-    CC.RP.end = endSurge;
-    CC.RP.clearAftermath = clearAftermath;
-    CC.RP.tick = tick;
+    api.get = () => ({ ...state });
+    api.setRP = setRP;
+    api.trigger = triggerSurge;
+    api.end = endSurge;
+    api.clearAftermath = clearAftermath;
+    api.tick = tick;
   }
 
   // --- Integrations (rolls, saves, checks, SP regen)
@@ -2189,7 +2190,11 @@ CC.RP = (function () {
   function d4() { return 1 + Math.floor(Math.random() * 4); }
 
   // Boot
-  document.addEventListener("DOMContentLoaded", init);
-  return {};
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+  return api;
 })();
 


### PR DESCRIPTION
## Summary
- Initialize Resonance Points module immediately if DOM is ready so the increment/decrement buttons work
- Expose RP hooks via an internal API object to avoid `CC.RP` being undefined during startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9207ec824832e9d72a04323d36254