### PR TITLE
fix: allow dm to save player edits

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1664,8 +1664,12 @@ function redo(){
 })();
 $('btn-save').addEventListener('click', async () => {
   const btn = $('btn-save');
-  const player = currentPlayer() || (isDM() ? dmPlayer : null);
-  const char = currentCharacter(player) || (isDM() ? dmCharacter : null);
+  let player = currentPlayer();
+  let char = currentCharacter(player);
+  if (isDM()) {
+    if (!player) player = dmPlayer;
+    if (!char) char = dmCharacter;
+  }
   if (!player || !char) return toast('Login required', 'error');
   btn.classList.add('loading'); btn.disabled = true;
   try {


### PR DESCRIPTION
## Summary
- fix DM save handler to use selected player and character when no player session

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b96cca5c4c832eb91a449c87cb0e66