### PR TITLE
Reduce bottom spacing before footer

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -73,13 +73,14 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
   width:auto;
 }
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
-main{max-width:65ch;margin:16px auto;padding:0 12px calc(16px + env(safe-area-inset-bottom))}
+main{max-width:65ch;margin:16px auto;padding:0 12px calc(4px + env(safe-area-inset-bottom))}
 fieldset[data-tab].card{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:14px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translateX(10px);cursor:default;transition:opacity .3s ease,transform .3s ease}
+main>:last-child{margin-bottom:0}
 fieldset[data-tab].card.active{display:block;opacity:1;transform:translateX(0)}
 fieldset[data-tab].card>legend{font-size:1.5rem;font-weight:600;color:var(--accent);margin:0 0 10px}
 .card-title{font-size:1.5rem;font-weight:600;color:var(--accent);margin:0 0 10px}
 p{max-width:65ch}
-footer{text-align:center;font-size:9pt;margin-top:24px;padding:12px 0;color:var(--muted)}
+footer{text-align:center;font-size:9pt;margin-top:8px;padding:4px 0 calc(4px + env(safe-area-inset-bottom));color:var(--muted)}
 footer p{max-width:none}
 .grid{display:grid;gap:12px}
 .grid-1{grid-template-columns:1fr}


### PR DESCRIPTION
## Summary
- tighten spacing between last page card and footer text
- ensure footer includes safe-area padding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d8a1d3a0832e8b0312507ac9d9d6