### PR TITLE
Fix faction reputation tracker buttons

### DIFF
--- a/__tests__/faction_rep.test.js
+++ b/__tests__/faction_rep.test.js
@@ -17,10 +17,34 @@ describe('faction reputation tracker', () => {
     const handlePerkEffects = jest.fn();
 
     setupFactionRepTracker(handlePerkEffects, pushHistory);
+    document.dispatchEvent(new Event('DOMContentLoaded'));
 
     document.getElementById('omni-rep-gain').click();
 
     expect(document.getElementById('omni-rep').value).toBe('205');
+    expect(pushHistory).toHaveBeenCalled();
+  });
+
+  test('lose button updates value and pushes history', () => {
+    document.body.innerHTML = `
+      <div>
+        <progress id="omni-rep-bar" max="100" value="0"></progress>
+        <span id="omni-rep-tier"></span>
+        <p id="omni-rep-perk"></p>
+        <button id="omni-rep-gain"></button>
+        <button id="omni-rep-lose"></button>
+        <input type="hidden" id="omni-rep" value="200" />
+      </div>
+    `;
+    const pushHistory = jest.fn();
+    const handlePerkEffects = jest.fn();
+
+    setupFactionRepTracker(handlePerkEffects, pushHistory);
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.getElementById('omni-rep-lose').click();
+
+    expect(document.getElementById('omni-rep').value).toBe('195');
     expect(pushHistory).toHaveBeenCalled();
   });
 });

--- a/scripts/faction.js
+++ b/scripts/faction.js
@@ -79,21 +79,28 @@ export function updateFactionRep(handlePerkEffects = () => {}) {
 }
 
 export function setupFactionRepTracker(handlePerkEffects = () => {}, pushHistory) {
-  const maxVal = REP_TIERS.length * 100 - 1;
-  FACTIONS.forEach(f => {
-    const input = $(`${f}-rep`);
-    const gain = $(`${f}-rep-gain`);
-    const lose = $(`${f}-rep-lose`);
-    if (!input || !gain || !lose) return;
-    function change(delta) {
-      const next = Math.max(0, Math.min(maxVal, num(input.value) + delta));
-      input.value = next;
-      updateFactionRep(handlePerkEffects);
-      if (typeof pushHistory === 'function') pushHistory();
-    }
-    gain.addEventListener('click', () => change(5));
-    lose.addEventListener('click', () => change(-5));
-  });
-  updateFactionRep(handlePerkEffects);
+  const init = () => {
+    const maxVal = REP_TIERS.length * 100 - 1;
+    FACTIONS.forEach(f => {
+      const input = $(`${f}-rep`);
+      const gain = $(`${f}-rep-gain`);
+      const lose = $(`${f}-rep-lose`);
+      if (!input || !gain || !lose) return;
+      function change(delta) {
+        const next = Math.max(0, Math.min(maxVal, num(input.value) + delta));
+        input.value = next;
+        updateFactionRep(handlePerkEffects);
+        if (typeof pushHistory === 'function') pushHistory();
+      }
+      gain.addEventListener('click', e => { e.preventDefault(); change(5); });
+      lose.addEventListener('click', e => { e.preventDefault(); change(-5); });
+    });
+    updateFactionRep(handlePerkEffects);
+  };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
 }
 


### PR DESCRIPTION
## Summary
- ensure faction reputation tracker initializes after DOM is ready and prevent default button actions
- cover gain and lose scenarios with DOMContentLoaded-aware tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9db2d33bc832ebdaf720ca4312df0