### PR TITLE
Improve reputation and RP tracking visuals

### DIFF
--- a/__tests__/faction_rep.test.js
+++ b/__tests__/faction_rep.test.js
@@ -21,7 +21,11 @@ describe('faction reputation tracker', () => {
 
     document.getElementById('omni-rep-gain').click();
 
-    expect(document.getElementById('omni-rep').value).toBe('205');
+    const repInput = document.getElementById('omni-rep');
+    const bar = document.getElementById('omni-rep-bar');
+    expect(repInput.value).toBe('205');
+    expect(bar.value).toBe(205);
+    expect(bar.max).toBe(699);
     expect(pushHistory).toHaveBeenCalled();
   });
 
@@ -44,7 +48,11 @@ describe('faction reputation tracker', () => {
 
     document.getElementById('omni-rep-lose').click();
 
-    expect(document.getElementById('omni-rep').value).toBe('195');
+    const repInput = document.getElementById('omni-rep');
+    const bar = document.getElementById('omni-rep-bar');
+    expect(repInput.value).toBe('195');
+    expect(bar.value).toBe(195);
+    expect(bar.max).toBe(699);
     expect(pushHistory).toHaveBeenCalled();
   });
 });

--- a/scripts/faction.js
+++ b/scripts/faction.js
@@ -54,7 +54,12 @@ export function updateFactionRep(handlePerkEffects = () => {}) {
     input.value = val;
     const tierIdx = Math.min(REP_TIERS.length - 1, Math.floor(val / 100));
     const tierName = REP_TIERS[tierIdx];
-    bar.value = val % 100;
+    // Display the full reputation total on the progress element so players
+    // see overall advancement instead of only the progress within the current
+    // tier. Update the bar's max to the global cap to keep the visual scale in
+    // sync.
+    bar.max = maxVal;
+    bar.value = val;
     tierEl.textContent = tierName;
     perkEl.innerHTML = '';
     const facName = FACTION_NAME_MAP[f];

--- a/styles/main.css
+++ b/styles/main.css
@@ -570,6 +570,7 @@ select[required]:valid{
   border-radius: 50%;
   border: 1.5px solid var(--line, #bbb);
   background: var(--bg, #fff);
+  opacity: 1; /* override global button:disabled fade so progress dots stay visible */
 }
 .rp-dot[aria-pressed="true"] {
   background: var(--accent, #222);


### PR DESCRIPTION
## Summary
- show overall faction reputation on progress bars
- keep resonance point progress dots fully visible even when disabled
- test faction rep bar updates when gaining/losing points

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e690b36c832e87230f9a23910964