### PR TITLE
Fix RP and faction tracker UI sync issues

### DIFF
--- a/__tests__/faction_rep.test.js
+++ b/__tests__/faction_rep.test.js
@@ -26,6 +26,8 @@ describe('faction reputation tracker', () => {
     expect(repInput.value).toBe('205');
     expect(bar.value).toBe(205);
     expect(bar.max).toBe(699);
+    expect(bar.getAttribute('value')).toBe('205');
+    expect(bar.getAttribute('max')).toBe('699');
     expect(pushHistory).toHaveBeenCalled();
   });
 
@@ -53,6 +55,8 @@ describe('faction reputation tracker', () => {
     expect(repInput.value).toBe('195');
     expect(bar.value).toBe(195);
     expect(bar.max).toBe(699);
+    expect(bar.getAttribute('value')).toBe('195');
+    expect(bar.getAttribute('max')).toBe('699');
     expect(pushHistory).toHaveBeenCalled();
   });
 });

--- a/__tests__/rp_value.test.js
+++ b/__tests__/rp_value.test.js
@@ -67,6 +67,12 @@ describe('Resonance Points tracker', () => {
     document.dispatchEvent(new Event('DOMContentLoaded'));
 
     const inc = document.getElementById('rp-inc');
+    const dec = document.getElementById('rp-dec');
+
+    // At start, decrement should be disabled while increment is enabled.
+    expect(dec.disabled).toBe(true);
+    expect(inc.disabled).toBe(false);
+
     for (let i = 0; i < 5; i++) inc.click();
 
     const output = document.getElementById('rp-value');
@@ -74,15 +80,19 @@ describe('Resonance Points tracker', () => {
     expect(output.value).toBe('5');
     expect(output.getAttribute('value')).toBe('5');
 
+    // Mid-range: both controls active.
+    expect(dec.disabled).toBe(false);
+    expect(inc.disabled).toBe(false);
+
     const bankDots = document.querySelectorAll('.rp-bank-dot');
     expect(bankDots[0].getAttribute('aria-pressed')).toBe('true');
     expect(bankDots[1].getAttribute('aria-pressed')).toBe('false');
 
-    inc.click();
-    inc.click();
-    expect(output.textContent).toBe('7');
-    expect(bankDots[0].getAttribute('aria-pressed')).toBe('true');
-    expect(bankDots[1].getAttribute('aria-pressed')).toBe('false');
+    // Push to maximum to confirm increment disables at cap
+    for (let i = 0; i < 5; i++) inc.click();
+    expect(output.textContent).toBe('10');
+    expect(inc.disabled).toBe(true);
+    expect(dec.disabled).toBe(false);
   });
 });
 

--- a/scripts/faction.js
+++ b/scripts/faction.js
@@ -56,10 +56,13 @@ export function updateFactionRep(handlePerkEffects = () => {}) {
     const tierName = REP_TIERS[tierIdx];
     // Display the full reputation total on the progress element so players
     // see overall advancement instead of only the progress within the current
-    // tier. Update the bar's max to the global cap to keep the visual scale in
-    // sync.
+    // tier. Update both the DOM properties and attributes so that CSS
+    // selectors or assistive technology reading the raw attributes stay in
+    // sync with the underlying values.
     bar.max = maxVal;
     bar.value = val;
+    bar.setAttribute('max', String(maxVal));
+    bar.setAttribute('value', String(val));
     tierEl.textContent = tierName;
     perkEl.innerHTML = '';
     const facName = FACTION_NAME_MAP[f];

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1837,8 +1837,12 @@ CC.RP = (function () {
         dot.setAttribute('aria-pressed', String(v <= banked));
       });
     }
-    if (els.btnInc) els.btnInc.disabled = false;
-    if (els.btnDec) els.btnDec.disabled = false;
+    // Disable controls at their bounds so users receive immediate feedback
+    // that no further adjustment is possible. Previously the buttons remained
+    // active even when the value was clamped, leading to the impression that
+    // they were non-functional.
+    if (els.btnInc) els.btnInc.disabled = total >= 10;
+    if (els.btnDec) els.btnDec.disabled = total <= 0;
     if (els.rpTrack) els.rpTrack.classList.toggle('maxed', total >= 10);
 
     if (els.surgeState) {


### PR DESCRIPTION
## Summary
- keep faction reputation progress attributes in sync with totals
- disable RP tracker buttons at min/max values
- add tests for updated faction and RP trackers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9ee553180832e818e7ed1846c0abf