### PR TITLE
Fix ability modifier display when power save ability is missing

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -746,7 +746,13 @@ function updateDerived(){
   updateHP();
   const initiative = mod(elDex.value) + (addWisToInitiative ? mod(elWis.value) : 0);
   elInitiative.value = (initiative >= 0 ? '+' : '') + initiative;
-  elPowerSaveDC.value = 8 + pb + mod($( elPowerSaveAbility.value ).value);
+  // Guard against missing ability elements when calculating the power save DC.
+  // If the selected ability cannot be found in the DOM, default its modifier to 0
+  // rather than throwing an error which prevents other derived stats from
+  // updating and leaves all modifiers displayed as +0.
+  const saveAbilityEl = $(elPowerSaveAbility.value);
+  const saveMod = saveAbilityEl ? mod(saveAbilityEl.value) : 0;
+  elPowerSaveDC.value = 8 + pb + saveMod;
   ABILS.forEach(a=>{
     const m = mod($(a).value);
     $(a+'-mod').textContent = (m>=0?'+':'') + m;


### PR DESCRIPTION
## Summary
- avoid crashing when selected power save ability is not found
- keep ability modifiers, saves and skills updating correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9fe780650832eb85e8cbbd8a44210