### PR TITLE
Color-coded reputation tracker

### DIFF
--- a/__tests__/faction_rep.test.js
+++ b/__tests__/faction_rep.test.js
@@ -28,6 +28,11 @@ describe('faction reputation tracker', () => {
     expect(bar.max).toBe(699);
     expect(bar.getAttribute('value')).toBe('205');
     expect(bar.getAttribute('max')).toBe('699');
+    const expectedHue = 120 * (205 / 699);
+    const expectedColor = `hsl(${expectedHue}, 70%, 50%)`;
+    expect(bar.style.getPropertyValue('--progress-color')).toBe(expectedColor);
+    const tier = document.getElementById('omni-rep-tier');
+    expect(tier.style.getPropertyValue('--progress-color')).toBe(expectedColor);
     expect(pushHistory).toHaveBeenCalled();
   });
 
@@ -57,6 +62,11 @@ describe('faction reputation tracker', () => {
     expect(bar.max).toBe(699);
     expect(bar.getAttribute('value')).toBe('195');
     expect(bar.getAttribute('max')).toBe('699');
+    const expectedHue = 120 * (195 / 699);
+    const expectedColor = `hsl(${expectedHue}, 70%, 50%)`;
+    expect(bar.style.getPropertyValue('--progress-color')).toBe(expectedColor);
+    const tier = document.getElementById('omni-rep-tier');
+    expect(tier.style.getPropertyValue('--progress-color')).toBe(expectedColor);
     expect(pushHistory).toHaveBeenCalled();
   });
 });

--- a/__tests__/rp_value.test.js
+++ b/__tests__/rp_value.test.js
@@ -41,7 +41,7 @@ describe('Resonance Points tracker', () => {
     document.getElementById = (id) => realGet(id) || {
       innerHTML: '',
       value: '',
-      style: {},
+      style: { setProperty: () => {}, getPropertyValue: () => '' },
       classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
       setAttribute: () => {},
       getAttribute: () => null,

--- a/scripts/faction.js
+++ b/scripts/faction.js
@@ -63,7 +63,12 @@ export function updateFactionRep(handlePerkEffects = () => {}) {
     bar.value = val;
     bar.setAttribute('max', String(maxVal));
     bar.setAttribute('value', String(val));
+    const ratio = val / maxVal;
+    const hue = 120 * ratio;
+    const color = `hsl(${hue}, 70%, 50%)`;
+    bar.style.setProperty('--progress-color', color);
     tierEl.textContent = tierName;
+    tierEl.style.setProperty('--progress-color', color);
     perkEl.innerHTML = '';
     const facName = FACTION_NAME_MAP[f];
     const perks = (FACTION_REP_PERKS[facName] && FACTION_REP_PERKS[facName][tierName]) || [];

--- a/styles/main.css
+++ b/styles/main.css
@@ -180,9 +180,10 @@ button:focus-visible{outline:2px solid var(--accent);outline-offset:2px;animatio
   }
 }
 progress{
+  --progress-color: var(--accent);
   -webkit-appearance:none;
   appearance:none;
-  border:1px solid var(--accent);
+  border:1px solid var(--progress-color);
   border-radius:999px;
   background:var(--surface-2);
   overflow:hidden;
@@ -192,15 +193,24 @@ progress::-webkit-progress-bar{
   background:var(--surface-2);
 }
 progress::-webkit-progress-value{
-  background:var(--accent);
+  background:var(--progress-color);
   transition:width .4s ease;
 }
 progress::-moz-progress-bar{
-  background:var(--accent);
+  background:var(--progress-color);
   transition:width .4s ease;
 }
 
-.pill{display:inline-block;padding:6px 10px;border:1px solid var(--accent);border-radius:999px;color:var(--accent);font-size:.85rem;white-space:nowrap}
+.pill{
+  --progress-color: var(--accent);
+  display:inline-block;
+  padding:6px 10px;
+  border:1px solid var(--progress-color);
+  border-radius:999px;
+  color:var(--progress-color);
+  font-size:.85rem;
+  white-space:nowrap;
+}
 
 .bar-label{position:relative}
 .bar-label>progress{width:100%;height:36px}


### PR DESCRIPTION
## Summary
- add dynamic color gradient for faction reputation progress bars and tier pills
- style progress elements and pills via CSS variables for per-level color
- test reputation updates for color changes and fix RP test stubs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba025de7a4832e9647dc53e8cbb8f9