### PR TITLE
Revamp load modal layout with actions and delete confirmation

### DIFF
--- a/index.html
+++ b/index.html
@@ -505,11 +505,14 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
-    <h3>Your Characters</h3>
-    <div id="char-list" class="catalog"></div>
-    <div class="inline">
-      <input id="new-character-name" placeholder="New character name"/>
-      <button id="create-character" class="btn-sm" type="button">Create/Switch</button>
+    <h3>All Characters</h3>
+    <div class="load-layout">
+      <div id="char-list" class="catalog"></div>
+      <div class="load-actions">
+        <button id="recover-save" class="btn-sm" type="button">Recover Save</button>
+        <button id="create-character" class="btn-sm" type="button">Create New</button>
+        <button id="save-current" class="btn-sm" type="button">Save</button>
+      </div>
     </div>
   </div>
 </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -406,6 +406,10 @@ progress::-moz-progress-bar{
 .catalog-item:last-child{border-bottom:none}
 .catalog-item.active{background:var(--accent);color:var(--text-on-accent)}
 .catalog-item.active .pill{border-color:var(--text-on-accent);color:var(--text-on-accent)}
+#char-list .catalog-item{grid-template-columns:1fr auto}
+.load-layout{display:flex;gap:16px;align-items:flex-start}
+.load-actions{display:flex;flex-direction:column;gap:10px;min-width:120px}
+.load-actions button{width:100%}
 .small{font-size:.9rem;color:var(--muted)}
 .overlay{position:fixed;top:0;left:0;right:0;height:calc(var(--vh,1vh)*100);display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.6);backdrop-filter:blur(2px);z-index:1000;padding:16px 16px calc(16px + env(safe-area-inset-bottom));opacity:1;pointer-events:auto;transition:opacity .3s ease-in-out;will-change:opacity}
 .overlay.hidden{opacity:0;pointer-events:none}


### PR DESCRIPTION
## Summary
- Restyle load modal with two-column layout and action buttons
- Display characters with delete icons and add double-confirm before removal
- Add recover, create, and save controls alongside character list
- Confirm before starting a new character to avoid accidental progress loss

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba04aa8dd4832ea7630dad28d5f92f