### PR TITLE
feat: invert logo in light theme

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -72,6 +72,9 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
   height:36px;
   width:auto;
 }
+.theme-light .tabs-title .logo{
+  filter:invert(1);
+}
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{max-width:65ch;margin:16px auto;padding:0 12px calc(4px + env(safe-area-inset-bottom))}
 fieldset[data-tab].card{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:14px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translateX(10px);cursor:default;transition:opacity .3s ease,transform .3s ease}


### PR DESCRIPTION
## Summary
- invert header logo when enabling the light theme for better visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba09298958832eb8d29c2f365b1fda