### PR TITLE
Ensure combat stat cards match dice roll width on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
   </fieldset>
 
   <fieldset data-tab="combat" class="card">
-    <div class="grid grid-2">
+    <div class="grid grid-2 grid-2-fixed">
       <fieldset class="card hp-field">
         <legend>HP</legend>
           <input id="hp-roll" type="hidden" value="0"/>
@@ -165,7 +165,7 @@
       </fieldset>
     </div>
 
-    <div class="grid grid-2">
+    <div class="grid grid-2 grid-2-fixed">
       <fieldset class="card">
         <legend>Stats and Effects</legend>
         <label for="initiative">Initiative Bonus</label>

--- a/styles/main.css
+++ b/styles/main.css
@@ -89,6 +89,7 @@ footer p{max-width:none}
 .grid-1{grid-template-columns:1fr}
 .grid-2{grid-template-columns:1fr}
 .grid-3{grid-template-columns:1fr}
+.grid-2-fixed{grid-template-columns:repeat(2,1fr)}
 @media(min-width:600px){.grid-2{grid-template-columns:repeat(2,1fr)}.grid-3{grid-template-columns:repeat(2,1fr)}}
 @media(min-width:900px){.grid-3{grid-template-columns:repeat(3,1fr)}}
 #statuses{grid-template-columns:repeat(2,1fr);margin-top:8px}


### PR DESCRIPTION
## Summary
- Add `grid-2-fixed` CSS utility to force two-column layout on small screens
- Apply `grid-2-fixed` to HP/SP and Stats & Effects/Resonance Points sections so their width mirrors Dice Roll & Coin Flip modals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa0053f60832eaae70f14d172c5e0