### PR TITLE
Display combat resources in single column layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
   </fieldset>
 
   <fieldset data-tab="combat" class="card">
-    <div class="grid grid-2 grid-2-fixed">
+    <div class="grid grid-1">
       <fieldset class="card hp-field">
         <legend>HP</legend>
           <input id="hp-roll" type="hidden" value="0"/>
@@ -165,7 +165,7 @@
       </fieldset>
     </div>
 
-    <div class="grid grid-2 grid-2-fixed">
+    <div class="grid grid-1">
       <fieldset class="card">
         <legend>Stats and Effects</legend>
         <label for="initiative">Initiative Bonus</label>
@@ -178,7 +178,7 @@
         <input id="tc" type="number" readonly/>
         <div class="status-effects">
           <h3>Status Effects</h3>
-          <div id="statuses" class="grid grid-2"></div>
+          <div id="statuses" class="grid grid-1"></div>
         </div>
       </fieldset>
 


### PR DESCRIPTION
## Summary
- Stack HP, SP, Cinematic Action Point, RP, Stats & Effects, and Status Effects sections in a single column to match Dice Roll/Coin Flip width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bae6343860832e99da6c705c5e67f3