### PR TITLE
Add character selection for recovery save flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,6 +517,18 @@
   </div>
 </div>
 
+<div class="overlay hidden" id="modal-recover-char" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Select Character</h3>
+    <div id="recover-char-list" class="catalog"></div>
+  </div>
+</div>
+
 <div class="overlay hidden" id="modal-recover-list" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
     <button class="x" data-close aria-label="Close">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1147,6 +1147,15 @@ async function renderCharacterList(){
   selectedChar = current;
 }
 
+async function renderRecoverCharList(){
+  const list = $('recover-char-list');
+  if(!list) return;
+  let names = [];
+  try { names = await listCharacters(); }
+  catch (e) { console.error('Failed to list characters', e); }
+  list.innerHTML = names.map(c=>`<div class="catalog-item"><button class="btn-sm" data-char="${c}">${c}</button></div>`).join('');
+}
+
 async function renderRecoverList(name){
   const list = $('recover-list');
   if(!list) return;
@@ -1156,7 +1165,7 @@ async function renderRecoverList(name){
   if(backups.length === 0){
     list.innerHTML = '<p>No backups found.</p>';
   } else {
-    list.innerHTML = backups.map(b=>`<div class="catalog-item"><button class="btn-sm" data-recover-ts="${b.ts}">${new Date(b.ts).toLocaleString()}</button></div>`).join('');
+    list.innerHTML = backups.map(b=>`<div class="catalog-item"><button class="btn-sm" data-recover-ts="${b.ts}">${name} - ${new Date(b.ts).toLocaleString()}</button></div>`).join('');
   }
   show('modal-recover-list');
 }
@@ -1190,12 +1199,24 @@ if(charList){
   });
 }
 
+const recoverCharListEl = $('recover-char-list');
+if(recoverCharListEl){
+  recoverCharListEl.addEventListener('click', e=>{
+    const btn = e.target.closest('button[data-char]');
+    if(btn){
+      recoverTarget = btn.dataset.char;
+      hide('modal-recover-char');
+      renderRecoverList(recoverTarget);
+    }
+  });
+}
+
 const recoverBtn = $('recover-save');
 if(recoverBtn){
-  recoverBtn.addEventListener('click', ()=>{
-    if(!selectedChar) return toast('Select a character first','error');
-    recoverTarget = selectedChar;
-    renderRecoverList(recoverTarget);
+  recoverBtn.addEventListener('click', async ()=>{
+    hide('modal-load-list');
+    await renderRecoverCharList();
+    show('modal-recover-char');
   });
 }
 


### PR DESCRIPTION
## Summary
- Add new modal to choose a character when recovering saves
- Display character name and timestamp for recent backups
- Update recover flow to list characters before showing backups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baed53dd10832e957ccc24ea05e73f