### PR TITLE
Center combat section after death saves

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
     </fieldset>
     </fieldset>
 
-  <fieldset data-tab="combat" class="card card-wide">
+  <fieldset data-tab="combat" class="card">
     <div class="grid grid-1">
       <fieldset class="card hp-field">
         <legend>HP</legend>

--- a/styles/main.css
+++ b/styles/main.css
@@ -415,7 +415,6 @@ progress::-moz-progress-bar{
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:8px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .3s ease-in-out;background:color-mix(in srgb,var(--surface) 85%,transparent)}
 .card:focus-within{box-shadow:0 0 0 2px var(--accent),var(--shadow)}
 .card.dragging{opacity:.5}
-.card-wide{margin-left:calc(-20px - env(safe-area-inset-left));width:calc(100% + 20px + env(safe-area-inset-left))}
 .catalog{max-height:360px;overflow:auto;border:1px dashed var(--line);border-radius:10px;padding:6px}
 .perk-list{margin:0;padding-left:20px;list-style:disc}
 .perk{margin:0}


### PR DESCRIPTION
## Summary
- Remove `card-wide` layout to center combat elements below death saves
- Drop unused `card-wide` CSS rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb3eb4f948832ea3a8d45b4ad274f7