### PR TITLE
Make all cards wide and translucent

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
     </fieldset>
     </fieldset>
 
-  <fieldset data-tab="combat" class="card card-wide">
+  <fieldset data-tab="combat" class="card">
     <div class="grid grid-1">
       <fieldset class="card hp-field">
         <legend>HP</legend>

--- a/styles/main.css
+++ b/styles/main.css
@@ -77,7 +77,7 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 }
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{width:100%;max-width:var(--content-width);margin:16px auto;padding:0 calc(20px + env(safe-area-inset-right)) calc(4px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left))}
-fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 85%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:10px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translateX(10px);cursor:default;transition:opacity .3s ease,transform .3s ease}
+fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:10px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translateX(10px);cursor:default;transition:opacity .3s ease,transform .3s ease}
 main>:last-child{margin-bottom:0}
 fieldset[data-tab].card.active{display:block;opacity:1;transform:translateX(0)}
 fieldset[data-tab].card>legend{font-size:1.5rem;font-weight:600;color:var(--accent);margin:0 0 10px}
@@ -412,10 +412,9 @@ progress::-moz-progress-bar{
 .sp-field #sp-temp{flex:0 0 60px;max-width:60px;}
 .sp-field #long-rest{width:100%;margin-top:8px;}
 .sp-field .cap-box{margin-top:8px;}
-.card{border:1px solid var(--line);border-radius:var(--radius);padding:8px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .3s ease-in-out;background:color-mix(in srgb,var(--surface) 85%,transparent)}
+.card{border:1px solid var(--line);border-radius:var(--radius);padding:8px;display:flex;flex-direction:column;gap:10px;cursor:grab;transition:box-shadow .3s ease-in-out;background:color-mix(in srgb,var(--surface) 5%,transparent);margin-left:calc(-20px - env(safe-area-inset-left));width:calc(100% + 20px + env(safe-area-inset-left));font-size:1.1rem}
 .card:focus-within{box-shadow:0 0 0 2px var(--accent),var(--shadow)}
 .card.dragging{opacity:.5}
-.card-wide{margin-left:calc(-20px - env(safe-area-inset-left));width:calc(100% + 20px + env(safe-area-inset-left))}
 .catalog{max-height:360px;overflow:auto;border:1px dashed var(--line);border-radius:10px;padding:6px}
 .perk-list{margin:0;padding-left:20px;list-style:disc}
 .perk{margin:0}


### PR DESCRIPTION
## Summary
- Expand card styling to full-width and enlarge content
- Adjust card backgrounds to 95% transparency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3eb4f948832ea3a8d45b4ad274f7