### PR TITLE
Reset sections on new character

### DIFF
--- a/__tests__/new_character.test.js
+++ b/__tests__/new_character.test.js
@@ -1,0 +1,60 @@
+import { jest } from '@jest/globals';
+
+describe('new character reset', () => {
+  test('starting a new character resets ability scores and story fields', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ text: async () => '' });
+
+    document.body.innerHTML = `
+      <div id="abil-grid"></div>
+      <div id="saves"></div>
+      <div id="skills"></div>
+      <div id="powers"></div>
+      <div id="sigs"></div>
+      <div id="weapons"></div>
+      <div id="armors"></div>
+      <div id="items"></div>
+      <div id="campaign-log"></div>
+      <button id="create-character"></button>
+      <input id="superhero" />
+    `;
+
+    const realGet = document.getElementById.bind(document);
+    document.getElementById = (id) => realGet(id) || {
+      innerHTML: '',
+      value: '',
+      style: { setProperty: () => {}, getPropertyValue: () => '' },
+      classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+      setAttribute: () => {},
+      getAttribute: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      appendChild: () => {},
+      contains: () => false,
+      add: () => {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      focus: () => {},
+      click: () => {},
+      textContent: '',
+      disabled: false,
+      checked: false,
+      hidden: false
+    };
+
+    console.error = jest.fn();
+
+    await import('../scripts/main.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.getElementById('str').value = '18';
+    document.getElementById('superhero').value = 'Vigilante';
+
+    window.confirm = jest.fn().mockReturnValue(true);
+    window.prompt = jest.fn().mockReturnValue('Hero');
+
+    document.getElementById('create-character').click();
+
+    expect(document.getElementById('str').value).toBe('10');
+    expect(document.getElementById('superhero').value).toBe('');
+  });
+});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,6 @@
 /* ========= helpers ========= */
 import { $, qs, qsa, num, mod, calculateArmorBonus, revertAbilityScore } from './helpers.js';
-import { setupFactionRepTracker, ACTION_HINTS } from './faction.js';
+import { setupFactionRepTracker, ACTION_HINTS, updateFactionRep } from './faction.js';
 import {
   currentCharacter,
   setCurrentCharacter,
@@ -1232,7 +1232,7 @@ if(newCharBtn){
     const clean = name.trim();
     if(!clean) return toast('Name required','error');
     setCurrentCharacter(clean);
-    deserialize({});
+    deserialize(DEFAULT_STATE);
     hide('modal-load-list');
     toast(`Switched to ${clean}`,'success');
   });
@@ -1662,7 +1662,8 @@ function serialize(){
   data.campaignLog = campaignLog;
   return data;
 }
-function deserialize(data){
+const DEFAULT_STATE = serialize();
+ function deserialize(data){
   $('powers').innerHTML=''; $('sigs').innerHTML=''; $('weapons').innerHTML=''; $('armors').innerHTML=''; $('items').innerHTML='';
   Object.entries(data||{}).forEach(([k,v])=>{ const el=$(k); if (!el) return; if (el.type==='checkbox') el.checked=!!v; else el.value=v; });
   (data && data.powers ? data.powers : []).forEach(p=> $('powers').appendChild(createCard('power', p)));
@@ -1678,6 +1679,7 @@ function deserialize(data){
     currentTierIdx = getTierIndex(xp);
   }
   updateDerived();
+  updateFactionRep(handlePerkEffects);
 }
 
 /* ========= autosave + history ========= */


### PR DESCRIPTION
## Summary
- Reset ability scores and character/story fields using a stored default state when creating a new character
- Refresh faction reputation data during deserialization
- Add regression test verifying new character reset behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb42ba7bd8832e916c00f6914bb085