### PR TITLE
Remove save option from load confirmation

### DIFF
--- a/index.html
+++ b/index.html
@@ -545,7 +545,6 @@
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
     <p id="load-confirm-text"></p>
     <div class="actions">
-      <button id="load-save" class="btn-sm">Save</button>
       <button id="load-cancel" class="btn-sm">Cancel</button>
       <button id="load-accept" class="btn-sm">Accept</button>
     </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1260,7 +1260,6 @@ if(recoverListEl){
   });
 }
 
-const loadSaveBtn = $('load-save');
 const loadCancelBtn = $('load-cancel');
 const loadAcceptBtn = $('load-accept');
 async function doLoad(){
@@ -1277,13 +1276,6 @@ async function doLoad(){
   }catch(e){
     toast('Load failed','error');
   }
-}
-if(loadSaveBtn){
-  loadSaveBtn.addEventListener('click', async ()=>{
-    try{ await saveCharacter(serialize()); }
-    catch(e){ toast('Save failed','error'); return; }
-    await doLoad();
-  });
 }
 if(loadAcceptBtn){ loadAcceptBtn.addEventListener('click', doLoad); }
 if(loadCancelBtn){ loadCancelBtn.addEventListener('click', ()=>{ hide('modal-load'); }); }


### PR DESCRIPTION
## Summary
- Remove redundant save button from load confirmation modal
- Simplify load flow by dropping unused save handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb426c54f4832e99546da5056cfb4c