### PR TITLE
Prevent emoji animations from flashing on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,13 +750,13 @@
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
   <p>Product of XoVrom industries ® 2025</p>
 </footer>
-<div id="down-animation" aria-hidden="true">⚠️</div>
-<div id="death-animation" aria-hidden="true">💀</div>
-<div id="damage-animation" aria-hidden="true"></div>
-<div id="heal-animation" aria-hidden="true"></div>
-<div id="save-animation" aria-hidden="true">💾</div>
-<div id="coin-animation" aria-hidden="true"></div>
-<div id="sp-animation" aria-hidden="true"></div>
+<div id="down-animation" aria-hidden="true" hidden>⚠️</div>
+<div id="death-animation" aria-hidden="true" hidden>💀</div>
+<div id="damage-animation" aria-hidden="true" hidden></div>
+<div id="heal-animation" aria-hidden="true" hidden></div>
+<div id="save-animation" aria-hidden="true" hidden>💾</div>
+<div id="coin-animation" aria-hidden="true" hidden></div>
+<div id="sp-animation" aria-hidden="true" hidden></div>
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script type="module" src="scripts/main.js"></script>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -967,10 +967,12 @@ function playDamageAnimation(amount){
   const anim=$('damage-animation');
   if(!anim) return Promise.resolve();
   anim.textContent=`${amount}`;
+  anim.hidden=false;
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{
       anim.classList.remove('show');
+      anim.hidden=true;
       anim.removeEventListener('animationend', done);
       res();
     };
@@ -982,10 +984,12 @@ function playDownAnimation(){
   if(!animationsEnabled) return Promise.resolve();
   const anim = $('down-animation');
   if(!anim) return Promise.resolve();
+  anim.hidden=false;
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{
       anim.classList.remove('show');
+      anim.hidden=true;
       anim.removeEventListener('animationend', done);
       res();
     };
@@ -997,10 +1001,12 @@ function playDeathAnimation(){
   if(!animationsEnabled) return Promise.resolve();
   const anim = $('death-animation');
   if(!anim) return Promise.resolve();
+  anim.hidden=false;
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{
       anim.classList.remove('show');
+      anim.hidden=true;
       anim.removeEventListener('animationend', done);
       res();
     };
@@ -1013,10 +1019,12 @@ function playHealAnimation(amount){
   const anim=$('heal-animation');
   if(!anim) return Promise.resolve();
   anim.textContent=`+${amount}`;
+  anim.hidden=false;
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{
       anim.classList.remove('show');
+      anim.hidden=true;
       anim.removeEventListener('animationend', done);
       res();
     };
@@ -1028,10 +1036,12 @@ function playSaveAnimation(){
   if(!animationsEnabled) return Promise.resolve();
   const anim=$('save-animation');
   if(!anim) return Promise.resolve();
+  anim.hidden=false;
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{
       anim.classList.remove('show');
+      anim.hidden=true;
       anim.removeEventListener('animationend', done);
       res();
     };
@@ -1044,10 +1054,12 @@ function playCoinAnimation(result){
   const anim=$('coin-animation');
   if(!anim) return Promise.resolve();
   anim.textContent=result;
+  anim.hidden=false;
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{
       anim.classList.remove('show');
+      anim.hidden=true;
       anim.removeEventListener('animationend', done);
       res();
     };
@@ -1060,10 +1072,12 @@ function playSPAnimation(amount){
   const anim = $('sp-animation');
   if(!anim) return Promise.resolve();
   anim.textContent = `${amount>0?'+':''}${amount}`;
+  anim.hidden=false;
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{
       anim.classList.remove('show');
+      anim.hidden=true;
       anim.removeEventListener('animationend', done);
       res();
     };


### PR DESCRIPTION
## Summary
- Hide animation emoji containers until activated to avoid flash on refresh
- Unhide and re-hide containers when playing animations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbae2ee898832e9fcd0f4caaa27cd7