### PR TITLE
Add fun tip menu option to entertain users

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
         <button id="btn-campaign" class="btn-sm">Campaign Log</button>
         <button id="btn-rules" class="btn-sm">Rules</button>
         <button id="btn-help" class="btn-sm">Help</button>
+        <button id="btn-fun" class="btn-sm">Fun Tip</button>
         <button id="btn-save" class="btn-sm">Save</button>
       </div>
     </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1144,6 +1144,24 @@ const btnHelp = $('btn-help');
 if (btnHelp) {
   btnHelp.addEventListener('click', ()=>{ show('modal-help'); });
 }
+const btnFun = $('btn-fun');
+if (btnFun) {
+  // Lighthearted reminders to amuse players and hint at game mechanics
+  const tips = [
+    'A hero is just one good roll away.',
+    'Check your gear before heading out!',
+    'Remember to take breaks between battles.',
+    'Allies can turn the tide—track your faction rep.',
+    'Saving your progress is the real treasure.',
+    'Try a new build; surprises keep enemies guessing.',
+    'Even mutants need snacks; pack some supplies.',
+    'Roll high and stay hydrated.'
+  ];
+  btnFun.addEventListener('click', () => {
+    const tip = tips[Math.floor(Math.random() * tips.length)];
+    toast(tip, 'info');
+  });
+}
 const btnLoad = $('btn-load');
 if (btnLoad) {
   btnLoad.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add "Fun Tip" menu button to deliver random playful messages
- wire up button to show random tip via toast
- expand tip list with more varied in-game reminders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbb1c1e9f0832e85e3fb82372768ed