### PR TITLE
feat: extend user action animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -758,6 +758,7 @@
 <div id="save-animation" aria-hidden="true" hidden>💾</div>
 <div id="coin-animation" aria-hidden="true" hidden></div>
 <div id="sp-animation" aria-hidden="true" hidden></div>
+<div id="load-animation" aria-hidden="true" hidden>📂</div>
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script type="module" src="scripts/main.js"></script>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -40,7 +40,7 @@ header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(calc(-
 #btn-menu.open svg{transform:rotate(90deg)}
 .icon:hover,.tab:hover{background:var(--accent);color:var(--text-on-accent);transform:translateY(-1px)}
 .icon:active{transform:translateY(1px)}
-.icon:focus-visible,.tab:focus-visible,.modal .x:focus-visible,a:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.modal .x:focus-visible,a:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 a{color:var(--accent);text-decoration:none}
 a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 .skip-link{position:absolute;left:-999px;top:auto;width:1px;height:1px;overflow:hidden;}
@@ -148,8 +148,12 @@ button:disabled{background:var(--surface-2);color:var(--muted);cursor:not-allowe
 button.loading{opacity:.8;pointer-events:none;position:relative;padding-right:2.5em}
 button.loading::after{content:"";position:absolute;width:1em;height:1em;border:2px solid currentColor;border-top-color:transparent;border-radius:50%;right:8px;top:50%;transform:translateY(-50%);animation:spin 1s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
-button:focus-visible{outline:2px solid var(--accent);outline-offset:2px;animation:focusPulse .6s ease}
+button:focus-visible,
+.icon:focus-visible,
+.tab:focus-visible{outline:2px solid var(--accent);outline-offset:2px;animation:focusPulse .6s ease}
 @keyframes focusPulse{from{box-shadow:0 0 0 0 var(--accent)}to{box-shadow:0 0 0 6px transparent}}
+.action-anim{animation:pressFeedback .2s ease}
+@keyframes pressFeedback{0%{transform:scale(1)}50%{transform:scale(.95)}100%{transform:scale(1)}}
 .btn-sm{min-height:36px;padding:8px 10px;border-radius:var(--radius);font-size:clamp(.6rem,2vw,.85rem);display:flex;align-items:center;justify-content:center;white-space:nowrap}
 .btn-sm:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .btn-sm:disabled{opacity:.5;cursor:not-allowed}
@@ -405,6 +409,26 @@ progress::-moz-progress-bar{
   0%{transform:scale(0);opacity:0;}
   30%{transform:scale(1.2);opacity:1;}
   100%{transform:scale(1);opacity:0;}
+}
+#load-animation{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:6rem;
+  color:var(--accent);
+  pointer-events:none;
+  opacity:0;
+  z-index:3000;
+}
+#load-animation.show{
+  animation:loadDrop 1s ease-in-out forwards;
+}
+@keyframes loadDrop{
+  0%{transform:translateY(-20px);opacity:0;}
+  30%{transform:translateY(0);opacity:1;}
+  100%{transform:translateY(20px);opacity:0;}
 }
 .sp-grid{display:grid;width:100%;grid-template-columns:repeat(3,1fr);gap:8px;}
 .sp-grid .btn-sm{width:100%;}


### PR DESCRIPTION
## Summary
- generalize click animation to icons, tabs, and other controls
- add focus pulse feedback for icons and tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbb54bdbfc832ebea61cbecfb2e5b6