### PR TITLE
Extend fun tip toast duration to 5 seconds

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -116,13 +116,13 @@ function playTone(type){
     osc.stop(audioCtx.currentTime + 0.15);
   }catch(e){ /* noop */ }
 }
-function toast(msg, type='info'){
+function toast(msg,type='info'){
   const t=$('toast');
   t.textContent=msg;
   t.className=`toast ${type}`;
   t.classList.add('show');
   playTone(type);
-  setTimeout(()=>t.classList.remove('show'),1200);
+  setTimeout(()=>t.classList.remove('show'),5000);
 }
 
 function debounce(fn, delay){
@@ -1225,7 +1225,7 @@ if (btnFun) {
     if (!getNextTip) {
       ({ getNextTip } = await import('./funTips.js'));
     }
-    toast(getNextTip(), 'info');
+    toast(getNextTip(),'info');
   });
 }
 const btnLoad = $('btn-load');


### PR DESCRIPTION
## Summary
- Hardcode toast helper to a fixed five-second duration
- Trigger fun tip toast without extra configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc11a2e3dc832e8290cfefeda8eac4