### PR TITLE
style: redesign death saves card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,30 +102,32 @@
     </div>
     <fieldset class="card">
       <legend>Death Saves</legend>
-      <span class="pill result" id="death-save-out" data-placeholder="Roll"></span>
-      <div class="death-saves">
-        <div class="death-save-group">
-          <span>Successes</span>
-          <label for="death-success-1" class="sr-only">Success 1</label>
-          <input type="checkbox" id="death-success-1"/>
-          <label for="death-success-2" class="sr-only">Success 2</label>
-          <input type="checkbox" id="death-success-2"/>
-          <label for="death-success-3" class="sr-only">Success 3</label>
-          <input type="checkbox" id="death-success-3"/>
+      <div class="death-saves-grid">
+        <div class="death-save-tracks">
+          <div class="death-save-group">
+            <span>Successes</span>
+            <label for="death-success-1" class="sr-only">Success 1</label>
+            <input type="checkbox" id="death-success-1"/>
+            <label for="death-success-2" class="sr-only">Success 2</label>
+            <input type="checkbox" id="death-success-2"/>
+            <label for="death-success-3" class="sr-only">Success 3</label>
+            <input type="checkbox" id="death-success-3"/>
+          </div>
+          <div class="death-save-group">
+            <span>Failures</span>
+            <label for="death-fail-1" class="sr-only">Failure 1</label>
+            <input type="checkbox" id="death-fail-1"/>
+            <label for="death-fail-2" class="sr-only">Failure 2</label>
+            <input type="checkbox" id="death-fail-2"/>
+            <label for="death-fail-3" class="sr-only">Failure 3</label>
+            <input type="checkbox" id="death-fail-3"/>
+          </div>
         </div>
-        <div class="death-save-group">
-          <span>Failures</span>
-          <label for="death-fail-1" class="sr-only">Failure 1</label>
-          <input type="checkbox" id="death-fail-1"/>
-          <label for="death-fail-2" class="sr-only">Failure 2</label>
-          <input type="checkbox" id="death-fail-2"/>
-          <label for="death-fail-3" class="sr-only">Failure 3</label>
-          <input type="checkbox" id="death-fail-3"/>
+        <span id="death-save-out" class="death-save-result" data-placeholder="Roll"></span>
+        <div class="death-save-buttons">
+          <button id="roll-death-save" class="btn-sm" type="button">Roll</button>
+          <button id="death-save-reset" class="btn-sm" type="button">Reset</button>
         </div>
-      </div>
-      <div class="inline">
-        <button id="roll-death-save" class="btn-sm" type="button">Roll</button>
-        <button id="death-save-reset" class="btn-sm" type="button">Reset</button>
       </div>
     </fieldset>
     </fieldset>

--- a/styles/main.css
+++ b/styles/main.css
@@ -267,10 +267,14 @@ progress::-moz-progress-bar{
 .faction-rep .inline>button{flex:0 0 auto;width:auto;}
 .faction-rep progress{width:100%;height:20px;}
 .faction-rep .btn-sm{min-height:28px;padding:4px 6px;}
-.death-saves{display:flex;flex-direction:column;gap:16px;align-items:center;}
-.death-save-group{display:grid;grid-template-columns:repeat(3,auto);gap:32px;justify-content:center;}
-.death-save-group span{grid-column:1/-1;text-align:center;}
+.death-saves-grid{display:grid;grid-template-columns:auto 64px auto;gap:16px;align-items:center;}
+.death-save-tracks{display:flex;flex-direction:column;gap:16px;}
+.death-save-group{display:flex;flex-direction:column;gap:4px;}
+.death-save-group span{text-align:left;}
 .death-save-group input[type="checkbox"]{margin:0;}
+#death-save-out.death-save-result{display:flex;align-items:center;justify-content:center;border:1px solid var(--accent);width:64px;height:64px;font-weight:700;}
+#death-save-out.death-save-result:empty::before{content:attr(data-placeholder);visibility:hidden;}
+.death-save-buttons{display:flex;flex-direction:column;gap:8px;}
 #down-animation{
   position:fixed;
   inset:0;


### PR DESCRIPTION
## Summary
- restructure death saves card with grid layout separating trackers, result, and controls
- style death save tracker groups vertically with square result display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc1e3a1ec8832ea7e975224194fcae