### PR TITLE
style: adjust death save layout

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -269,10 +269,10 @@ progress::-moz-progress-bar{
 .faction-rep .btn-sm{min-height:28px;padding:4px 6px;}
 .death-saves-grid{display:grid;grid-template-columns:auto 64px auto;gap:16px;align-items:center;}
 .death-save-tracks{display:flex;flex-direction:column;gap:16px;}
-.death-save-group{display:flex;flex-direction:column;gap:4px;}
+.death-save-group{display:flex;flex-direction:row;align-items:center;gap:4px;}
 .death-save-group span{text-align:left;}
 .death-save-group input[type="checkbox"]{margin:0;}
-#death-save-out.death-save-result{display:flex;align-items:center;justify-content:center;border:1px solid var(--accent);width:64px;height:64px;font-weight:700;}
+#death-save-out.death-save-result{display:flex;align-items:center;justify-content:center;border:1px solid var(--accent);border-radius:var(--radius);width:64px;height:64px;font-weight:700;}
 #death-save-out.death-save-result:empty::before{content:attr(data-placeholder);visibility:hidden;}
 .death-save-buttons{display:flex;flex-direction:column;gap:8px;}
 #down-animation{


### PR DESCRIPTION
## Summary
- align death save success and failure dots horizontally
- round corners on death save roll display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2076c80c832e9db4b4f3ea5cf0a7