### PR TITLE
Reorganize Stats & Effects layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,14 +185,24 @@
     <div class="grid grid-1">
       <fieldset class="card">
         <legend>Stats and Effects</legend>
-        <label for="initiative">Initiative Bonus</label>
-        <input id="initiative" type="text" inputmode="numeric" placeholder="auto from DEX + bonuses" readonly/>
-        <label for="speed">Speed (ft)</label>
-        <input id="speed" type="number" inputmode="numeric" placeholder="30"/>
-        <label for="pp">Passive Perception</label>
-        <input id="pp" type="number" readonly/>
-        <label for="tc">TC</label>
-        <input id="tc" type="number" readonly/>
+        <div class="stats-grid">
+          <div>
+            <label for="initiative">Initiative Bonus</label>
+            <input id="initiative" type="text" inputmode="numeric" placeholder="auto from DEX + bonuses" readonly/>
+          </div>
+          <div>
+            <label for="speed">Speed (ft)</label>
+            <input id="speed" type="number" inputmode="numeric" placeholder="30"/>
+          </div>
+          <div>
+            <label for="pp">Passive Perception</label>
+            <input id="pp" type="number" readonly/>
+          </div>
+          <div>
+            <label for="tc">TC</label>
+            <input id="tc" type="number" readonly/>
+          </div>
+        </div>
         <div class="status-effects">
           <h3>Status Effects</h3>
           <div id="statuses" class="grid grid-1"></div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -107,6 +107,7 @@ footer p{
 @media(min-width:900px){.grid-3{grid-template-columns:repeat(3,1fr)}}
 #statuses{grid-template-columns:repeat(2,1fr);margin-top:8px}
 .status-effects{font-size:90%}
+.stats-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px}
 label{display:block;font-weight:700;margin-bottom:6px}
 input:not([type="checkbox"]),select,textarea,button{-webkit-appearance:none;-moz-appearance:none;appearance:none;width:auto;max-width:100%;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:12px;transition:var(--transition)}
 input:not([type="checkbox"]),select,textarea{width:100%}


### PR DESCRIPTION
## Summary
- Display Stats and Effects in a two-column grid with grouped fields for Initiative, Speed, Passive Perception, and TC.
- Add styling for new Stats grid layout.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc39c067c4832ea812063f0de1db48