### PR TITLE
Restrict status effect toast to gameplay actions

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -418,19 +418,18 @@ if (statusGrid) {
   });
 }
 
+const ACTION_BUTTONS = 'button:not(.tab), [role="button"], [data-roll-save], [data-roll-skill], [data-add], [data-del]';
 document.addEventListener('click', e => {
-  if (activeStatuses.size &&
-      !e.target.closest('header .top') &&
-      !e.target.closest('header .tabs') &&
-      !e.target.closest('#statuses') &&
-      !e.target.closest('#modal-enc') &&
-      !e.target.closest('#modal-log') &&
-      !e.target.closest('#modal-log-full') &&
-      !e.target.closest('#modal-rules') &&
-      !e.target.closest('#modal-campaign') &&
-      !e.target.closest('#btn-theme')) {
-    alert('Afflicted by: ' + Array.from(activeStatuses).join(', '));
+  if (!activeStatuses.size) return;
+
+  const btn = e.target.closest(ACTION_BUTTONS);
+  if (!btn) return;
+
+  if (btn.closest('header .top, header .tabs, #statuses, #modal-enc, #modal-log, #modal-log-full, #modal-rules, #modal-campaign, #btn-theme')) {
+    return;
   }
+
+  toast('Afflicted by: ' + Array.from(activeStatuses).join(', '), 'error');
 }, true);
 
 const ALIGNMENT_PERKS = {


### PR DESCRIPTION
## Summary
- Show status effect warnings only when an actionable button is pressed
- Exclude menu and tab navigation from triggering status effect toast messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3c0e27dc832eacd55d131c8dc246