### PR TITLE
Align passive perception and TC fields

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -109,6 +109,7 @@ footer p{
 .status-effects{font-size:90%}
 .stats-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px}
 label{display:block;font-weight:700;margin-bottom:6px}
+.stats-grid label{min-height:3.2em;display:flex;align-items:flex-end}
 input:not([type="checkbox"]),select,textarea,button{-webkit-appearance:none;-moz-appearance:none;appearance:none;width:auto;max-width:100%;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:12px;transition:var(--transition)}
 input:not([type="checkbox"]),select,textarea{width:100%}
 select{background-image:var(--chevron);background-repeat:no-repeat;background-position:right 12px center;background-size:16px;padding-right:40px}


### PR DESCRIPTION
## Summary
- Align Passive Perception and TC fields by giving labels consistent height and bottom alignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3f9b1f44832e9bdfe9673cf499be