### PR TITLE
Reduce skill label font size

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -506,6 +506,12 @@ body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
   margin-bottom:0;
 }
 
+/* Ensure skill names like "Sleight of Hand" fit on one line */
+#skills .ability-box label{
+  font-size:0.85rem;
+  white-space:nowrap;
+}
+
 .ability-box .score{
   position:relative;
   width:100%;


### PR DESCRIPTION
## Summary
- ensure long skill names like "Sleight of Hand" stay on one line by adding dedicated CSS with smaller font size and no wrapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4d3a8bac832eae093ef83f136718