### PR TITLE
Toggle theme via header or logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@
         </svg>
       </button>
       <div id="menu-actions" class="menu" hidden>
-        <button id="btn-theme" class="btn-sm">Toggle Theme</button>
         <button id="btn-load" class="btn-sm">Load</button>
         <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
         <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
@@ -604,7 +603,7 @@
     </button>
     <h3>How to Use the Tracker</h3>
     <ul class="feature-list">
-      <li><b>Theme</b> Open the menu and choose <i>Toggle Theme</i> to cycle between light, high-contrast, and dark modes.</li>
+      <li><b>Theme</b> Tap the header or logo to cycle between light, high-contrast, and dark modes.</li>
       <li><b>Main menu</b> Access Load, Help, and Save from the menu.</li>
       <li><b>Tab navigation</b> Use the Combat, Abilities, Powers, Gear, and Story tabs to move between sections.</li>
       <li><b>Combat tools</b> Update HP/SP, mark death saves, adjust defenses, and make quick rolls or flips.</li>
@@ -617,7 +616,7 @@
     <h4>Frequently Asked Questions</h4>
     <ul class="qa-list">
       <li><b>Can I use the tracker offline?</b> Yes. The app stores data in your browser so it works offline.</li>
-      <li><b>How do I change the theme?</b> Open the menu and tap <i>Toggle Theme</i>.</li>
+      <li><b>How do I change the theme?</b> Tap the header or logo to switch themes.</li>
       <li><b>Where do I adjust my HP or SP?</b> Visit the Combat tab and tap the current values to edit them.</li>
       <li><b>How do I roll a die or flip a coin?</b> Use the quick tools on the Combat tab.</li>
       <li><b>How can I manage my equipment?</b> Use the Gear tab to add and manage items.</li>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -149,7 +149,6 @@ document.addEventListener('input', e=>{
 
 /* ========= theme ========= */
 const root = document.documentElement;
-const btnTheme = $('btn-theme');
 // Mapping of theme names to the ID of the SVG icon shown on the theme button
 const THEME_ICONS = {
   dark: 'icon-dark',
@@ -173,27 +172,21 @@ function applyTheme(t){
     .map(n => `theme-${n}`);
   root.classList.remove(...classes);
   if (t !== 'dark') root.classList.add(`theme-${t}`);
-  if(btnTheme){
-    qsa('svg', btnTheme).forEach(i => i.style.display = 'none');
-    const iconId = THEME_ICONS[t] || 'icon-dark';
-    const icon = qs(`#${iconId}`, btnTheme);
-    if(icon) icon.style.display = 'block';
-  }
 }
 function loadTheme(){
   const theme = localStorage.getItem('theme') || 'dark';
   applyTheme(theme);
 }
 loadTheme();
-if (btnTheme) {
-  btnTheme.addEventListener('click', ()=>{
-    const themes = Object.keys(THEME_ICONS);
-    const curr = localStorage.getItem('theme') || 'dark';
-    const next = themes[(themes.indexOf(curr)+1)%themes.length];
-    localStorage.setItem('theme', next);
-    applyTheme(next);
-  });
+
+function toggleTheme(){
+  const themes = Object.keys(THEME_ICONS);
+  const curr = localStorage.getItem('theme') || 'dark';
+  const next = themes[(themes.indexOf(curr)+1)%themes.length];
+  localStorage.setItem('theme', next);
+  applyTheme(next);
 }
+
 
 const CLASS_THEMES = {
   'Mutant':'mutant',
@@ -252,6 +245,16 @@ if (btnMenu && menuActions) {
 
 /* ========= header ========= */
 const headerEl = qs('header');
+if (headerEl) {
+  headerEl.addEventListener('click', e => {
+    if (
+      e.target.closest('#btn-menu') ||
+      e.target.closest('#menu-actions') ||
+      e.target.closest('nav')
+    ) return;
+    toggleTheme();
+  });
+}
 
 /* ========= tabs ========= */
 function setTab(name){
@@ -425,7 +428,7 @@ document.addEventListener('click', e => {
   const btn = e.target.closest(ACTION_BUTTONS);
   if (!btn) return;
 
-  if (btn.closest('header .top, header .tabs, #statuses, #modal-enc, #modal-log, #modal-log-full, #modal-rules, #modal-campaign, #btn-theme')) {
+  if (btn.closest('header .top, header .tabs, #statuses, #modal-enc, #modal-log, #modal-log-full, #modal-rules, #modal-campaign')) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- Switch visual theme when tapping the header or logo
- Remove dropdown menu's theme toggle button and update help text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc7077f140832e8a6b94554cebd6da