### PR TITLE
Add hidden DM login toast

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
         <button id="btn-help" class="btn-sm">Help</button>
         <button id="btn-fun" class="btn-sm">Fun Tip</button>
         <button id="btn-save" class="btn-sm">Save</button>
+        <button id="btn-dm-tools" class="btn-sm" hidden>DM Tools</button>
       </div>
     </div>
   </div>
@@ -777,6 +778,7 @@
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
   <p>Product of XoVrom industries ® 2025</p>
 </footer>
+<button id="dm-login" class="dm-login-btn" aria-label="DM Login"></button>
 <div id="down-animation" aria-hidden="true" hidden>⚠️</div>
 <div id="death-animation" aria-hidden="true" hidden>💀</div>
 <div id="damage-animation" aria-hidden="true" hidden></div>
@@ -785,8 +787,10 @@
 <div id="coin-animation" aria-hidden="true" hidden></div>
 <div id="sp-animation" aria-hidden="true" hidden></div>
 <div id="load-animation" aria-hidden="true" hidden>📂</div>
+<div class="toast" id="dm-toast" role="dialog"></div>
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script type="module" src="scripts/main.js"></script>
+<script type="module" src="scripts/dm.js"></script>
 
 </body>
 </html>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -1,0 +1,91 @@
+const DM_PIN = '1231';
+const RECOVERY_ANSWER = 'August 29 2022';
+
+const dmBtn = document.getElementById('dm-login');
+const dmToast = document.getElementById('dm-toast');
+const baseToast = document.getElementById('toast');
+const dmMenu = document.getElementById('btn-dm-tools');
+
+function setDmMenuVisibility(){
+  if(dmMenu){
+    dmMenu.hidden = !sessionStorage.getItem('dmLoggedIn');
+  }
+}
+
+function baseMessage(msg){
+  baseToast.textContent = msg;
+  baseToast.className = 'toast show';
+  setTimeout(()=> baseToast.classList.remove('show'), 3000);
+}
+
+function showDmToast(html){
+  dmToast.innerHTML = html;
+  dmToast.classList.add('show');
+}
+function hideDmToast(){
+  dmToast.classList.remove('show');
+}
+
+function openLogin(){
+  showDmToast(`
+    <input id="dm-pin" type="password" inputmode="numeric" maxlength="4" pattern="\\d{4}" placeholder="PIN" />
+    <div class="inline">
+      <button id="dm-login-btn" class="btn-sm">Log In</button>
+      <button id="dm-logout-btn" class="btn-sm">Log Out</button>
+    </div>
+    <button id="dm-recover-btn" class="btn-sm">Recover PIN</button>
+  `);
+  document.getElementById('dm-login-btn').addEventListener('click', handleLogin);
+  document.getElementById('dm-logout-btn').addEventListener('click', handleLogout);
+  document.getElementById('dm-recover-btn').addEventListener('click', openRecovery);
+}
+
+function handleLogin(){
+  const val = document.getElementById('dm-pin').value.trim();
+  if(val === DM_PIN){
+    hideDmToast();
+    baseMessage('Logged in');
+    sessionStorage.setItem('dmLoggedIn', '1');
+    setDmMenuVisibility();
+  } else {
+    baseMessage('Wrong PIN');
+  }
+}
+
+function handleLogout(){
+  hideDmToast();
+  baseMessage('Logged out');
+  sessionStorage.removeItem('dmLoggedIn');
+  setDmMenuVisibility();
+}
+
+function openRecovery(){
+  showDmToast(`
+    <label for="dm-answer">Your First Date Anniversary</label>
+    <input id="dm-answer" type="text" placeholder="Answer" />
+    <div class="inline">
+      <button id="dm-answer-btn" class="btn-sm">Submit</button>
+    </div>
+  `);
+  document.getElementById('dm-answer-btn').addEventListener('click', handleRecovery);
+}
+
+function handleRecovery(){
+  const ans = document.getElementById('dm-answer').value.trim();
+  if(ans === RECOVERY_ANSWER){
+    hideDmToast();
+    baseMessage('PIN: ' + DM_PIN);
+  } else {
+    baseMessage('Incorrect');
+  }
+}
+
+if(dmBtn){
+  dmBtn.addEventListener('click', openLogin);
+}
+
+if(dmMenu){
+  dmMenu.addEventListener('click', () => baseMessage('DM menu option'));
+  setDmMenuVisibility();
+  window.addEventListener('pageshow', setDmMenuVisibility);
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -489,6 +489,10 @@ body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
 .toast.success::before{background-image:var(--icon-success)}
 .toast.error::before{background-image:var(--icon-error)}
 
+.dm-login-btn{display:block;width:100%;height:20px;margin:0;padding:0;opacity:0;border:none;background:transparent}
+#dm-toast{flex-direction:column;gap:6px}
+#dm-toast::before{display:none}
+
 /* ability grid */
 .ability-grid{grid-template-columns:repeat(2,1fr)}
 


### PR DESCRIPTION
## Summary
- Add invisible DM login trigger beneath footer
- Implement toast-based login with 4-digit PIN and recovery question
- Style hidden button and custom toast
- Reveal DM Tools menu only after successful DM login and hide on logout
- Recheck menu visibility on page show to ensure DM Tools stay hidden when logged out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc6f296d84832e8897ec0cdeb4f188