### PR TITLE
Add Shard of Many Fates DM tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
         <button id="btn-help" class="btn-sm">Help</button>
         <button id="btn-fun" class="btn-sm">Fun Tip</button>
         <button id="btn-save" class="btn-sm">Save</button>
-        <button id="btn-dm-tools" class="btn-sm" hidden>DM Tools</button>
+        <button id="ccShard-open" class="btn-sm" hidden>Shard of Many Fates</button>
       </div>
     </div>
   </div>
@@ -78,6 +78,13 @@
 <main id="main">
   <!-- COMBAT -->
   <fieldset data-tab="combat" class="card">
+    <fieldset id="ccShard-player" class="card" hidden>
+      <legend>Shard Draw</legend>
+      <div class="inline">
+        <button id="ccShard-player-draw" class="btn-sm">Draw</button>
+      </div>
+      <ol id="ccShard-player-results" class="cc-list"></ol>
+    </fieldset>
     <div class="grid grid-2 roll-flip-grid">
       <fieldset class="card">
         <legend>Dice Roll</legend>
@@ -772,6 +779,128 @@
   </div>
 </div>
 
+<!-- Shard of Many Fates -->
+<!-- Shard of Many Fates • Catalyst Core Add-on -->
+<section id="cc-shard" class="cc-deck hidden">
+      <header class="cc-deck__header">
+        <h2>Shard of Many Fates</h2>
+        <div class="cc-deck__header-controls">
+          <button id="ccShard-showAll" class="cc-btn cc-btn--ghost">Card List</button>
+          <button id="ccShard-reset" class="cc-btn cc-btn--ghost" title="Reset draws">Reset</button>
+          <button id="ccShard-close" class="cc-btn cc-btn--ghost">Close</button>
+        </div>
+      </header>
+
+      <div class="cc-deck__top">
+        <div class="cc-deck__draw">
+          <div class="cc-deck__drawRow">
+            <label>Declared draws:</label>
+            <input id="ccShard-declared" type="number" min="1" max="22" value="1" />
+            <button id="ccShard-start" class="cc-btn">Start Draw</button>
+            <button id="ccShard-draw" class="cc-btn cc-btn--primary" disabled>Draw Plate</button>
+          </div>
+
+          <div class="cc-deck__toggles">
+            <label class="cc-switch">
+              <input id="ccShard-reshuffle24h" type="checkbox" checked>
+              <span>Shard reforms after 24h</span>
+            </label>
+            <label class="cc-switch">
+              <input id="ccShard-allowCAPCancel" type="checkbox" checked>
+              <span>Allow CAP to cancel a draw</span>
+            </label>
+          </div>
+        </div>
+
+        <aside class="cc-deck__save">
+          <h4>Save Target</h4>
+          <div class="cc-deck__saveRow">
+            <label>Profile ID</label>
+            <input id="ccShard-profileId" placeholder="player_or_character_id">
+          </div>
+          <div class="cc-deck__saveRow">
+            <label>Use Firebase</label>
+            <label class="cc-switch">
+              <input id="ccShard-useFirebase" type="checkbox">
+              <span>RTDB</span>
+            </label>
+          </div>
+          <button id="ccShard-saveLog" class="cc-btn">Save Log</button>
+          <button id="ccShard-exportJSON" class="cc-btn cc-btn--ghost">Export JSON</button>
+          <input id="ccShard-importFile" type="file" accept="application/json" hidden>
+          <button id="ccShard-importJSON" class="cc-btn cc-btn--ghost">Import JSON</button>
+        </aside>
+      </div>
+
+      <div class="cc-deck__main">
+        <div class="cc-deck__card">
+          <div id="ccShard-flash" class="cc-deck__flash"></div>
+          <div class="cc-deck__cardFront">
+            <div class="cc-deck__sigil">Ready</div>
+            <h3 id="ccShard-cardName">No plate drawn</h3>
+            <p id="ccShard-cardVisual" class="muted">Draw to reveal a fate.</p>
+
+            <div class="cc-tabs">
+              <nav class="cc-tabs__nav">
+                <button data-tab="effect" class="active">Effect</button>
+                <button data-tab="hooks">GM Hooks</button>
+                <button data-tab="resolution">Resolution</button>
+                <button data-tab="enemy">Enemy</button>
+                <button data-tab="rewards">Rewards</button>
+              </nav>
+              <article class="cc-tabs__pane active" id="ccShard-tab-effect"></article>
+              <article class="cc-tabs__pane" id="ccShard-tab-hooks"></article>
+              <article class="cc-tabs__pane" id="ccShard-tab-resolution"></article>
+              <article class="cc-tabs__pane" id="ccShard-tab-enemy"></article>
+              <article class="cc-tabs__pane" id="ccShard-tab-rewards"></article>
+            </div>
+
+            <div class="cc-deck__actions">
+              <button id="ccShard-capCancel" class="cc-btn cc-btn--danger" disabled>Use CAP to cancel</button>
+              <button id="ccShard-complete" class="cc-btn cc-btn--primary" disabled>Resolve Plate</button>
+            </div>
+          </div>
+        </div>
+
+        <aside class="cc-deck__sidebar">
+          <h4>Draw Log</h4>
+          <ol id="ccShard-log" class="cc-list"></ol>
+
+          <h4>Stat Blocks</h4>
+          <select id="ccShard-statSelect">
+            <option value="">Select stat block</option>
+            <option value="H1">Herald of Morvox, Echo Warden (H1)</option>
+            <option value="G1">Greyline Assault Cell (G1)</option>
+            <option value="C1">Conclave Trial Agent, Blade of Accession (C1)</option>
+            <option value="E1">Echo Operative, Tier 3 Ally (E1)</option>
+            <option value="B1">Betrayer Template (B1)</option>
+          </select>
+          <button id="ccShard-openNPC" class="cc-btn cc-btn--ghost" disabled>Open NPC Sheet</button>
+          <pre id="ccShard-statView" class="cc-code"></pre>
+        </aside>
+      </div>
+    </section>
+
+    <div id="ccShard-cardList" class="cc-cardList hidden">
+      <div class="cc-cardList__body">
+        <button id="ccShard-cardList-close" class="cc-btn cc-btn--ghost">Close</button>
+        <ol id="ccShard-cardList-ol" class="cc-list"></ol>
+      </div>
+    </div>
+
+    <div id="ccShard-npcModal" class="cc-npcModal hidden">
+      <div class="cc-npcModal__inner">
+        <h3 id="ccShard-npcName"></h3>
+        <div class="cc-npcStats">
+          <label>HP <input id="ccShard-npcHP" type="number" min="0"></label>
+          <label>SP <input id="ccShard-npcSP" type="number" min="0"></label>
+        </div>
+        <div id="ccShard-npcActions" class="cc-npcModal__actions"></div>
+        <pre id="ccShard-npcLog" class="cc-code"></pre>
+        <button id="ccShard-npcClose" class="cc-btn cc-btn--ghost">Close</button>
+      </div>
+    </div>
+
 
   <footer>
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
@@ -790,6 +919,7 @@
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script type="module" src="scripts/main.js"></script>
 <script type="module" src="scripts/dm.js"></script>
+<script src="shard-of-many-fates.js"></script>
 
 </body>
 </html>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -4,11 +4,30 @@ const RECOVERY_ANSWER = 'August 29 2022';
 const dmBtn = document.getElementById('dm-login');
 const dmToast = document.getElementById('dm-toast');
 const baseToast = document.getElementById('toast');
-const dmMenu = document.getElementById('btn-dm-tools');
+const shardBtn = document.getElementById('ccShard-open');
+const shardCard = document.getElementById('ccShard-player');
+const shardDraw = document.getElementById('ccShard-player-draw');
+const shardResults = document.getElementById('ccShard-player-results');
 
-function setDmMenuVisibility(){
-  if(dmMenu){
-    dmMenu.hidden = !sessionStorage.getItem('dmLoggedIn');
+const SHARD_KEY = 'ccShardEnabled';
+const NOTIFY_KEY = 'dmNotifications';
+
+function setShardBtnVisibility(){
+  if(shardBtn){
+    const dm = sessionStorage.getItem('dmLoggedIn');
+    const enabled = localStorage.getItem(SHARD_KEY) === '1';
+    shardBtn.hidden = !dm && !enabled;
+  }
+}
+
+function setShardCardVisibility(showToast=false){
+  if(shardCard){
+    const enabled = localStorage.getItem(SHARD_KEY) === '1';
+    shardCard.hidden = !enabled;
+    if(enabled && showToast){
+      baseMessage("The Shard's have shown them selves to you.");
+      shardCard.scrollIntoView({ behavior: 'smooth' });
+    }
   }
 }
 
@@ -26,7 +45,21 @@ function hideDmToast(){
   dmToast.classList.remove('show');
 }
 
+function logDMAction(text){
+  const arr = JSON.parse(localStorage.getItem(NOTIFY_KEY) || '[]');
+  arr.push({ time: Date.now(), text });
+  localStorage.setItem(NOTIFY_KEY, JSON.stringify(arr));
+}
+function escapeHtml(s){
+  return String(s).replace(/[&<>"']/g, m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
+}
+window.logDMAction = logDMAction;
+
 function openLogin(){
+  if(sessionStorage.getItem('dmLoggedIn')){
+    openDmTools();
+    return;
+  }
   showDmToast(`
     <input id="dm-pin" type="password" inputmode="numeric" maxlength="4" pattern="\\d{4}" placeholder="PIN" />
     <div class="inline">
@@ -40,13 +73,49 @@ function openLogin(){
   document.getElementById('dm-recover-btn').addEventListener('click', openRecovery);
 }
 
+function openDmTools(){
+  const enabled = localStorage.getItem(SHARD_KEY) === '1';
+  const notes = JSON.parse(localStorage.getItem(NOTIFY_KEY) || '[]');
+  showDmToast(`
+    <label class="cc-switch"><input id="dm-shard-toggle" type="checkbox" ${enabled? 'checked' : ''}><span>Allow Shards</span></label>
+    <button id="dm-view-notes" class="btn-sm">Notifications (${notes.length})</button>
+    <button id="dm-logout-btn" class="btn-sm">Log Out</button>
+  `);
+  document.getElementById('dm-shard-toggle').addEventListener('change', e=>{
+    if(e.target.checked) localStorage.setItem(SHARD_KEY,'1');
+    else localStorage.removeItem(SHARD_KEY);
+    setShardBtnVisibility();
+    setShardCardVisibility(true);
+    if(!e.target.checked) baseMessage('Shards disabled');
+  });
+  document.getElementById('dm-view-notes').addEventListener('click', openNotifications);
+  document.getElementById('dm-logout-btn').addEventListener('click', handleLogout);
+}
+
+function openNotifications(){
+  const notes = JSON.parse(localStorage.getItem(NOTIFY_KEY) || '[]');
+  showDmToast(`
+    <h3>Notifications</h3>
+    <ol class="cc-list">${notes.map(n=>`<li><span class="muted">${new Date(n.time).toLocaleString()}</span> ${escapeHtml(n.text)}</li>`).reverse().join('')}</ol>
+    <div class="inline">
+      <button id="dm-clear-notes" class="btn-sm">Clear</button>
+      <button id="dm-back-btn" class="btn-sm">Back</button>
+    </div>
+  `);
+  document.getElementById('dm-clear-notes').addEventListener('click', ()=>{
+    localStorage.removeItem(NOTIFY_KEY);
+    openNotifications();
+  });
+  document.getElementById('dm-back-btn').addEventListener('click', openDmTools);
+}
+
 function handleLogin(){
   const val = document.getElementById('dm-pin').value.trim();
   if(val === DM_PIN){
-    hideDmToast();
-    baseMessage('Logged in');
     sessionStorage.setItem('dmLoggedIn', '1');
-    setDmMenuVisibility();
+    setShardBtnVisibility();
+    openDmTools();
+    baseMessage('Logged in');
   } else {
     baseMessage('Wrong PIN');
   }
@@ -56,7 +125,7 @@ function handleLogout(){
   hideDmToast();
   baseMessage('Logged out');
   sessionStorage.removeItem('dmLoggedIn');
-  setDmMenuVisibility();
+  setShardBtnVisibility();
 }
 
 function openRecovery(){
@@ -84,8 +153,21 @@ if(dmBtn){
   dmBtn.addEventListener('click', openLogin);
 }
 
-if(dmMenu){
-  dmMenu.addEventListener('click', () => baseMessage('DM menu option'));
-  setDmMenuVisibility();
-  window.addEventListener('pageshow', setDmMenuVisibility);
+if(shardBtn){
+  setShardBtnVisibility();
+  window.addEventListener('pageshow', setShardBtnVisibility);
+}
+
+setShardCardVisibility();
+window.addEventListener('storage', e=>{
+  if(e.key === SHARD_KEY) setShardCardVisibility(true);
+});
+
+if(shardDraw){
+  shardDraw.addEventListener('click', async ()=>{
+    const cards = window.CCShard && typeof window.CCShard.draw === 'function'
+      ? await window.CCShard.draw(1)
+      : [];
+    shardResults.innerHTML = cards.map(c=>`<li>${c.name}</li>`).join('');
+  });
 }

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -1,0 +1,733 @@
+/* Shard of Many Fates • Catalyst Core Add-on */
+(function () {
+  const $ = (sel) => document.querySelector(sel);
+  const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+
+  const ui = {
+    root: $('#cc-shard'),
+    openBtn: $('#ccShard-open'),
+    closeBtn: $('#ccShard-close'),
+    resetBtn: $('#ccShard-reset'),
+    startBtn: $('#ccShard-start'),
+    drawBtn: $('#ccShard-draw'),
+    capCancelBtn: $('#ccShard-capCancel'),
+    completeBtn: $('#ccShard-complete'),
+    declared: $('#ccShard-declared'),
+    reshuffle24h: $('#ccShard-reshuffle24h'),
+    allowCAPCancel: $('#ccShard-allowCAPCancel'),
+    profileId: $('#ccShard-profileId'),
+    useFirebase: $('#ccShard-useFirebase'),
+    saveLog: $('#ccShard-saveLog'),
+    exportJSON: $('#ccShard-exportJSON'),
+    importJSON: $('#ccShard-importJSON'),
+    importFile: $('#ccShard-importFile'),
+    showAllBtn: $('#ccShard-showAll'),
+    cardList: $('#ccShard-cardList'),
+    cardListClose: $('#ccShard-cardList-close'),
+    cardListOl: $('#ccShard-cardList-ol'),
+    cardName: $('#ccShard-cardName'),
+    cardVisual: $('#ccShard-cardVisual'),
+    tabBtns: $$('#cc-shard .cc-tabs__nav button'),
+    tabPanes: {
+      effect: $('#ccShard-tab-effect'),
+      hooks: $('#ccShard-tab-hooks'),
+      resolution: $('#ccShard-tab-resolution'),
+      enemy: $('#ccShard-tab-enemy'),
+      rewards: $('#ccShard-tab-rewards')
+    },
+    log: $('#ccShard-log'),
+    statSelect: $('#ccShard-statSelect'),
+    openNPCBtn: $('#ccShard-openNPC'),
+    statView: $('#ccShard-statView'),
+    npcModal: $('#ccShard-npcModal'),
+    npcName: $('#ccShard-npcName'),
+    npcHP: $('#ccShard-npcHP'),
+    npcSP: $('#ccShard-npcSP'),
+    npcActions: $('#ccShard-npcActions'),
+    npcLog: $('#ccShard-npcLog'),
+    npcClose: $('#ccShard-npcClose'),
+    flash: $('#ccShard-flash'),
+  };
+
+  let fb = null; // optional Firebase DB instance
+
+  const state = {
+    deck: [],
+    archive: [],
+    declared: 1,
+    drawnCount: 0,
+    activeCard: null,
+    queue: [],
+    startedAt: null,
+    lastReset: null,
+  };
+
+  const STORAGE_KEY = 'ccShard_v1';
+  const CLOUD_STATE_URL = 'https://ccccg-7d6b6-default-rtdb.firebaseio.com/shardDeck.json';
+
+  const DM_SHARD_KEY = 'ccShardEnabled';
+  const logDM = window.logDMAction || function(text){
+    const arr = JSON.parse(localStorage.getItem('dmNotifications') || '[]');
+    arr.push({ time: Date.now(), text });
+    localStorage.setItem('dmNotifications', JSON.stringify(arr));
+  };
+
+  function toast(msg){
+    const el = document.getElementById('toast');
+    if(el){
+      el.textContent = msg;
+      el.className = 'toast show';
+      setTimeout(()=> el.classList.remove('show'),3000);
+    }
+  }
+
+  // All 22 plates
+  const PLATES = [
+    { id:'TRIBUNAL', name:'The Tribunal', src:'Balance',
+      visual:'A rotating hex of alien law glyphs surrounds the drawer then inverts.',
+      effect:[
+        'Shift one step on Moral or Discipline axis.',
+        'Adjust reputation with O.M.N.I. or PFV by one tier.',
+        'Gain a one-time perk aligned to the new axis for 3 sessions.'
+      ],
+      hooks:[
+        'O.M.N.I. audit team arrives.',
+        'PFV ethics board demands a mediation stream.',
+        'Conclave tags you with a luminal sigil.'
+      ],
+      resolution:[
+        'Three acts supporting prior alignment or argue a Conclave Trial.',
+        'Contrition or conviction scene clears the sigil and restores one rep.'
+      ],
+      enemy:null, rewards:null, heatDelta:1, capsAllowed:true },
+
+    { id:'METEOR', name:'The Meteor', src:'Comet',
+      visual:'A burning shard streaks overhead and fractures into the next nemesis sigil.',
+      effect:[
+        'Defeat the next significant enemy solo to ascend one Hero Tier and gain a Legendary class item.',
+        'If you fail, lose one reputation tier with a faction that was watching.'
+      ],
+      hooks:[
+        'PFV broadcasts a solo trial.',
+        'O.M.N.I. restricts backup to force narrative.'
+      ],
+      resolution:[
+        'Win the duel or repair failure with a public challenge or expose manipulation.'
+      ],
+      enemy:null, rewards:['Legendary class item on success'], heatDelta:1, capsAllowed:true },
+
+    { id:'NULL_VAULT', name:'The Null Vault', src:'Donjon',
+      visual:'The floor tears like video static. A doorframe with no door opens.',
+      effect:[
+        'Drawer is pulled into Morvox’s Echo Pit. Team must mount a rescue.'
+      ],
+      hooks:[
+        'O.M.N.I. flags a Null Fragment.',
+        'Acquire a Shepherd Pulse to phase in.'
+      ],
+      resolution:[
+        'Stage 1. Retrieve Shepherd Pulse. Skill challenge DC 14.',
+        'Stage 2. Shard sync DC 15. Inside, defeat a Herald (H1) or sever the Shard Choir.'
+      ],
+      enemy:'H1', rewards:null, heatDelta:2, capsAllowed:false },
+
+    { id:'SHEPHERDS_MASK', name:'The Shepherd’s Mask', src:'Euryale',
+      visual:'A smooth porcelain mask phases over the face then melts into tracer lines.',
+      effect:['Curse. −2 on all saves. On natural 20, roll twice and keep the lower.'],
+      hooks:['Voice sometimes routes through nearby speakers.','PFV healers refuse treatment without tribunal.'],
+      resolution:['Defeat a Herald (H1) in single combat or bathe mask in Conclave starlight at an Envoy Spire.'],
+      enemy:'H1', rewards:null, heatDelta:1, capsAllowed:true },
+
+    { id:'REDACTION', name:'The Redaction', src:'Fates',
+      visual:'Frames of your past hang in air. A black bar erases one.',
+      effect:[
+        'Once, erase an event in your past or a current outcome and rewrite one consequence in your favor.',
+        'Choose another thread that becomes one step harder.'
+      ],
+      hooks:['O.M.N.I. reconstructs from surveillance gaps.','A loved one remembers both versions and has nightmares.'],
+      resolution:['Accept the complication and play it out or stabilize at an Oracle node.'],
+      enemy:null, rewards:null, heatDelta:1, capsAllowed:true },
+
+    { id:'BROADCAST', name:'The Broadcast', src:'Flames',
+      visual:'Holo-billboards flip to your face stamped TRAITOR or MONSTER.',
+      effect:['Gain a powerful enemy who commits resources against you. Heat +2 on reveal.'],
+      hooks:['Greyline assault cell raids your safehouse.','O.M.N.I. issues a sealed detention order.'],
+      resolution:['Clear your name publicly or defeat the enemy live.'],
+      enemy:'G1', rewards:null, heatDelta:2, capsAllowed:true },
+
+    { id:'FRAGMENT', name:'The Fragment', src:'Fool',
+      visual:'A cracked shard refracts everyone into clumsy caricatures.',
+      effect:['Lose 1d4 CAP this arc. You must draw one extra plate immediately.'],
+      hooks:['Conclave junior emissary tries to pocket the fragment.','Memes cause mild hostility penalties for 24h.'],
+      resolution:['Redeem by a public rescue or destroy the fragment at a shard kiln.'],
+      enemy:null, rewards:null, heatDelta:0, capsAllowed:true },
+
+    { id:'CACHE', name:'The Catalyst Cache', src:'Gem',
+      visual:'A carbon case phases in, humming with shardlight.',
+      effect:['Gain 1d6 Catalyst Fragments and one Rare class item. Watermarked tracker included.'],
+      hooks:['Greyline attempts a theft in transit.','PFV asks for one fragment donation.'],
+      resolution:['Scrub watermark with Conclave key or sacrifice 1 fragment to lower heat.'],
+      enemy:null, rewards:['+1d6 fragments','1 Rare class item'], heatDelta:1, capsAllowed:true },
+
+    { id:'STATIC', name:'The Static', src:'Idiot',
+      visual:'Your vision pixelates. Thoughts stutter.',
+      effect:['Permanent −1d4 INT. Lose a language or technical specialty until retrained.'],
+      hooks:['Old passphrases fail and strand allies.','A former student offers help for a price.'],
+      resolution:['Two downtime Research actions + mnemonic imprint or attach Neural Sync with a side effect.'],
+      enemy:null, rewards:null, heatDelta:0, capsAllowed:true },
+
+    { id:'TRICKSTER', name:'The Trickster Signal', src:'Jester',
+      visual:'Confetti of system alerts rains from nowhere.',
+      effect:['Choose 10,000 credits or draw two additional plates. If drawn twice, a contact is an O.M.N.I. sleeper.'],
+      hooks:['Funds are laundered through an enemy shell.','Sleeper reveal hits at a critical moment.'],
+      resolution:['Expose laundering source or reveal the sleeper cleanly.'],
+      enemy:null, rewards:['10,000 credits or 2 extra draws'], heatDelta:0, capsAllowed:true },
+
+    { id:'HELIX_CODE', name:'The Helix Code', src:'Key',
+      visual:'A living circuitry key slides into your palm and links to your kit.',
+      effect:['Gain a Legendary class item with a Greyline backdoor ping. First combat use pings location.'],
+      hooks:['Greyline issues an extraction contract.','PFV pleads for quarantine and offers alternative.'],
+      resolution:['Purge backdoor via O.M.N.I. or Conclave, or bait Greyline and win.'],
+      enemy:'G1', rewards:['Legendary class item'], heatDelta:2, capsAllowed:true },
+
+    { id:'ECHO_OPERATIVE', name:'The Echo Operative', src:'Knight',
+      visual:'A soldier steps out of your shadow with inverted colors.',
+      effect:['Gain a loyal Tier 3 NPC ally that mirrors one of your tactics. If they die you gain a scar or phobia.'],
+      hooks:['They may be your alt-timeline self.','O.M.N.I. tries to draft them.'],
+      resolution:['Roleplay the bond. Protect or release them to their arc.'],
+      enemy:null, rewards:['Ally E1'], heatDelta:0, capsAllowed:true },
+
+    { id:'DREAM', name:'The Dream', src:'Moon',
+      visual:'A shardlight crescent drips motes into your hands.',
+      effect:['Gain 1d3 Resonance Point wishes. Each use adds Heat +1.'],
+      hooks:['Conclave auditors observe every use.','O.M.N.I. moves to confiscate you.'],
+      resolution:['RP are consumed on use. Live with the heat.'],
+      enemy:null, rewards:['+1d3 RP wishes'], heatDelta:0, capsAllowed:true },
+
+    { id:'DEFECTOR', name:'The Defector', src:'Rogue',
+      visual:'Your team appears. One face shatters.',
+      effect:['One ally or contact betrays you at a pivotal moment.'],
+      hooks:['Breadcrumb sabotage culminates during a high-stakes op.'],
+      resolution:['Confront, convert, or cut them loose. Clean resolution restores 1 rep.'],
+      enemy:'B1', rewards:null, heatDelta:1, capsAllowed:true },
+
+    { id:'COLLAPSE', name:'The Collapse', src:'Ruin',
+      visual:'Apartments and accounts collapse like hollow cubes.',
+      effect:['All civilian assets are seized or destroyed. Gain a one-scene Renegade surge of +1d6 to an aggressive action.'],
+      hooks:['HelixDyne shell corp executed the move.','PFV relief if you do public service.'],
+      resolution:['Expose the paper trail or steal your life back in a heist.'],
+      enemy:null, rewards:['Renegade surge x1 scene'], heatDelta:1, capsAllowed:true },
+
+    { id:'WRAITH', name:'The Wraith', src:'Skull',
+      visual:'Skeletal silhouette with shardlight eyes. Breath frosts.',
+      effect:['A relentless hunter spawns and pursues until slain, growing stronger if ignored.'],
+      hooks:['It wears the face of someone the drawer failed to save.','It gains strength each night you avoid it.'],
+      resolution:['Hunt and defeat it.'],
+      enemy:'C1|H1', rewards:null, heatDelta:1, capsAllowed:true },
+
+    { id:'ASCENDANT', name:'The Ascendant', src:'Star',
+      visual:'A seven-point star embeds in your sternum and dims.',
+      effect:['Increase one ability score by +2. For the next two encounters, once per encounter add +1d4 to any roll without SP.'],
+      hooks:['Conclave offers a test.','O.M.N.I. tempts with higher clearance.'],
+      resolution:['None.'],
+      enemy:null, rewards:['+2 to one ability'], heatDelta:0, capsAllowed:true },
+
+    { id:'HALO', name:'The Halo', src:'Sun',
+      visual:'A rotating shard halo casts your emblem across the scene.',
+      effect:['Gain an Elite or Legendary artifact. Gain +1d4 CAP for this campaign arc.'],
+      hooks:['Null Silence ripple briefly disrupts enemy comms for one fight.'],
+      resolution:['None.'],
+      enemy:null, rewards:['Elite or Legendary artifact','+1d4 CAP'], heatDelta:1, capsAllowed:true },
+
+    { id:'SILENCE_BLOOM', name:'The Silence Bloom', src:'Talons',
+      visual:'Gear dissolves into black petals and vanishes.',
+      effect:['All carried gear erased except bonded artifacts and Catalyst Fragments. Powers remain.'],
+      hooks:['PFV will re-outfit you after a televised mission.','Greyline offers a predatory loan.'],
+      resolution:['Regain gear via patronage, heist, or Conclave trial of merit to restore one item.'],
+      enemy:null, rewards:null, heatDelta:1, capsAllowed:true },
+
+    { id:'VIGIL', name:'The Vigil', src:'Throne',
+      visual:'A city district lifts from the map and stamps into your palm.',
+      effect:['Gain leadership of a district, safehouse, or O.M.N.I. post. Set one team policy when operating there.'],
+      hooks:['Rivals challenge your claim.','Conclave declares it a micro-trial zone.'],
+      resolution:['Maintain public trust and win a public duel or court case to keep it.'],
+      enemy:null, rewards:['Territory with policy perk'], heatDelta:1, capsAllowed:true },
+
+    { id:'ORACLE', name:'The Oracle', src:'Vizier',
+      visual:'A sphere of light reveals one actionable truth.',
+      effect:['Ask the GM one campaign question. The answer is specific and actionable.'],
+      hooks:['The truth angers someone who needed it buried.'],
+      resolution:['None.'],
+      enemy:null, rewards:['One true answer'], heatDelta:0, capsAllowed:true },
+
+    { id:'SHEPHERDS_THREAD', name:'The Shepherd’s Thread', src:'Void',
+      visual:'A black filament tethers your chest to darkness.',
+      effect:[
+        'Your soul is bound to Morvox. You cannot benefit from inspires.',
+        'Once per encounter WIS save DC 15 or lose your action to "listen." On failure Morvox speaks one sentence through you.'
+      ],
+      hooks:['O.M.N.I. seeks to weaponize your tether.','Your voice echoes from radios, mirrors, and glass.'],
+      resolution:['Enter the Null Vault and sever at the Shard Choir or perform a Conclave Rite with starlight, two fragments, and a personal sacrifice.'],
+      enemy:'H1', rewards:null, heatDelta:2, capsAllowed:false },
+  ];
+
+  const STATS = {
+    H1: `H1. Herald of Morvox, Echo Warden
+Tier 3 elite controller
+HP 58  |  TC 16  |  Speed 30 ft  |  SP 7
+Saves WIS +3, DEX +2, CON +2
+Traits: Silence Bloom aura 10 ft; Fragment Glide
+Actions:
+• Echo Lash (1 SP): +6 to hit, 2d8 psychic. WIS DC 15 or Disoriented 1 round.
+• Broadcast Scramble (2 SP): 20 ft radius. Foes lose reactions and have disadvantage on next attack. WIS DC 15 halves.
+• Shepard’s Mark (3 SP): If marked target attacks Herald they are stunned; if they attack others they deal +1d6 that turn. WIS DC 16 negates.
+Reaction:
+• Memory Tear: When crit, attacker WIS DC 15 or stunned 1 round.`,
+    G1: `G1. Greyline Assault Cell
+Tier 3 fireteam | HP 64 | TC 15 | SP 6 | Speed 30 ft
+Saves DEX +3, CON +2
+Traits: Coordinated Fire; Kill-Switch Smoke 1/enc
+Actions:
+• Suppression Volley (1 SP): 15 ft cone. DEX DC 14 or 2d6 ballistic and lose reaction.
+• Breach Charge (2 SP): Destroy cover. Within 10 ft DEX DC 14 or 2d8 force, knocked prone.
+• Netline Taser (2 SP): 30 ft. On hit Restrained until end of next turn.
+Reaction: Drag Out.`,
+    C1: `C1. Conclave Trial Agent, Blade of Accession
+Tier 4 duelist | HP 72 | TC 17 | Speed 35 ft (hover 10) | SP 8
+Traits: Astral Parry; Starlit Code
+Actions:
+• Prism Edge (1 SP): +7 to hit, 2d10 radiant; WIS DC 15 or disadvantage on next attack.
+• Accession Step (2 SP): Teleport 20 ft, free Prism Edge at +2 to hit.
+• Starlight Decree (3 SP): 15 ft pulse. WIS DC 16 or lose reactions and movement.`,
+    E1: `E1. Echo Operative (Ally)
+Tier 3 | HP 50 | TC 15 | SP 6
+Perk: Copies one signature tactic
+Actions:
+• Covering Fire (1 SP): Ally +2 TC, 10 ft reposition.
+• Drive Forward (2 SP): You and an ally move 20 ft; the ally has advantage on next attack.
+• Last Stand (3 SP): Stay at 1 HP and grant allies within 10 ft +1d6 temp HP.`,
+    B1: `B1. Betrayer Template
+Add to an existing sheet on reveal
++ Hidden Blade: once/scene +2d6 if target surprised
++ False Flag (1 SP): Nearby ally WIS DC 14 or loses reaction
+Weakness: Disadvantage on Deception vs party after reveal.`,
+  };
+
+  const NPCS = {
+    H1: {
+      name: 'Herald of Morvox, Echo Warden',
+      hp: 58,
+      sp: 7,
+      actions: [
+        { name: 'Echo Lash', attack: 6, damage: '2d8', sp: 1, effect: 'WIS DC 15 or Disoriented 1 round.' },
+        { name: 'Broadcast Scramble', sp: 2, effect: 'Foes lose reactions and have disadvantage on next attack. WIS DC 15 halves.' },
+        { name: 'Shepard\u2019s Mark', sp: 3, effect: 'If marked target attacks Herald they are stunned; if they attack others they deal +1d6 that turn. WIS DC 16 negates.' }
+      ]
+    },
+    G1: {
+      name: 'Greyline Assault Cell',
+      hp: 64,
+      sp: 6,
+      actions: [
+        { name: 'Suppression Volley', damage: '2d6', sp: 1, effect: 'DEX DC 14 or lose reaction.' },
+        { name: 'Breach Charge', damage: '2d8', sp: 2, effect: 'DEX DC 14 or knocked prone.' },
+        { name: 'Netline Taser', sp: 2, effect: 'On hit Restrained until end of next turn.' }
+      ]
+    },
+    C1: {
+      name: 'Conclave Trial Agent, Blade of Accession',
+      hp: 72,
+      sp: 8,
+      actions: [
+        { name: 'Prism Edge', attack: 7, damage: '2d10', sp: 1, effect: 'WIS DC 15 or disadvantage on next attack.' },
+        { name: 'Accession Step', attack: 9, damage: '2d10', sp: 2, effect: 'Teleport 20 ft, free Prism Edge at +2 to hit.' },
+        { name: 'Starlight Decree', sp: 3, effect: '15 ft pulse. WIS DC 16 or lose reactions and movement.' }
+      ]
+    },
+    E1: {
+      name: 'Echo Operative',
+      hp: 50,
+      sp: 6,
+      actions: [
+        { name: 'Covering Fire', sp: 1, effect: 'Ally +2 TC, 10 ft reposition.' },
+        { name: 'Drive Forward', sp: 2, effect: 'You and an ally move 20 ft; the ally has advantage on next attack.' },
+        { name: 'Last Stand', sp: 3, effect: 'Stay at 1 HP and grant allies within 10 ft +1d6 temp HP.' }
+      ]
+    },
+    B1: {
+      name: 'Betrayer Template',
+      hp: 0,
+      sp: 0,
+      actions: [
+        { name: 'Hidden Blade', damage: '2d6', effect: 'Once/scene +2d6 if target surprised.' },
+        { name: 'False Flag', sp: 1, effect: 'Nearby ally WIS DC 14 or loses reaction.' }
+      ]
+    }
+  };
+
+
+  function rnd(arr){ return arr[Math.floor(Math.random()*arr.length)]; }
+  function roll(expr){
+    const m = /^([0-9]+)d([0-9]+)$/i.exec(expr.trim());
+    if(!m) return 0;
+    const cnt = parseInt(m[1],10); const sides = parseInt(m[2],10);
+    let total = 0; for(let i=0;i<cnt;i++) total += Math.floor(Math.random()*sides)+1;
+    return total;
+  }
+
+  function init(){
+    wireUI(); load(); buildFreshDeckIfNeeded(); render();
+  }
+
+  function wireUI(){
+    ui.openBtn.addEventListener('click', ()=> ui.root.classList.remove('hidden'));
+    ui.closeBtn.addEventListener('click', ()=> ui.root.classList.add('hidden'));
+
+    ui.resetBtn.addEventListener('click', resetAll);
+    ui.startBtn.addEventListener('click', startSession);
+    ui.drawBtn.addEventListener('click', drawPlate);
+    ui.capCancelBtn.addEventListener('click', capCancel);
+    ui.completeBtn.addEventListener('click', completePlate);
+
+    ui.declared.addEventListener('change', e=> state.declared = Math.max(1, Math.min(22, +e.target.value||1)));
+
+    ui.reshuffle24h.addEventListener('change', persist);
+    ui.allowCAPCancel.addEventListener('change', renderActions);
+
+    ui.showAllBtn.addEventListener('click', ()=>{ renderCardList(); ui.cardList.classList.remove('hidden'); });
+    ui.cardListClose.addEventListener('click', ()=> ui.cardList.classList.add('hidden'));
+
+    ui.tabBtns.forEach(btn=> btn.addEventListener('click', ()=>{
+      ui.tabBtns.forEach(b=> b.classList.remove('active'));
+      btn.classList.add('active');
+      const t = btn.dataset.tab;
+      ui.tabPanes.effect.classList.toggle('active', t==='effect');
+      ui.tabPanes.hooks.classList.toggle('active', t==='hooks');
+      ui.tabPanes.resolution.classList.toggle('active', t==='resolution');
+      ui.tabPanes.enemy.classList.toggle('active', t==='enemy');
+      ui.tabPanes.rewards.classList.toggle('active', t==='rewards');
+    }));
+
+    ui.statSelect.addEventListener('change', ()=>{
+      const key = ui.statSelect.value; ui.statView.textContent = STATS[key] || '';
+      ui.openNPCBtn.disabled = !NPCS[key];
+    });
+    ui.openNPCBtn.addEventListener('click', ()=> openNPC(ui.statSelect.value));
+    ui.npcClose.addEventListener('click', ()=> ui.npcModal.classList.add('hidden'));
+
+    ui.saveLog.addEventListener('click', saveLog);
+    ui.exportJSON.addEventListener('click', exportJSON);
+    ui.importJSON.addEventListener('click', ()=> ui.importFile.click());
+    ui.importFile.addEventListener('change', importJSON);
+  }
+
+  function buildFreshDeckIfNeeded(force=false){
+    const now = Date.now();
+    const reshuffle = ui.reshuffle24h.checked;
+    if (force || !state.lastReset || (reshuffle && now - state.lastReset > 24*60*60*1000)) {
+      state.deck = PLATES.map(p=>p.id);
+      state.archive = [];
+      state.drawnCount = 0;
+      state.activeCard = null;
+      state.queue = [];
+      state.startedAt = null;
+      state.lastReset = now;
+      persist();
+    } else if (!Array.isArray(state.deck) || state.deck.length===0) {
+      state.deck = PLATES.map(p=>p.id).filter(id => !state.archive.includes(id));
+    }
+  }
+
+  function fillQueue(){
+    let target = state.declared;
+    while (state.drawnCount + state.queue.length < target){
+      if (!state.deck.length) buildFreshDeckIfNeeded(true);
+      if (!state.deck.length) break;
+      const id = state.deck.splice(Math.floor(Math.random()*state.deck.length),1)[0];
+      const plate = PLATES.find(p=>p.id===id);
+      const entry = { ...plate, drawnAt: Date.now() };
+      state.queue.push(entry);
+      logDraw(entry);
+      logDM(`Drew plate: ${plate.name}`);
+      if (plate.id==='FRAGMENT'){ state.declared++; target++; }
+    }
+  }
+
+  function startSession(){
+    if (state.activeCard) return;
+    state.declared = Math.max(1, Math.min(22, +ui.declared.value || 1));
+    state.drawnCount = 0;
+    state.queue = [];
+    state.startedAt = Date.now();
+    ui.drawBtn.disabled = false; render();
+    logDM(`Session started (${state.declared} draws)`);
+    persist();
+  }
+
+  async function drawPlate(){
+    if (localStorage.getItem(DM_SHARD_KEY) !== '1'){
+      toast('The Shards reject your call');
+      logDM('Draw attempt rejected');
+      return;
+    }
+    if (state.activeCard || state.queue.length) return;
+    if (!confirm('Draw from the Shard?')) return;
+    if (!confirm('Are you sure? This cannot be undone.')) return;
+    await load();
+    if (!state.deck.length) buildFreshDeckIfNeeded(true);
+    if (state.drawnCount >= state.declared) return;
+    fillQueue();
+    await persist();
+    await playDrawAnimation();
+    state.activeCard = state.queue.shift() || null;
+    renderPlate();
+    persist();
+  }
+
+  function capCancel(){
+    if (!state.activeCard) return;
+    if (!ui.allowCAPCancel.checked) return;
+    logLine(`CAP used. Canceled plate: ${state.activeCard.name}`);
+    logDM(`CAP canceled: ${state.activeCard.name}`);
+    state.activeCard = null;
+    ui.capCancelBtn.disabled = true;
+    fillQueue();
+    state.activeCard = state.queue.shift() || null;
+    renderPlate(); persist();
+  }
+
+  function completePlate(){
+    if (!state.activeCard) return;
+    logDM(`Resolved plate: ${state.activeCard.name}`);
+    state.archive.push(state.activeCard.id);
+    state.drawnCount++;
+    markResolved(state.activeCard);
+    state.activeCard = state.queue.shift() || null;
+    if (state.drawnCount >= state.declared) ui.drawBtn.disabled = true;
+    persist();
+    render();
+  }
+
+
+  function playDrawAnimation(){
+    return new Promise(res=>{
+      ui.flash.classList.add('active');
+      ui.flash.addEventListener('animationend', ()=>{
+        ui.flash.classList.remove('active');
+        res();
+      }, { once:true });
+    });
+  }
+
+  function renderPlate(){
+    const c = state.activeCard;
+    ui.cardName.textContent = c ? `${c.name} (${c.src})` : 'No plate drawn';
+    ui.cardVisual.textContent = c ? c.visual : 'Draw to reveal a fate.';
+    ui.tabPanes.effect.innerHTML = c ? bullets(c.effect) : '';
+    ui.tabPanes.hooks.innerHTML = c ? bullets(c.hooks) : '';
+    ui.tabPanes.resolution.innerHTML = c ? bullets(c.resolution) : '';
+    ui.tabPanes.rewards.innerHTML = c && c.rewards ? bullets(c.rewards) : '<em>None specified</em>';
+    if (c && c.enemy){
+      const keys = c.enemy.split('|');
+      ui.tabPanes.enemy.innerHTML = keys.map(k => `<strong>${k}</strong><pre class="cc-code">${escapeHtml(STATS[k]||'Unknown')}</pre>`).join('');
+    } else ui.tabPanes.enemy.innerHTML = '<em>None</em>';
+    renderActions();
+  }
+
+  function renderActions(){
+    const active = !!state.activeCard;
+    ui.completeBtn.disabled = !active;
+    ui.capCancelBtn.disabled = !(active && ui.allowCAPCancel.checked && state.activeCard.capsAllowed);
+  }
+
+  function logDraw(c){
+    const li = document.createElement('li');
+    const time = new Date(c.drawnAt).toLocaleString();
+    li.dataset.key = `${c.id}_${c.drawnAt}`;
+    li.innerHTML = `<strong>${c.name}</strong> <span class="muted">(${time})</span>`;
+    ui.log.append(li);
+  }
+  function markResolved(c){
+    const li = ui.log.querySelector(`li[data-key="${c.id}_${c.drawnAt}"]`);
+    if (li){
+      li.classList.add('muted');
+      li.append(' — resolved');
+    }
+  }
+  function logLine(t){
+    const li = document.createElement('li'); li.textContent = t; ui.log.append(li);
+  }
+  function bullets(arr){
+    if (!arr || !arr.length) return '<em>None</em>';
+    return `<ul>${arr.map(x=>`<li>${escapeHtml(x)}</li>`).join('')}</ul>`;
+  }
+
+  function renderCardList(){
+    ui.cardListOl.innerHTML = '';
+    PLATES.forEach(p=>{
+      const li = document.createElement('li');
+      li.innerHTML = `<strong>${p.name}</strong><p class="muted">${escapeHtml(p.visual)}</p><div><strong>Effect:</strong>${bullets(p.effect)}</div><div><strong>Hooks:</strong>${bullets(p.hooks)}</div><div><strong>Resolution:</strong>${bullets(p.resolution)}</div>`;
+      ui.cardListOl.append(li);
+    });
+  }
+
+  function openNPC(id){
+    const npc = NPCS[id]; if(!npc) return;
+    ui.npcName.textContent = npc.name;
+    ui.npcHP.max = npc.hp; ui.npcHP.value = npc.hp;
+    ui.npcSP.max = npc.sp; ui.npcSP.value = npc.sp;
+    ui.npcActions.innerHTML = '';
+    ui.npcLog.textContent = '';
+    npc.actions.forEach(act=>{
+      const btn = document.createElement('button');
+      btn.textContent = act.name;
+      btn.className = 'cc-btn';
+      btn.addEventListener('click', ()=> handleNpcAction(act));
+      ui.npcActions.append(btn);
+    });
+    ui.npcModal.classList.remove('hidden');
+  }
+
+  function handleNpcAction(action){
+    const parts = [];
+    if(typeof action.attack === 'number'){
+      const d20 = roll('1d20');
+      const total = d20 + action.attack;
+      parts.push(`attack ${total} (d20 ${d20}+${action.attack})`);
+    }
+    if(action.damage){
+      const dmg = roll(action.damage);
+      parts.push(`damage ${dmg}`);
+    }
+    if(action.effect) parts.push(action.effect);
+    if(action.sp){
+      ui.npcSP.value = Math.max(0, (Number(ui.npcSP.value)||0) - action.sp);
+    }
+    ui.npcLog.textContent = `${action.name}: ${parts.join('; ')}\n` + ui.npcLog.textContent;
+  }
+
+  function resetAll(){
+    state.archive = []; state.deck = []; state.drawnCount = 0;
+    state.declared = 1; state.activeCard = null; state.queue = [];
+    state.startedAt = null; state.lastReset = Date.now();
+    ui.log.innerHTML = '';
+    buildFreshDeckIfNeeded(true); render(); persist();
+    logDM('Deck reset');
+  }
+
+  function render(){
+    ui.declared.value = state.declared;
+    const allowed = localStorage.getItem(DM_SHARD_KEY) === '1';
+    if (!state.activeCard && state.queue.length) {
+      state.activeCard = state.queue.shift();
+    }
+    ui.drawBtn.disabled = !state.startedAt || state.drawnCount >= state.declared || !!state.activeCard || state.queue.length > 0 || !allowed;
+    renderPlate();
+  }
+
+  async function persist(){
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ state, savedAt: Date.now() }));
+    if (typeof fetch === 'function') {
+      try {
+        await fetch(CLOUD_STATE_URL, {
+          method:'PUT',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({ state, savedAt: Date.now() })
+        });
+      } catch(e){ console.error('Cloud save failed', e); }
+    }
+  }
+
+  async function load(){
+    if (typeof fetch === 'function') {
+      try {
+        const res = await fetch(CLOUD_STATE_URL);
+        if(res.ok){
+          const data = await res.json();
+          if(data && data.state){ Object.assign(state, data.state); if(!Array.isArray(state.queue)) state.queue = []; return; }
+        }
+      } catch(e){}
+    }
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY); if (!raw) return;
+      const data = JSON.parse(raw); if (data && data.state) Object.assign(state, data.state);
+    } catch {}
+    if(!Array.isArray(state.queue)) state.queue = [];
+  }
+
+  function exportJSON(){
+    const data = { state,
+      archiveNames: state.archive.map(id => PLATES.find(p=>p.id===id)?.name || id),
+      savedAt: new Date().toISOString() };
+    const blob = new Blob([JSON.stringify(data,null,2)], { type:'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const pid = (ui.profileId.value || 'unknown').replace(/[^\w.-]+/g,'_');
+    a.href = url; a.download = `cc_shard_log_${pid}_${Date.now()}.json`; document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
+  }
+  async function importJSON(e){
+    const file = e.target.files?.[0]; if (!file) return;
+    const text = await file.text(); const data = JSON.parse(text);
+    if (data && data.state){ Object.assign(state, data.state); render(); persist(); logLine('Imported shard state from JSON.'); }
+  }
+
+  async function saveLog(){
+    const profileId = ui.profileId.value.trim();
+    if (!profileId){ alert('Enter a Profile ID to save'); return; }
+    const payload = {
+      profileId, state,
+      archiveNames: state.archive.map(id => PLATES.find(p=>p.id===id)?.name || id),
+      savedAt: Date.now()
+    };
+    if (ui.useFirebase.checked && fb){
+      try { const path = `shard_logs/${profileId}/${payload.savedAt}`; await fb.ref(path).set(payload); logLine(`Saved to Firebase: ${path}`);}
+      catch(err){ logLine(`Firebase error: ${err.message||err}`); }
+    } else {
+      localStorage.setItem(`${STORAGE_KEY}__${profileId}`, JSON.stringify(payload));
+      logLine(`Saved locally for ${profileId}.`);
+    }
+  }
+
+  function escapeHtml(s){ return String(s).replace(/[&<>"']/g, m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m])); }
+
+  async function drawCardsSimple(count){
+    if (localStorage.getItem(DM_SHARD_KEY) !== '1') {
+      toast('The Shards reject your call');
+      logDM('Blocked draw: shards disabled');
+      return [];
+    }
+    if (state.activeCard) return [state.activeCard];
+    if (!confirm('Draw from the Shard?')) return [];
+    if (!confirm('Are you sure? This cannot be undone.')) return [];
+    await load();
+    buildFreshDeckIfNeeded();
+    if (!state.deck.length) return [];
+    const id = state.deck.splice(Math.floor(Math.random() * state.deck.length), 1)[0];
+    const plate = PLATES.find(p => p.id === id);
+    state.activeCard = { ...plate, drawnAt: Date.now() };
+    await persist();
+    await playDrawAnimation();
+    renderPlate();
+    if (plate.id==='FRAGMENT') state.declared += 1;
+    logDM(`Draw: ${plate.name}`);
+    return [plate];
+  }
+
+  window.CCShard = {
+    open: ()=> ui.root.classList.remove('hidden'),
+    reset: resetAll,
+    setFirebase: (database)=>{ fb = database; },
+    plates: PLATES,
+    stats: STATS,
+    draw: drawCardsSimple
+  };
+
+  async function init(){
+    wireUI();
+    await load();
+    buildFreshDeckIfNeeded();
+    render();
+  }
+
+  init();
+})();

--- a/styles/main.css
+++ b/styles/main.css
@@ -490,7 +490,7 @@ body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
 .toast.error::before{background-image:var(--icon-error)}
 
 .dm-login-btn{display:block;width:100%;height:20px;margin:0;padding:0;opacity:0;border:none;background:transparent}
-#dm-toast{flex-direction:column;gap:6px}
+#dm-toast{flex-direction:column;gap:6px;max-height:80vh;overflow:auto}
 #dm-toast::before{display:none}
 
 /* ability grid */
@@ -664,3 +664,48 @@ select[required]:valid{
 .tag { font-size: 0.8rem; padding: 2px 8px; border-radius: 999px; background: #e9f5ff; color: #0a5; border: 1px solid #bfe6ff; }
 .tag.warn { background: #fff5e5; color: #a65; border-color: #ffd9a1; }
 
+/* Shard of Many Fates • Catalyst Core Add-on */
+#cc-shard.hidden { display: none; }
+#cc-shard { background:#0c0f13; color:#e6f1ff; border:1px solid #1b2532; border-radius:8px; padding:16px; margin:12px 0; }
+#cc-shard h2, #cc-shard h3, #cc-shard h4 { margin: 0 0 8px 0; }
+#cc-shard .muted { opacity:.8; }
+.cc-btn { padding:8px 12px; border:1px solid #253247; background:#121821; color:#e6f1ff; border-radius:6px; cursor:pointer; }
+.cc-btn--primary { background:#0b2a3a; border-color:#104a64; }
+.cc-btn--ghost { background:transparent; }
+.cc-btn--danger { background:#3a0b14; border-color:#64101c; }
+
+.cc-switch { display:inline-flex; align-items:center; gap:8px; }
+.cc-deck__header { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; }
+.cc-deck__top { display:grid; grid-template-columns: 1fr 280px; gap:16px; margin-bottom:12px; }
+.cc-deck__main { display:grid; grid-template-columns: 2fr 1fr; gap:16px; }
+.cc-deck__drawRow, .cc-deck__saveRow { display:flex; align-items:center; gap:8px; margin:8px 0; }
+
+.cc-deck__card { position:relative; border:1px solid #1b2532; border-radius:8px; padding:12px; background:#0c1017; }
+.cc-deck__flash { position:absolute; inset:0; background:#fff; opacity:0; pointer-events:none; }
+.cc-deck__flash.active { animation:ccShardFlash .8s ease-out; }
+@keyframes ccShardFlash {
+  0%,100%{opacity:0;}
+  10%{opacity:.9;}
+  20%{opacity:0;}
+  30%{opacity:.9;}
+  40%{opacity:0;}
+}
+.cc-deck__sigil { font-size:12px; text-transform:uppercase; letter-spacing:.12em; opacity:.8; }
+.cc-deck__actions { display:flex; gap:8px; margin-top:12px; }
+
+.cc-deck__sidebar { border:1px solid #1b2532; border-radius:8px; padding:12px; background:#0c1017; max-height:680px; overflow:auto; }
+.cc-list { margin:0; padding-left:16px; }
+.cc-code { background:#0b1119; color:#bfe2ff; padding:12px; border-radius:6px; border:1px solid #1b2532; white-space:pre-wrap; }
+
+.cc-cardList, .cc-npcModal { position:fixed; inset:0; background:rgba(0,0,0,.8); display:flex; align-items:center; justify-content:center; z-index:1000; }
+.cc-cardList.hidden, .cc-npcModal.hidden { display:none; }
+.cc-cardList__body, .cc-npcModal__inner { background:#0c0f13; color:#e6f1ff; border:1px solid #1b2532; border-radius:8px; padding:16px; max-height:90vh; overflow:auto; width:90%; max-width:600px; }
+.cc-npcStats { display:flex; gap:8px; margin-bottom:8px; }
+.cc-npcModal__actions { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:8px; }
+
+.cc-tabs { margin-top:8px; }
+.cc-tabs__nav { display:flex; gap:6px; margin-bottom:8px; }
+.cc-tabs__nav button { padding:6px 10px; border:1px solid #253247; background:#0d141c; border-radius:4px; color:#cfe7ff; cursor:pointer; }
+.cc-tabs__nav button.active { background:#0b2a3a; border-color:#104a64; }
+.cc-tabs__pane { display:none; border:1px dashed #223044; border-radius:6px; padding:8px; }
+.cc-tabs__pane.active { display:block; }


### PR DESCRIPTION
## Summary
- remove heat tracking from the Shard of Many Fates and slim the reset flow
- add a full card reference list and NPC sheets with HP/SP tracking
- wire action buttons for NPC powers to simple roll helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc75373ad8832ea993710c2eed2ad9