### PR TITLE
Restrict Shard of Many Fates access to DM Tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,6 @@
         <button id="btn-help" class="btn-sm">Help</button>
         <button id="btn-fun" class="btn-sm">Fun Tip</button>
         <button id="btn-save" class="btn-sm">Save</button>
-        <button id="ccShard-open" class="btn-sm" hidden>Shard of Many Fates</button>
       </div>
     </div>
   </div>
@@ -81,9 +80,12 @@
     <fieldset id="ccShard-player" class="card" hidden>
       <legend>Shard Draw</legend>
       <div class="inline">
+        <label for="ccShard-player-count" class="sr-only">Cards</label>
+        <input id="ccShard-player-count" type="number" inputmode="numeric" min="1" value="1" />
         <button id="ccShard-player-draw" class="btn-sm">Draw</button>
       </div>
       <ol id="ccShard-player-results" class="cc-list"></ol>
+      <button id="ccShard-player-confirm" class="btn-sm" hidden>Confirm</button>
     </fieldset>
     <div class="grid grid-2 roll-flip-grid">
       <fieldset class="card">
@@ -776,6 +778,22 @@
       </svg>
     </button>
     <pre id="rules-text"></pre>
+  </div>
+</div>
+
+<div class="overlay hidden" id="modal-shard-resolve" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3 id="shard-resolve-title">Resolve Shard</h3>
+    <div id="shard-resolve-body"></div>
+    <div class="actions">
+      <button id="shard-resolve-addnpc" class="btn-sm" hidden>Add NPC as Character</button>
+      <button id="shard-resolve-complete" class="btn-sm">Mark Resolved</button>
+    </div>
   </div>
 </div>
 

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -4,21 +4,21 @@ const RECOVERY_ANSWER = 'August 29 2022';
 const dmBtn = document.getElementById('dm-login');
 const dmToast = document.getElementById('dm-toast');
 const baseToast = document.getElementById('toast');
-const shardBtn = document.getElementById('ccShard-open');
 const shardCard = document.getElementById('ccShard-player');
 const shardDraw = document.getElementById('ccShard-player-draw');
+const shardCount = document.getElementById('ccShard-player-count');
+const shardConfirm = document.getElementById('ccShard-player-confirm');
 const shardResults = document.getElementById('ccShard-player-results');
+
+const resolveTitle = document.getElementById('shard-resolve-title');
+const resolveBody = document.getElementById('shard-resolve-body');
+const resolveAddBtn = document.getElementById('shard-resolve-addnpc');
+const resolveCompleteBtn = document.getElementById('shard-resolve-complete');
 
 const SHARD_KEY = 'ccShardEnabled';
 const NOTIFY_KEY = 'dmNotifications';
-
-function setShardBtnVisibility(){
-  if(shardBtn){
-    const dm = sessionStorage.getItem('dmLoggedIn');
-    const enabled = localStorage.getItem(SHARD_KEY) === '1';
-    shardBtn.hidden = !dm && !enabled;
-  }
-}
+const DRAW_COUNT_KEY = 'ccShardPlayerDraws';
+const DRAW_LOCK_KEY = 'ccShardPlayerLocked';
 
 function setShardCardVisibility(showToast=false){
   if(shardCard){
@@ -38,8 +38,9 @@ function baseMessage(msg){
 }
 
 function showDmToast(html){
-  dmToast.innerHTML = html;
+  dmToast.innerHTML = `${html}<button id="dm-toast-close" class="btn-sm">Close</button>`;
   dmToast.classList.add('show');
+  document.getElementById('dm-toast-close').addEventListener('click', hideDmToast);
 }
 function hideDmToast(){
   dmToast.classList.remove('show');
@@ -56,37 +57,58 @@ function escapeHtml(s){
 window.logDMAction = logDMAction;
 
 function openLogin(){
-  if(sessionStorage.getItem('dmLoggedIn')){
-    openDmTools();
-    return;
-  }
-  showDmToast(`
-    <input id="dm-pin" type="password" inputmode="numeric" maxlength="4" pattern="\\d{4}" placeholder="PIN" />
-    <div class="inline">
-      <button id="dm-login-btn" class="btn-sm">Log In</button>
-      <button id="dm-logout-btn" class="btn-sm">Log Out</button>
-    </div>
-    <button id="dm-recover-btn" class="btn-sm">Recover PIN</button>
-  `);
-  document.getElementById('dm-login-btn').addEventListener('click', handleLogin);
-  document.getElementById('dm-logout-btn').addEventListener('click', handleLogout);
-  document.getElementById('dm-recover-btn').addEventListener('click', openRecovery);
+  openDmTools();
 }
 
 function openDmTools(){
+  if(!sessionStorage.getItem('dmLoggedIn')){
+    showDmToast(`
+      <input id="dm-pin" type="password" inputmode="numeric" maxlength="4" pattern="\\d{4}" placeholder="PIN" />
+      <div class="inline">
+        <button id="dm-login-btn" class="btn-sm">Log In</button>
+      </div>
+      <button id="dm-recover-btn" class="btn-sm">Recover PIN</button>
+    `);
+    document.getElementById('dm-login-btn').addEventListener('click', handleLogin);
+    document.getElementById('dm-recover-btn').addEventListener('click', openRecovery);
+    return;
+  }
   const enabled = localStorage.getItem(SHARD_KEY) === '1';
   const notes = JSON.parse(localStorage.getItem(NOTIFY_KEY) || '[]');
   showDmToast(`
     <label class="cc-switch"><input id="dm-shard-toggle" type="checkbox" ${enabled? 'checked' : ''}><span>Allow Shards</span></label>
-    <button id="dm-view-notes" class="btn-sm">Notifications (${notes.length})</button>
-    <button id="dm-logout-btn" class="btn-sm">Log Out</button>
+    <div class="inline">
+      <button id="ccShard-open" class="btn-sm">Shard of Many Fates</button>
+      <button id="dm-resolve-shard" class="btn-sm">Resolve Shards</button>
+      <button id="dm-reset-draws" class="btn-sm">Reset Draws</button>
+      <button id="dm-view-notes" class="btn-sm">Notifications (${notes.length})</button>
+      <button id="dm-logout-btn" class="btn-sm">Log Out</button>
+    </div>
   `);
   document.getElementById('dm-shard-toggle').addEventListener('change', e=>{
     if(e.target.checked) localStorage.setItem(SHARD_KEY,'1');
     else localStorage.removeItem(SHARD_KEY);
-    setShardBtnVisibility();
     setShardCardVisibility(true);
     if(!e.target.checked) baseMessage('Shards disabled');
+  });
+  const shardBtn = document.getElementById('ccShard-open');
+  if(shardBtn){
+    shardBtn.addEventListener('click', ()=>{
+      if(window.CCShard && typeof window.CCShard.open === 'function'){
+        window.CCShard.open();
+      }
+    });
+  }
+  const resolveBtn = document.getElementById('dm-resolve-shard');
+  if(resolveBtn){
+    resolveBtn.addEventListener('click', openShardResolver);
+  }
+  document.getElementById('dm-reset-draws').addEventListener('click', ()=>{
+    localStorage.removeItem(DRAW_COUNT_KEY);
+    localStorage.removeItem(DRAW_LOCK_KEY);
+    const btn = document.getElementById('ccShard-player-draw');
+    if(btn) btn.disabled = false;
+    baseMessage('Players may draw again');
   });
   document.getElementById('dm-view-notes').addEventListener('click', openNotifications);
   document.getElementById('dm-logout-btn').addEventListener('click', handleLogout);
@@ -109,11 +131,41 @@ function openNotifications(){
   document.getElementById('dm-back-btn').addEventListener('click', openDmTools);
 }
 
+function openShardResolver(){
+  const card = window.CCShard && typeof window.CCShard.getActiveCard === 'function'
+    ? window.CCShard.getActiveCard()
+    : null;
+  if(card){
+    resolveTitle.textContent = card.name;
+    const res = card.resolution ? card.resolution.map(r=>`<li>${escapeHtml(r)}</li>`).join('') : '<li>None</li>';
+    let enemyHtml = '<p><em>No enemy</em></p>';
+    if(card.enemy){
+      const stats = (window.CCShard && window.CCShard.stats) || {};
+      enemyHtml = card.enemy.split('|').map(k=>`<strong>${k}</strong><pre class="cc-code">${escapeHtml(stats[k]||'Unknown')}</pre>`).join('');
+    }
+    resolveBody.innerHTML = `<h4>Resolution</h4><ul>${res}</ul><h4>Enemy</h4>${enemyHtml}`;
+    const ally = card.rewards && card.rewards.find(r=>/ally\s+(\w+)/i.test(r));
+    if(ally){
+      const m = ally.match(/ally\s+(\w+)/i);
+      resolveAddBtn.dataset.npcId = m ? m[1] : '';
+      resolveAddBtn.hidden = !resolveAddBtn.dataset.npcId;
+    } else {
+      resolveAddBtn.hidden = true;
+    }
+    resolveCompleteBtn.disabled = false;
+  } else {
+    resolveTitle.textContent = 'Resolve Shard';
+    resolveBody.innerHTML = '<p>No active shard.</p>';
+    resolveAddBtn.hidden = true;
+    resolveCompleteBtn.disabled = true;
+  }
+  window.dispatchEvent(new CustomEvent('dm:showModal',{ detail: 'modal-shard-resolve' }));
+}
+
 function handleLogin(){
   const val = document.getElementById('dm-pin').value.trim();
   if(val === DM_PIN){
     sessionStorage.setItem('dmLoggedIn', '1');
-    setShardBtnVisibility();
     openDmTools();
     baseMessage('Logged in');
   } else {
@@ -125,7 +177,6 @@ function handleLogout(){
   hideDmToast();
   baseMessage('Logged out');
   sessionStorage.removeItem('dmLoggedIn');
-  setShardBtnVisibility();
 }
 
 function openRecovery(){
@@ -153,21 +204,61 @@ if(dmBtn){
   dmBtn.addEventListener('click', openLogin);
 }
 
-if(shardBtn){
-  setShardBtnVisibility();
-  window.addEventListener('pageshow', setShardBtnVisibility);
-}
-
 setShardCardVisibility();
 window.addEventListener('storage', e=>{
   if(e.key === SHARD_KEY) setShardCardVisibility(true);
 });
 
 if(shardDraw){
+  if(localStorage.getItem(DRAW_LOCK_KEY) === '1') shardDraw.disabled = true;
   shardDraw.addEventListener('click', async ()=>{
+    if(localStorage.getItem(DRAW_LOCK_KEY) === '1'){
+      baseMessage('Shard draws exhausted');
+      return;
+    }
+    const count = Math.max(1, parseInt(shardCount.value,10)||1);
     const cards = window.CCShard && typeof window.CCShard.draw === 'function'
-      ? await window.CCShard.draw(1)
+      ? await window.CCShard.draw(count)
       : [];
-    shardResults.innerHTML = cards.map(c=>`<li>${c.name}</li>`).join('');
+    if(cards.length){
+      shardResults.innerHTML = cards.map(c=>`<li>${c.name}</li>`).join('');
+      shardConfirm.hidden = false;
+    }
+  });
+}
+
+if(shardConfirm){
+  shardConfirm.addEventListener('click', ()=>{
+    shardConfirm.hidden = true;
+    shardResults.innerHTML = '';
+    const draws = parseInt(localStorage.getItem(DRAW_COUNT_KEY) || '0',10) + 1;
+    localStorage.setItem(DRAW_COUNT_KEY, draws.toString());
+    if(draws >= 2){
+      localStorage.setItem(DRAW_LOCK_KEY, '1');
+      shardDraw.disabled = true;
+      baseMessage('Shard draws exhausted');
+      logDMAction('Player exhausted shard draws');
+    } else {
+      baseMessage('Draw confirmed');
+    }
+  });
+}
+
+if(resolveAddBtn){
+  resolveAddBtn.addEventListener('click', ()=>{
+    const id = resolveAddBtn.dataset.npcId;
+    if(id){
+      window.dispatchEvent(new CustomEvent('dm:addNpc',{ detail:{ id }}));
+    }
+    window.dispatchEvent(new CustomEvent('dm:hideModal',{ detail:'modal-shard-resolve' }));
+  });
+}
+if(resolveCompleteBtn){
+  resolveCompleteBtn.addEventListener('click', ()=>{
+    if(window.CCShard && typeof window.CCShard.resolveActive === 'function'){
+      window.CCShard.resolveActive();
+      baseMessage('Shard resolved');
+    }
+    window.dispatchEvent(new CustomEvent('dm:hideModal',{ detail:'modal-shard-resolve' }));
   });
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -12,6 +12,8 @@ import {
   saveCharacter,
 } from './characters.js';
 import { show, hide } from './modal.js';
+window.addEventListener('dm:showModal', e => show(e.detail));
+window.addEventListener('dm:hideModal', e => hide(e.detail));
 // Load the optional confetti library lazily so tests and offline environments
 // don't attempt a network import on startup.
 let confettiPromise = null;
@@ -1387,6 +1389,25 @@ if(saveCurrentBtn){
     catch(e){ toast('Save failed','error'); }
   });
 }
+
+window.addEventListener('dm:addNpc', e=>{
+  const id = e.detail && e.detail.id;
+  if(!id || !window.CCShard || typeof window.CCShard.getNPC !== 'function') return;
+  const npc = window.CCShard.getNPC(id);
+  if(!npc) return;
+  const name = prompt('Enter character name for NPC', npc.name) || npc.name;
+  setCurrentCharacter(name);
+  deserialize(DEFAULT_STATE);
+  const hpBar = $('hp-bar');
+  const spBar = $('sp-bar');
+  const hpPill = $('hp-pill');
+  const spPill = $('sp-pill');
+  if(hpBar){ hpBar.max = npc.hp; hpBar.value = npc.hp; }
+  if(spBar){ spBar.max = npc.sp; spBar.value = npc.sp; }
+  if(hpPill) hpPill.textContent = `${npc.hp}/${npc.hp}`;
+  if(spPill) spPill.textContent = `${npc.sp}/${npc.sp}`;
+  toast(`Switched to ${name}`,'success');
+});
 
 const recoverListEl = $('recover-list');
 if(recoverListEl){

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -380,7 +380,9 @@ Weakness: Disadvantage on Deception vs party after reveal.`,
   }
 
   function wireUI(){
-    ui.openBtn.addEventListener('click', ()=> ui.root.classList.remove('hidden'));
+    if(ui.openBtn){
+      ui.openBtn.addEventListener('click', ()=> ui.root.classList.remove('hidden'));
+    }
     ui.closeBtn.addEventListener('click', ()=> ui.root.classList.add('hidden'));
 
     ui.resetBtn.addEventListener('click', resetAll);
@@ -702,15 +704,19 @@ Weakness: Disadvantage on Deception vs party after reveal.`,
     await load();
     buildFreshDeckIfNeeded();
     if (!state.deck.length) return [];
-    const id = state.deck.splice(Math.floor(Math.random() * state.deck.length), 1)[0];
-    const plate = PLATES.find(p => p.id === id);
-    state.activeCard = { ...plate, drawnAt: Date.now() };
+    const results = [];
+    for(let i=0;i<count && state.deck.length;i++){
+      const id = state.deck.splice(Math.floor(Math.random() * state.deck.length), 1)[0];
+      const plate = PLATES.find(p => p.id === id);
+      results.push(plate);
+      state.activeCard = { ...plate, drawnAt: Date.now() };
+      if (plate.id==='FRAGMENT') state.declared += 1;
+      logDM(`Draw: ${plate.name}`);
+    }
     await persist();
     await playDrawAnimation();
     renderPlate();
-    if (plate.id==='FRAGMENT') state.declared += 1;
-    logDM(`Draw: ${plate.name}`);
-    return [plate];
+    return results;
   }
 
   window.CCShard = {
@@ -719,7 +725,10 @@ Weakness: Disadvantage on Deception vs party after reveal.`,
     setFirebase: (database)=>{ fb = database; },
     plates: PLATES,
     stats: STATS,
-    draw: drawCardsSimple
+    draw: drawCardsSimple,
+    getActiveCard: ()=> state.activeCard,
+    getNPC: id => NPCS[id],
+    resolveActive: completePlate
   };
 
   async function init(){


### PR DESCRIPTION
## Summary
- Let DM toasts close themselves and streamline the DM tools login flow
- Add draw-count limits and numeric card draw input for shard users
- Support multi-card draws in shard engine
- Add Resolve Shards modal with enemy stats and NPC add option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc88e78d70832eb61666ef5952ff39