### PR TITLE
feat(dm): add floating tool icon and shard draw enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,10 +79,10 @@
   <fieldset data-tab="combat" class="card">
     <fieldset id="ccShard-player" class="card" hidden>
       <legend>Shard Draw</legend>
-      <div class="inline">
-        <label for="ccShard-player-count" class="sr-only">Cards</label>
-        <input id="ccShard-player-count" type="number" inputmode="numeric" min="1" value="1" />
+      <label for="ccShard-player-count" class="sr-only">Cards</label>
+      <div class="grid shard-draw-grid">
         <button id="ccShard-player-draw" class="btn-sm">Draw</button>
+        <input id="ccShard-player-count" type="number" inputmode="numeric" min="1" value="1" />
       </div>
       <ol id="ccShard-player-results" class="cc-list"></ol>
     </fieldset>
@@ -819,6 +819,16 @@
     <div class="actions">
       <button id="shard-reset-confirm" class="btn-sm">Reset</button>
       <button class="btn-sm" data-close>Cancel</button>
+    </div>
+</div>
+</div>
+
+<div class="overlay hidden" id="modal-shard-reveal" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <h3 id="shard-reveal-name">Shard Drawn</h3>
+    <p id="shard-reveal-visual"></p>
+    <div class="actions">
+      <button id="shard-reveal-next" class="btn-sm">Close</button>
     </div>
   </div>
 </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -105,6 +105,8 @@ footer p{
 .grid-2-fixed{grid-template-columns:repeat(2,1fr)}
 @media(min-width:600px){.grid-2{grid-template-columns:repeat(2,1fr)}.grid-3{grid-template-columns:repeat(2,1fr)}}
 @media(min-width:900px){.grid-3{grid-template-columns:repeat(3,1fr)}}
+#ccShard-player .shard-draw-grid{grid-template-columns:auto auto;align-items:center}
+#ccShard-player .shard-draw-grid input{width:4em}
 #statuses{grid-template-columns:repeat(2,1fr);margin-top:8px}
 .status-effects{font-size:90%}
 .stats-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px}
@@ -489,7 +491,26 @@ body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
 .toast.success::before{background-image:var(--icon-success)}
 .toast.error::before{background-image:var(--icon-error)}
 
-.dm-login-btn{display:block;width:100%;height:20px;margin:0;padding:0;opacity:0;border:none;background:transparent}
+.dm-login-btn{
+  position:fixed;
+  bottom:18px;
+  right:18px;
+  width:44px;
+  height:44px;
+  margin:0;
+  padding:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  border:1px solid var(--accent);
+  border-radius:50%;
+  background:var(--surface);
+  box-shadow:var(--shadow);
+  cursor:pointer;
+  font-weight:700;
+}
+.dm-login-btn::before{content:'DM';}
+.dm-login-btn[hidden]{display:none;}
 #dm-toast{flex-direction:column;gap:6px;max-height:80vh;overflow:auto}
 #dm-toast::before{display:none}
 


### PR DESCRIPTION
## Summary
- minimize DM Tools into a floating icon when closed
- instantly hide Shard draw card when Allow Shards is disabled
- arrange Shard draw controls into two-column layout with draw count input on the right
- reveal drawn Shard cards in a modal that requires acknowledgment before continuing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb492e6d0832e8a747c36d6914580