### PR TITLE
Adjust shard draw layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,8 +81,8 @@
       <legend>Shard Draw</legend>
       <label for="ccShard-player-count" class="sr-only">Cards</label>
       <div class="grid shard-draw-grid">
-        <button id="ccShard-player-draw" class="btn-sm">Draw</button>
         <input id="ccShard-player-count" type="number" inputmode="numeric" min="1" value="1" />
+        <button id="ccShard-player-draw" class="btn-sm">Draw</button>
       </div>
       <ol id="ccShard-player-results" class="cc-list"></ol>
     </fieldset>

--- a/styles/main.css
+++ b/styles/main.css
@@ -105,8 +105,9 @@ footer p{
 .grid-2-fixed{grid-template-columns:repeat(2,1fr)}
 @media(min-width:600px){.grid-2{grid-template-columns:repeat(2,1fr)}.grid-3{grid-template-columns:repeat(2,1fr)}}
 @media(min-width:900px){.grid-3{grid-template-columns:repeat(3,1fr)}}
-#ccShard-player .shard-draw-grid{grid-template-columns:auto auto;align-items:center}
+#ccShard-player .shard-draw-grid{grid-template-columns:auto 1fr;align-items:center}
 #ccShard-player .shard-draw-grid input{width:4em}
+#ccShard-player .shard-draw-grid button{width:100%}
 #statuses{grid-template-columns:repeat(2,1fr);margin-top:8px}
 .status-effects{font-size:90%}
 .stats-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px}


### PR DESCRIPTION
## Summary
- Reorder player shard draw controls so the count input appears before the draw button
- Make the draw button expand to fill remaining space in the grid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bce09cd758832e82f13b05537a4b8b