### PR TITLE
Show DM tools button only after login

### DIFF
--- a/index.html
+++ b/index.html
@@ -917,7 +917,10 @@
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
   <p>Product of XoVrom industries ® 2025</p>
 </footer>
-<button id="dm-login" class="dm-login-btn" aria-label="DM Login"></button>
+<div style="text-align:center;margin-top:1rem;">
+  <button id="dm-login-link" class="btn-sm" type="button">DM Login</button>
+</div>
+<button id="dm-login" class="dm-login-btn" aria-label="DM Tools" hidden></button>
 <div id="down-animation" aria-hidden="true" hidden>⚠️</div>
 <div id="death-animation" aria-hidden="true" hidden>💀</div>
 <div id="damage-animation" aria-hidden="true" hidden></div>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -2,6 +2,7 @@ const DM_PIN = '1231';
 const RECOVERY_ANSWER = 'August 29 2022';
 
 const dmBtn = document.getElementById('dm-login');
+const dmLink = document.getElementById('dm-login-link');
 const dmToast = document.getElementById('dm-toast');
 const baseToast = document.getElementById('toast');
 const shardCard = document.getElementById('ccShard-player');
@@ -110,11 +111,18 @@ function showDmToast(html){
   dmToast.innerHTML = `${html}<button id="dm-toast-close" class="btn-sm">Close</button>`;
   dmToast.classList.add('show');
   if(dmBtn) dmBtn.hidden = true;
+  if(dmLink) dmLink.hidden = true;
   document.getElementById('dm-toast-close').addEventListener('click', hideDmToast);
 }
 function hideDmToast(){
   dmToast.classList.remove('show');
-  if(dmBtn) dmBtn.hidden = false;
+  updateDmButton();
+}
+
+function updateDmButton(){
+  const loggedIn = sessionStorage.getItem('dmLoggedIn') === '1';
+  if(dmBtn) dmBtn.hidden = !loggedIn;
+  if(dmLink) dmLink.hidden = loggedIn;
 }
 
 function logDMAction(text){
@@ -242,6 +250,7 @@ function handleLogin(){
   const val = document.getElementById('dm-pin').value.trim();
   if(val === DM_PIN){
     sessionStorage.setItem('dmLoggedIn', '1');
+    updateDmButton();
     openDmTools();
     baseMessage('Logged in');
   } else {
@@ -250,9 +259,9 @@ function handleLogin(){
 }
 
 function handleLogout(){
+  sessionStorage.removeItem('dmLoggedIn');
   hideDmToast();
   baseMessage('Logged out');
-  sessionStorage.removeItem('dmLoggedIn');
 }
 
 function openRecovery(){
@@ -279,6 +288,10 @@ function handleRecovery(){
 if(dmBtn){
   dmBtn.addEventListener('click', openLogin);
 }
+if(dmLink){
+  dmLink.addEventListener('click', openLogin);
+}
+updateDmButton();
 
 setShardCardVisibility();
 window.addEventListener('storage', e=>{


### PR DESCRIPTION
## Summary
- Add DM Login link under the footer
- Hide floating DM tools button until DM logs in
- Update DM login/logout flow to toggle button visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bce44e7a98832eb2ae50d11fff8308