### PR TITLE
Fix DM login button not functioning

### DIFF
--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -135,7 +135,11 @@ function escapeHtml(s){
 }
 window.logDMAction = logDMAction;
 
-function openLogin(){
+function openLogin(e){
+  if (e) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
   openDmTools();
 }
 


### PR DESCRIPTION
## Summary
- Ensure DM login button click handlers prevent default actions
- Stop propagation when invoking DM tools to avoid interference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd130f9ad4832eb8a060a9fbf68eea