### PR TITLE
Center hidden DM login trigger under header

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,10 @@
   </nav>
 </header>
 
+<div class="dm-login-wrapper">
+  <button id="dm-login-link" type="button" aria-label="DM Login"></button>
+</div>
+
 <main id="main">
   <!-- COMBAT -->
   <fieldset data-tab="combat" class="card">
@@ -917,9 +921,6 @@
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
   <p>Product of XoVrom industries ® 2025</p>
 </footer>
-<div style="text-align:center;margin-top:1rem;">
-  <button id="dm-login-link" class="btn-sm" type="button">DM Login</button>
-</div>
 <button id="dm-login" class="dm-login-btn" aria-label="DM Tools" hidden></button>
 <div id="down-animation" aria-hidden="true" hidden>⚠️</div>
 <div id="death-animation" aria-hidden="true" hidden>💀</div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -512,6 +512,8 @@ body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
 }
 .dm-login-btn::before{content:'DM';}
 .dm-login-btn[hidden]{display:none;}
+.dm-login-wrapper{position:relative;height:0;margin-bottom:20px;text-align:center;}
+#dm-login-link{position:absolute;left:50%;top:0;transform:translateX(-50%);width:80px;height:20px;opacity:0;border:none;background:none;}
 #dm-toast{flex-direction:column;gap:6px;max-height:80vh;overflow:auto}
 #dm-toast::before{display:none}
 


### PR DESCRIPTION
## Summary
- Move DM login trigger beneath the header
- Hide DM login trigger via CSS while keeping it centered

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd12cb2fdc832e9235beea75fb47a7