### PR TITLE
feat(dm): add login modal and persistent tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,10 +74,6 @@
   </nav>
 </header>
 
-<div class="dm-login-wrapper">
-  <button id="dm-login-link" type="button" aria-label="DM Login"></button>
-</div>
-
 <main id="main">
   <!-- COMBAT -->
   <fieldset data-tab="combat" class="card">
@@ -537,6 +533,12 @@
 </main>
 
 
+<div class="overlay hidden" id="modal-dm-login" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" aria-label="DM Login" tabindex="-1">
+    <div id="dm-login-form"></div>
+  </div>
+</div>
+
 <div class="overlay hidden" id="modal-load-list" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
     <button class="x" data-close aria-label="Close">
@@ -921,6 +923,9 @@
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
   <p>Product of XoVrom industries ® 2025</p>
 </footer>
+<div class="dm-login-wrapper">
+  <button id="dm-login-link" type="button" aria-label="DM Login"></button>
+</div>
 <button id="dm-login" class="dm-login-btn" aria-label="DM Tools" hidden></button>
 <div id="down-animation" aria-hidden="true" hidden>⚠️</div>
 <div id="death-animation" aria-hidden="true" hidden>💀</div>

--- a/scripts/modal.js
+++ b/scripts/modal.js
@@ -57,10 +57,10 @@ export function show(id) {
   const el = $(id);
   if (!el || !el.classList.contains('hidden')) return;
   lastFocus = document.activeElement;
-  if (openModals === 0) {
-    document.body.classList.add('modal-open');
-    qsa('body > :not(.overlay)').forEach(e => e.setAttribute('inert', ''));
-  }
+    if (openModals === 0) {
+      document.body.classList.add('modal-open');
+      qsa('body > :not(.overlay):not(#dm-login):not(#dm-toast)').forEach(e => e.setAttribute('inert', ''));
+    }
   openModals++;
   el.style.display = 'flex';
   el.classList.remove('hidden');
@@ -89,8 +89,8 @@ export function hide(id) {
     lastFocus.focus();
   }
   openModals = Math.max(0, openModals - 1);
-  if (openModals === 0) {
-    document.body.classList.remove('modal-open');
-    qsa('body > :not(.overlay)').forEach(e => e.removeAttribute('inert'));
-  }
+    if (openModals === 0) {
+      document.body.classList.remove('modal-open');
+      qsa('body > :not(.overlay):not(#dm-login):not(#dm-toast)').forEach(e => e.removeAttribute('inert'));
+    }
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -470,7 +470,7 @@ progress::-moz-progress-bar{
 .modal:focus{outline:none}
 .overlay.hidden .modal{transform:scale(.95);opacity:0}
 body.modal-open{overflow:hidden}
-body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
+body.modal-open> :not(.overlay):not(#dm-login):not(#dm-toast){pointer-events:none;user-select:none}
 .modal h3{margin:0 0 4px;color:var(--accent);font-size:.9rem;line-height:1.2;font-weight:600}
 .modal .x{position:sticky;top:8px;margin-left:auto;margin-right:8px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition);z-index:2}
 .modal .x:hover{color:var(--accent)}
@@ -495,7 +495,7 @@ body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
 .dm-login-btn{
   position:fixed;
   bottom:18px;
-  right:18px;
+  left:18px;
   width:44px;
   height:44px;
   margin:0;
@@ -514,7 +514,7 @@ body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
 .dm-login-btn[hidden]{display:none;}
 .dm-login-wrapper{position:relative;height:0;margin-bottom:20px;text-align:center;}
 #dm-login-link{position:absolute;left:50%;top:0;transform:translateX(-50%);width:80px;height:20px;opacity:0;border:none;background:none;}
-#dm-toast{flex-direction:column;gap:6px;max-height:80vh;overflow:auto}
+#dm-toast{flex-direction:column;gap:6px;max-height:80vh;overflow:auto;left:72px;right:auto}
 #dm-toast::before{display:none}
 
 /* ability grid */


### PR DESCRIPTION
## Summary
- Move invisible DM login button to centered area beneath footer
- Show DM Tools floating button only after successful login
- Keep DM Tools toggle independent from other modals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd361eb400832ea4c7a1cfcdd134a7