### PR TITLE
Toggle theme only via logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -618,7 +618,7 @@
     </button>
     <h3>How to Use the Tracker</h3>
     <ul class="feature-list">
-      <li><b>Theme</b> Tap the header or logo to cycle between light, high-contrast, and dark modes.</li>
+      <li><b>Theme</b> Tap the logo to cycle between light, high-contrast, and dark modes.</li>
       <li><b>Main menu</b> Access Load, Help, and Save from the menu.</li>
       <li><b>Tab navigation</b> Use the Combat, Abilities, Powers, Gear, and Story tabs to move between sections.</li>
       <li><b>Combat tools</b> Update HP/SP, mark death saves, adjust defenses, and make quick rolls or flips.</li>
@@ -631,7 +631,7 @@
     <h4>Frequently Asked Questions</h4>
     <ul class="qa-list">
       <li><b>Can I use the tracker offline?</b> Yes. The app stores data in your browser so it works offline.</li>
-      <li><b>How do I change the theme?</b> Tap the header or logo to switch themes.</li>
+      <li><b>How do I change the theme?</b> Tap the logo to switch themes.</li>
       <li><b>Where do I adjust my HP or SP?</b> Visit the Combat tab and tap the current values to edit them.</li>
       <li><b>How do I roll a die or flip a coin?</b> Use the quick tools on the Combat tab.</li>
       <li><b>How can I manage my equipment?</b> Use the Gear tab to add and manage items.</li>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -247,13 +247,10 @@ if (btnMenu && menuActions) {
 
 /* ========= header ========= */
 const headerEl = qs('header');
-if (headerEl) {
-  headerEl.addEventListener('click', e => {
-    if (
-      e.target.closest('#btn-menu') ||
-      e.target.closest('#menu-actions') ||
-      e.target.closest('nav')
-    ) return;
+const logoEl = qs('.logo');
+if (logoEl) {
+  logoEl.addEventListener('click', e => {
+    e.stopPropagation();
     toggleTheme();
   });
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -71,6 +71,7 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 .tabs-title .logo{
   height:36px;
   width:auto;
+  cursor:pointer;
 }
 .theme-light .tabs-title .logo{
   filter:invert(1);


### PR DESCRIPTION
## Summary
- toggle theme only when the logo image is tapped
- show pointer cursor for the logo and update help text accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd3dd40b28832ea8baea19201d394d