### PR TITLE
Hide DM tools menu before login

### DIFF
--- a/index.html
+++ b/index.html
@@ -934,8 +934,8 @@
 <div id="coin-animation" aria-hidden="true" hidden></div>
 <div id="sp-animation" aria-hidden="true" hidden></div>
 <div id="load-animation" aria-hidden="true" hidden>📂</div>
-<div class="toast" id="dm-toast" role="dialog"></div>
-<div class="toast" id="toast" role="status" aria-live="polite"></div>
+  <div class="toast" id="dm-toast" role="dialog" aria-hidden="true" hidden></div>
+  <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script type="module" src="scripts/main.js"></script>
 <script type="module" src="scripts/dm.js"></script>
 <script src="shard-of-many-fates.js"></script>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -152,12 +152,18 @@ async function revealShard(card){
 
 function showDmToast(html){
   dmToast.innerHTML = `${html}<button id="dm-toast-close" class="btn-sm">Close</button>`;
-  dmToast.classList.add('show');
+  dmToast.hidden = false;
+  dmToast.setAttribute('aria-hidden', 'false');
+  requestAnimationFrame(() => dmToast.classList.add('show'));
   if(dmLink) dmLink.hidden = true;
   document.getElementById('dm-toast-close').addEventListener('click', hideDmToast);
 }
 function hideDmToast(){
   dmToast.classList.remove('show');
+  dmToast.addEventListener('transitionend', () => {
+    dmToast.hidden = true;
+    dmToast.setAttribute('aria-hidden', 'true');
+  }, { once: true });
   updateDmButton();
 }
 


### PR DESCRIPTION
## Summary
- hide DM tools toast until logged in
- toggle DM tools toast visibility with transition-based hide logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd75247a08832e86331691518722c4