### PR TITLE
fix: make DM login button clickable

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -514,7 +514,7 @@ body.modal-open> :not(.overlay):not(#dm-login):not(#dm-toast){pointer-events:non
 .dm-login-btn::before{content:'DM';}
 .dm-login-btn[hidden]{display:none;}
 .dm-login-wrapper{position:relative;height:0;margin-bottom:20px;text-align:center;}
-#dm-login-link{position:absolute;left:50%;top:0;transform:translateX(-50%);width:80px;height:20px;opacity:0;border:none;background:none;cursor:pointer;}
+#dm-login-link{position:fixed;left:50%;bottom:20px;transform:translateX(-50%);width:80px;height:20px;opacity:0;border:none;background:none;cursor:pointer;z-index:2000;}
 #dm-toast{flex-direction:column;gap:6px;max-height:80vh;overflow:auto;left:72px;right:auto}
 #dm-toast::before{display:none}
 


### PR DESCRIPTION
## Summary
- ensure hidden DM login link is positioned above footer so taps register

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8a72e254832eb0273eb4cfdb369d