### PR TITLE
feat: rework shards player card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,12 +79,12 @@
   <fieldset data-tab="combat" class="card">
     <fieldset id="ccShard-player" class="card" hidden aria-hidden="true">
       <legend>The Shards of Many Fates</legend>
-      <label for="ccShard-player-count" class="sr-only">Cards</label>
       <div class="grid shard-draw-grid">
+        <label for="ccShard-player-count">Cards</label>
         <input id="ccShard-player-count" type="number" inputmode="numeric" min="1" value="1" />
-        <button id="ccShard-player-draw" class="btn-sm">Draw</button>
+        <button id="ccShard-player-draw" type="button" class="btn-sm" disabled>Draw</button>
       </div>
-      <ol id="ccShard-player-results" class="cc-list"></ol>
+      <ol id="ccShard-player-results" class="cc-list" aria-live="polite"></ol>
     </fieldset>
     <div class="grid grid-2 roll-flip-grid">
       <fieldset class="card">

--- a/styles/main.css
+++ b/styles/main.css
@@ -106,7 +106,8 @@ footer p{
 .grid-2-fixed{grid-template-columns:repeat(2,1fr)}
 @media(min-width:600px){.grid-2{grid-template-columns:repeat(2,1fr)}.grid-3{grid-template-columns:repeat(2,1fr)}}
 @media(min-width:900px){.grid-3{grid-template-columns:repeat(3,1fr)}}
-#ccShard-player .shard-draw-grid{grid-template-columns:auto 1fr;align-items:center}
+#ccShard-player[aria-hidden="true"]{display:none}
+#ccShard-player .shard-draw-grid{grid-template-columns:auto auto 1fr;align-items:center}
 #ccShard-player .shard-draw-grid input{width:4em}
 #ccShard-player .shard-draw-grid button{width:100%}
 #statuses{grid-template-columns:repeat(2,1fr);margin-top:8px}


### PR DESCRIPTION
## Summary
- Rework Shards of Many Fates player card above dice roll to show card count label and screen reader-friendly results
- Adjust grid styling for updated shard draw layout
- Hide Shards card and disable draw button until DM toggle enables it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd9896acb8832ebc7110581211cc80