### PR TITLE
Rename card count label to Shards

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     <fieldset id="ccShard-player" class="card" hidden aria-hidden="true">
       <legend>The Shards of Many Fates</legend>
       <div class="grid shard-draw-grid">
-        <label for="ccShard-player-count">Cards</label>
+        <label for="ccShard-player-count">Shards</label>
         <input id="ccShard-player-count" type="number" inputmode="numeric" min="1" value="1" />
         <button id="ccShard-player-draw" type="button" class="btn-sm" disabled>Draw</button>
       </div>


### PR DESCRIPTION
## Summary
- Update Shards of Many Fates UI to label numeric input as "Shards" instead of "Cards"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda77ad8c8832e8a4abe45418c08de