### PR TITLE
Refactor DM login to toast and reposition secret button

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,12 +533,6 @@
 </main>
 
 
-<div class="overlay hidden" id="modal-dm-login" aria-hidden="true">
-  <div class="modal" role="dialog" aria-modal="true" aria-label="DM Login" tabindex="-1">
-    <div id="dm-login-form"></div>
-  </div>
-</div>
-
 <div class="overlay hidden" id="modal-load-list" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
     <button class="x" data-close aria-label="Close">
@@ -925,10 +919,10 @@
   <footer>
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
   <p>Product of XoVrom industries ® 2025</p>
+  <div class="dm-login-wrapper">
+    <button id="dm-login-link" type="button" aria-label="DM Login"></button>
+  </div>
 </footer>
-<div class="dm-login-wrapper">
-  <button id="dm-login-link" type="button" aria-label="DM Login"></button>
-</div>
 <button id="dm-login" class="dm-login-btn" aria-label="DM Tools" hidden></button>
 <div id="down-animation" aria-hidden="true" hidden>⚠️</div>
 <div id="death-animation" aria-hidden="true" hidden>💀</div>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -195,17 +195,15 @@ function escapeHtml(s){
   return String(s).replace(/[&<>"']/g, m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
 }
 window.logDMAction = logDMAction;
-const dmLoginForm = document.getElementById('dm-login-form');
 
 function renderLoginForm(){
-  if(!dmLoginForm) return;
-  dmLoginForm.innerHTML = `
+  showDmToast(`
       <input id="dm-pin" type="password" inputmode="numeric" maxlength="4" pattern="\\d{4}" placeholder="PIN" />
       <div class="inline">
         <button id="dm-login-btn" class="btn-sm">Log In</button>
       </div>
       <button id="dm-recover-btn" class="btn-sm">Recover PIN</button>
-  `;
+  `);
   document.getElementById('dm-login-btn').addEventListener('click', handleLogin);
   document.getElementById('dm-recover-btn').addEventListener('click', openRecovery);
 }
@@ -216,7 +214,6 @@ function openLogin(e){
     e.stopPropagation();
   }
   renderLoginForm();
-  window.dispatchEvent(new CustomEvent('dm:showModal',{ detail:'modal-dm-login' }));
 }
 
 function toggleDmTools(e){
@@ -332,7 +329,7 @@ function handleLogin(){
   if(val === DM_PIN){
     sessionStorage.setItem('dmLoggedIn', '1');
     updateDmButton();
-    window.dispatchEvent(new CustomEvent('dm:hideModal',{ detail:'modal-dm-login' }));
+    hideDmToast();
     baseMessage('Logged in');
   } else {
     baseMessage('Wrong PIN');
@@ -346,15 +343,14 @@ function handleLogout(){
 }
 
 function openRecovery(){
-  if(!dmLoginForm) return;
-  dmLoginForm.innerHTML = `
+  showDmToast(`
     <label for="dm-answer">Your First Date Anniversary</label>
     <input id="dm-answer" type="text" placeholder="Answer" />
     <div class="inline">
       <button id="dm-answer-btn" class="btn-sm">Submit</button>
       <button id="dm-back-btn" class="btn-sm">Back</button>
     </div>
-  `;
+  `);
   document.getElementById('dm-answer-btn').addEventListener('click', handleRecovery);
   document.getElementById('dm-back-btn').addEventListener('click', renderLoginForm);
 }
@@ -362,7 +358,6 @@ function openRecovery(){
 function handleRecovery(){
   const ans = document.getElementById('dm-answer').value.trim();
   if(ans === RECOVERY_ANSWER){
-    window.dispatchEvent(new CustomEvent('dm:hideModal',{ detail:'modal-dm-login' }));
     baseMessage('PIN: ' + DM_PIN);
   } else {
     baseMessage('Incorrect');

--- a/styles/main.css
+++ b/styles/main.css
@@ -88,10 +88,11 @@ footer{
   text-align:center;
   font-size:9pt;
   margin:8px auto 0;
-  padding:4px calc(20px + env(safe-area-inset-right)) calc(4px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left));
+  padding:4px calc(20px + env(safe-area-inset-right)) calc(44px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left));
   color:var(--muted);
   max-width:var(--content-width);
   width:100%;
+  position:relative;
 }
 
 footer p{
@@ -514,8 +515,8 @@ body.modal-open> :not(.overlay):not(#dm-login):not(#dm-toast){pointer-events:non
 }
 .dm-login-btn::before{content:'DM';}
 .dm-login-btn[hidden]{display:none;}
-.dm-login-wrapper{position:relative;height:0;margin-bottom:20px;text-align:center;}
-#dm-login-link{position:fixed;left:50%;bottom:20px;transform:translateX(-50%);width:80px;height:20px;opacity:0;border:none;background:none;cursor:pointer;z-index:2000;}
+.dm-login-wrapper{position:absolute;left:0;right:0;bottom:0;height:40px;text-align:center;}
+#dm-login-link{position:absolute;left:50%;bottom:10px;transform:translateX(-50%);width:80px;height:20px;opacity:0;border:none;background:none;cursor:pointer;}
 #dm-toast{flex-direction:column;gap:6px;max-height:80vh;overflow:auto;left:72px;right:auto}
 #dm-toast::before{display:none}
 


### PR DESCRIPTION
## Summary
- Replace DM login modal with toast-based form
- Only DM Tools logout removes DM session
- Move hidden DM login trigger into footer and extend footer padding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb9b935f4832e97362d8883beef0b