### PR TITLE
Ensure shard display after drawing

### DIFF
--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -574,6 +574,7 @@ function showNextFromQueue(){
   
 function render(){
   renderPlate();
+  if(state.activeCard) ui.root.classList.remove('hidden');
 }
 
 async function persist(){


### PR DESCRIPTION
## Summary
- Unhide Shard of Many Fates deck when a card is active so users immediately see results after a draw

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc2479634832ea4abd1bd3b0c1639