### PR TITLE
Fix DM draw notifications and toast layout

### DIFF
--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -235,7 +235,7 @@ function openDmTools(){
   }
   const notes = JSON.parse(localStorage.getItem(NOTIFY_KEY) || '[]');
   showDmToast(`
-    <div class="inline">
+    <div class="dm-toast-buttons">
       <button id="ccShard-open" class="btn-sm">The Shards of Many Fates</button>
       <button id="dm-view-notes" class="btn-sm">Notifications (${notes.length})</button>
       <button id="dm-logout-btn" class="btn-sm">Log Out</button>
@@ -405,6 +405,7 @@ if(shardDraw){
       await revealShard(card);
     }
     if(!names.length) return;
+    logDMAction(`Player drew shard${names.length>1?'s':''}: ${names.join(', ')}`);
     const draws = parseInt(localStorage.getItem(DRAW_COUNT_KEY) || '0',10) + 1;
     localStorage.setItem(DRAW_COUNT_KEY, draws.toString());
     if(draws >= 2){

--- a/styles/main.css
+++ b/styles/main.css
@@ -175,6 +175,9 @@ button:focus-visible,
 .inline>.bar-label{flex:1;width:auto;height:36px}
 .inline>.pill,
 .inline>.sr-only{flex:0;width:auto}
+
+.dm-toast-buttons{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.dm-toast-buttons>button{flex:1;width:auto;height:36px}
 @media(max-width:600px){
   .inline{flex-direction:column;align-items:stretch}
   .inline>input:not([type="checkbox"]),


### PR DESCRIPTION
## Summary
- Ensure DM toast buttons render in a row
- Notify DM when players draw shards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc34d1c64832ead2334476354a54a