### PR TITLE
Adjust DM login button vertical positioning

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -500,7 +500,7 @@ body.modal-open> :not(.overlay):not(#dm-login):not(#dm-toast){pointer-events:non
 
 .dm-login-btn{
   position:fixed;
-  bottom:18px;
+  bottom:33px;
   left:18px;
   width:44px;
   height:44px;
@@ -519,7 +519,7 @@ body.modal-open> :not(.overlay):not(#dm-login):not(#dm-toast){pointer-events:non
 .dm-login-btn::before{content:'DM';}
 .dm-login-btn[hidden]{display:none;}
 .dm-login-wrapper{position:absolute;left:0;right:0;bottom:0;height:40px;text-align:center;}
-#dm-login-link{position:absolute;left:50%;bottom:10px;transform:translateX(-50%);width:80px;height:20px;opacity:0;border:none;background:none;cursor:pointer;}
+#dm-login-link{position:absolute;left:50%;bottom:25px;transform:translateX(-50%);width:80px;height:20px;opacity:0;border:none;background:none;cursor:pointer;}
 #dm-toast{flex-direction:column;gap:6px;max-height:80vh;overflow:auto;left:72px;right:auto}
 #dm-toast::before{display:none}
 


### PR DESCRIPTION
## Summary
- move floating DM login button 15px higher
- shift hidden DM login trigger to match new position

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdcd6f8a74832e9375e9d7bb27c364