### PR TITLE
Improve DM login accessibility and toast layout

### DIFF
--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -164,12 +164,19 @@ async function revealShard(card){
 }
 
 function showDmToast(html){
-  dmToast.innerHTML = `${html}<button id="dm-toast-close" class="btn-sm">Close</button>`;
+  dmToast.innerHTML = html;
+  if(!dmToast.querySelector('#dm-toast-close')){
+    const closeBtn = document.createElement('button');
+    closeBtn.id = 'dm-toast-close';
+    closeBtn.className = 'btn-sm';
+    closeBtn.textContent = 'Close';
+    dmToast.appendChild(closeBtn);
+  }
   dmToast.hidden = false;
   dmToast.setAttribute('aria-hidden', 'false');
   requestAnimationFrame(() => dmToast.classList.add('show'));
   if(dmLink) dmLink.hidden = true;
-  document.getElementById('dm-toast-close').addEventListener('click', hideDmToast);
+  dmToast.querySelector('#dm-toast-close').addEventListener('click', hideDmToast);
 }
 function hideDmToast(){
   dmToast.classList.remove('show');
@@ -199,10 +206,11 @@ window.logDMAction = logDMAction;
 function renderLoginForm(){
   showDmToast(`
       <input id="dm-pin" type="password" inputmode="numeric" maxlength="4" pattern="\\d{4}" placeholder="PIN" />
-      <div class="inline">
+      <div class="dm-toast-buttons">
         <button id="dm-login-btn" class="btn-sm">Log In</button>
+        <button id="dm-recover-btn" class="btn-sm">Recover PIN</button>
+        <button id="dm-toast-close" class="btn-sm">Close</button>
       </div>
-      <button id="dm-recover-btn" class="btn-sm">Recover PIN</button>
   `);
   document.getElementById('dm-login-btn').addEventListener('click', handleLogin);
   document.getElementById('dm-recover-btn').addEventListener('click', openRecovery);
@@ -346,9 +354,10 @@ function openRecovery(){
   showDmToast(`
     <label for="dm-answer">Your First Date Anniversary</label>
     <input id="dm-answer" type="text" placeholder="Answer" />
-    <div class="inline">
+    <div class="dm-toast-buttons">
       <button id="dm-answer-btn" class="btn-sm">Submit</button>
       <button id="dm-back-btn" class="btn-sm">Back</button>
+      <button id="dm-toast-close" class="btn-sm">Close</button>
     </div>
   `);
   document.getElementById('dm-answer-btn').addEventListener('click', handleRecovery);

--- a/styles/main.css
+++ b/styles/main.css
@@ -176,7 +176,7 @@ button:focus-visible,
 .inline>.pill,
 .inline>.sr-only{flex:0;width:auto}
 
-.dm-toast-buttons{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.dm-toast-buttons{display:flex;align-items:center;gap:8px;flex-wrap:nowrap}
 .dm-toast-buttons>button{flex:1;width:auto;height:36px}
 @media(max-width:600px){
   .inline{flex-direction:column;align-items:stretch}
@@ -490,9 +490,9 @@ body.modal-open> :not(.overlay):not(#dm-login):not(#dm-toast){pointer-events:non
 #modal-help .feature-list svg{width:20px;height:20px;flex-shrink:0}
 #modal-rules .modal-rules{max-width:var(--modal-width)}
 #rules-text{white-space:pre-wrap}
-.toast{position:fixed;bottom:18px;right:18px;background:var(--surface);border:1px solid var(--accent);padding:10px 12px;border-radius:var(--radius);opacity:0;transform:translateY(8px);transition:opacity .3s ease-in-out,transform .3s ease-in-out;z-index:2000;display:flex;align-items:center;gap:6px}
+.toast{position:fixed;bottom:18px;right:18px;background:var(--surface);border:1px solid var(--accent);padding:10px 12px;border-radius:var(--radius);opacity:0;transform:translateY(8px);transition:opacity .3s ease-in-out,transform .3s ease-in-out;z-index:2000;display:flex;align-items:center;gap:6px;pointer-events:none}
 .toast::before{content:"";width:16px;height:16px;background-size:contain;background-repeat:no-repeat}
-.toast.show{opacity:1;transform:translateY(0)}
+.toast.show{opacity:1;transform:translateY(0);pointer-events:auto}
 .toast.success{border-color:var(--success);color:var(--success)}
 .toast.error{border-color:var(--error);color:var(--error)}
 .toast.success::before{background-image:var(--icon-success)}
@@ -518,8 +518,8 @@ body.modal-open> :not(.overlay):not(#dm-login):not(#dm-toast){pointer-events:non
 }
 .dm-login-btn::before{content:'DM';}
 .dm-login-btn[hidden]{display:none;}
-.dm-login-wrapper{position:absolute;left:0;right:0;bottom:0;height:40px;text-align:center;}
-#dm-login-link{position:absolute;left:50%;bottom:25px;transform:translateX(-50%);width:80px;height:20px;opacity:0;border:none;background:none;cursor:pointer;}
+.dm-login-wrapper{position:relative;left:0;right:0;bottom:0;height:40px;text-align:center;}
+#dm-login-link{position:absolute;left:50%;bottom:0;transform:translateX(-50%);width:120px;height:40px;opacity:0;border:none;background:none;cursor:pointer;}
 #dm-toast{flex-direction:column;gap:6px;max-height:80vh;overflow:auto;left:72px;right:auto}
 #dm-toast::before{display:none}
 


### PR DESCRIPTION
## Summary
- Add explicit Close button to DM login and recovery toasts for 3-column layouts
- Keep toasts self-contained by appending a Close button when missing and prevent button wrapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd0a62570832eb5769cb3de5bd297