### PR TITLE
Stack DM Tools menu vertically

### DIFF
--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -243,7 +243,7 @@ function openDmTools(){
   }
   const notes = JSON.parse(localStorage.getItem(NOTIFY_KEY) || '[]');
   showDmToast(`
-    <div class="dm-toast-buttons">
+    <div class="dm-toast-buttons dm-tools-menu">
       <button id="ccShard-open" class="btn-sm">The Shards of Many Fates</button>
       <button id="dm-view-notes" class="btn-sm">Notifications (${notes.length})</button>
       <button id="dm-logout-btn" class="btn-sm">Log Out</button>

--- a/styles/main.css
+++ b/styles/main.css
@@ -178,6 +178,8 @@ button:focus-visible,
 
 .dm-toast-buttons{display:flex;align-items:center;gap:8px;flex-wrap:nowrap}
 .dm-toast-buttons>button{flex:1;width:auto;height:36px}
+.dm-tools-menu{flex-direction:column;width:100%}
+.dm-tools-menu>button{flex:none;width:100%}
 @media(max-width:600px){
   .inline{flex-direction:column;align-items:stretch}
   .inline>input:not([type="checkbox"]),


### PR DESCRIPTION
## Summary
- Display DM Tools buttons in a single-column layout
- Add CSS styles to stack DM Tools menu buttons vertically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd5b621b4832e96b9565f87c0b182