### PR TITLE
Display drawn Shard card details

### DIFF
--- a/index.html
+++ b/index.html
@@ -829,7 +829,7 @@
 <div class="overlay hidden" id="modal-shard-reveal" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
     <h3 id="shard-reveal-name">Shard Drawn</h3>
-    <p id="shard-reveal-visual"></p>
+    <div id="shard-reveal-card" class="shard-card"></div>
     <div class="actions">
       <button id="shard-reveal-next" class="btn-sm">Close</button>
     </div>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -12,7 +12,7 @@ const shardDraw = document.getElementById('ccShard-player-draw');
 const shardCount = document.getElementById('ccShard-player-count');
 const shardResults = document.getElementById('ccShard-player-results');
 const shardRevealName = document.getElementById('shard-reveal-name');
-const shardRevealVisual = document.getElementById('shard-reveal-visual');
+const shardRevealCard = document.getElementById('shard-reveal-card');
 const shardRevealBtn = document.getElementById('shard-reveal-next');
 
 const resolveTitle = document.getElementById('shard-resolve-title');
@@ -148,10 +148,27 @@ function baseMessage(msg){
   setTimeout(()=> baseToast.classList.remove('show'), 3000);
 }
 
+function escapeHtml(s){
+  return String(s).replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
+}
+function bullets(arr){
+  if(!arr || !arr.length) return '<em>None</em>';
+  return `<ul>${arr.map(x=>`<li>${escapeHtml(x)}</li>`).join('')}</ul>`;
+}
+
 async function revealShard(card){
-  if(!shardRevealName || !shardRevealVisual || !shardRevealBtn) return;
+  if(!shardRevealName || !shardRevealCard || !shardRevealBtn) return;
   shardRevealName.textContent = card.name;
-  shardRevealVisual.textContent = card.visual || '';
+  const enemyHtml = card.enemy
+    ? card.enemy.split('|').map(k => `<strong>${escapeHtml(k)}</strong><pre class="cc-code">${escapeHtml((window.CCShard?.stats || {})[k] || 'Unknown')}</pre>`).join('')
+    : '<em>None</em>';
+  shardRevealCard.innerHTML = `
+    <p class="muted">${escapeHtml(card.visual || '')}</p>
+    <div><strong>Effect:</strong>${bullets(card.effect)}</div>
+    <div><strong>Hooks:</strong>${bullets(card.hooks)}</div>
+    <div><strong>Resolution:</strong>${bullets(card.resolution)}</div>
+    <div><strong>Enemy:</strong>${enemyHtml}</div>
+    <div><strong>Rewards:</strong>${card.rewards ? bullets(card.rewards) : '<em>None specified</em>'}</div>`;
   shardRevealBtn.textContent = 'Resolve';
   await new Promise(resolve=>{
     shardRevealBtn.onclick = () => {


### PR DESCRIPTION
## Summary
- show full shard card info in reveal modal when a card is drawn
- replace old visual-only reveal section with rich card details

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde30cd650832eb4cfb1e54a0e88cb