### PR TITLE
Fix DM login button not showing login toast

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -1,0 +1,35 @@
+import { jest } from '@jest/globals';
+
+describe('dm login', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve('0') }));
+    global.EventSource = undefined;
+    global.requestAnimationFrame = cb => cb();
+    document.body.innerHTML = `
+      <div class="dm-login-wrapper">
+        <button id="dm-login-link" type="button"></button>
+      </div>
+      <button id="dm-login" hidden></button>
+      <div class="toast" id="dm-toast" hidden></div>
+      <div class="toast" id="toast"></div>
+    `;
+    await import('../scripts/dm.js');
+  });
+
+  test('dm login link opens login toast', () => {
+    document.getElementById('dm-login-link').click();
+    const dmToast = document.getElementById('dm-toast');
+    expect(dmToast.hidden).toBe(false);
+    expect(dmToast.innerHTML).toContain('dm-login-btn');
+  });
+
+  test('dm tools button opens login when logged out', () => {
+    sessionStorage.clear();
+    const dmBtn = document.getElementById('dm-login');
+    dmBtn.hidden = false;
+    dmBtn.click();
+    const dmToast = document.getElementById('dm-toast');
+    expect(dmToast.hidden).toBe(false);
+  });
+});

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -375,7 +375,17 @@ function handleRecovery(){
 }
 
 if(dmBtn){
-  dmBtn.addEventListener('click', toggleDmTools);
+  dmBtn.addEventListener('click', e=>{
+    if(e){
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    if(sessionStorage.getItem('dmLoggedIn') === '1'){
+      toggleDmTools();
+    } else {
+      openLogin();
+    }
+  });
 }
 if(dmLink){
   dmLink.addEventListener('click', openLogin);


### PR DESCRIPTION
## Summary
- ensure DM tools button opens login prompt when no DM session exists
- add regression tests for DM login toast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf2a3a394832e964587a16444b4da