### PR TITLE
Ensure DM notified on shard draws

### DIFF
--- a/__tests__/shard_cloud_sync.test.js
+++ b/__tests__/shard_cloud_sync.test.js
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+
+const STATE_URL = 'https://ccccg-7d6b6-default-rtdb.firebaseio.com/shardDeck.json';
+const LOCK_URL = 'https://ccccg-7d6b6-default-rtdb.firebaseio.com/shardDeckLock.json';
+
+describe('Shard draws sync via cloud and prevent duplicates', () => {
+  let remoteData;
+  let lockVal;
+
+  beforeEach(() => {
+    remoteData = null;
+    lockVal = null;
+    localStorage.clear();
+    const stub = () => ({
+      addEventListener: jest.fn(),
+      classList: { add: jest.fn(), remove: jest.fn(), toggle: jest.fn() },
+      setAttribute: jest.fn(),
+      removeAttribute: jest.fn(),
+      appendChild: jest.fn(),
+      append: jest.fn(),
+      querySelector: jest.fn(() => null),
+      querySelectorAll: jest.fn(() => []),
+      innerHTML: '',
+      textContent: '',
+      disabled: false
+    });
+    document.getElementById = jest.fn(stub);
+    document.querySelector = jest.fn(stub);
+    document.querySelectorAll = jest.fn(() => []);
+    global.fetch = jest.fn(async (url, opts = {}) => {
+      if (url === LOCK_URL) {
+        if (opts.method === 'PUT') {
+          const body = JSON.parse(opts.body);
+          lockVal = body === 'null' ? null : body;
+          return { ok: true, status: 200, headers: { get: () => 'etag' }, json: async () => null };
+        }
+        return { ok: true, status: 200, headers: { get: () => 'etag' }, json: async () => lockVal };
+      }
+      if (url === STATE_URL) {
+        if (opts.method === 'PUT') {
+          remoteData = JSON.parse(opts.body);
+          return { ok: true, status: 200, headers: { get: () => 'etag' }, json: async () => null };
+        }
+        return { ok: true, status: 200, headers: { get: () => 'etag' }, json: async () => remoteData };
+      }
+      throw new Error('Unexpected fetch to ' + url);
+    });
+  });
+
+  test('two players cannot draw the same card', async () => {
+    await import('../shard-of-many-fates.js');
+    const firstDraw = await window.CCShard.draw(1);
+    const firstName = firstDraw[0].name;
+
+    jest.resetModules();
+    delete window.CCShard;
+    await import('../shard-of-many-fates.js');
+    const secondDraw = await window.CCShard.draw(1);
+    const secondName = secondDraw[0].name;
+
+    expect(secondName).not.toBe(firstName);
+  });
+});
+

--- a/__tests__/shard_notifications.test.js
+++ b/__tests__/shard_notifications.test.js
@@ -1,0 +1,46 @@
+import { jest } from '@jest/globals';
+
+// Utility to wait for async tasks to complete
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('Shard draws notify DM', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="ccShard-player">
+        <input id="ccShard-player-count" value="1" />
+        <button id="ccShard-player-draw"></button>
+        <ol id="ccShard-player-results"></ol>
+      </div>
+      <div id="toast"></div>
+    `;
+    // enable shards
+    localStorage.setItem('ccShardEnabled', '1');
+    // stub shard draw
+    window.CCShard = {
+      draw: () => [{ name: 'Test Shard' }]
+    };
+    // auto-confirm prompts
+    window.confirm = jest.fn(() => true);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    delete window.CCShard;
+  });
+
+  test('DM receives notification on shard draw', async () => {
+    const notifyHandler = jest.fn();
+    window.addEventListener('dm:notify', notifyHandler);
+
+    // import module after DOM setup
+    await import('../scripts/shard-player.js');
+
+    // click draw button
+    document.getElementById('ccShard-player-draw').click();
+    await flushPromises();
+
+    expect(localStorage.getItem('dmNotifications')).toBeNull();
+    expect(notifyHandler).toHaveBeenCalled();
+    expect(notifyHandler.mock.calls[0][0].detail).toMatch('Player drew shard');
+  });
+});

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -18,7 +18,7 @@ const shardToggleLabel = document.getElementById('dm-shard-label');
 const resolveTabBtns = document.querySelectorAll('#modal-shard-resolve .cc-tabs__nav button');
 
 const SHARD_KEY = 'ccShardEnabled';
-const NOTIFY_KEY = 'dmNotifications';
+const dmNotes = [];
 const DRAW_COUNT_KEY = 'ccShardPlayerDraws';
 const DRAW_LOCK_KEY = 'ccShardPlayerLocked';
 const CLOUD_SHARD_URL = 'https://ccccg-7d6b6-default-rtdb.firebaseio.com/shardEnabled.json';
@@ -171,9 +171,7 @@ window.addEventListener('dm:notify', () => {
 });
 
 function logDMAction(text){
-  const arr = JSON.parse(localStorage.getItem(NOTIFY_KEY) || '[]');
-  arr.push({ time: Date.now(), text });
-  localStorage.setItem(NOTIFY_KEY, JSON.stringify(arr));
+  dmNotes.push({ time: Date.now(), text });
   window.dispatchEvent(new CustomEvent('dm:notify', { detail: text }));
 }
 function escapeHtml(s){
@@ -219,7 +217,7 @@ function openDmTools(){
     openLogin();
     return;
   }
-  const notes = JSON.parse(localStorage.getItem(NOTIFY_KEY) || '[]');
+  const notes = dmNotes;
   showDmToast(`
     <div class="dm-toast-buttons dm-tools-menu">
       <button id="ccShard-open" class="btn-sm">The Shards of Many Fates</button>
@@ -237,7 +235,7 @@ function openDmTools(){
 }
 
 function openNotifications(){
-  const notes = JSON.parse(localStorage.getItem(NOTIFY_KEY) || '[]');
+  const notes = dmNotes;
   showDmToast(`
     <h3>Notifications</h3>
     <ol class="cc-list">${notes.map(n=>`<li><span class="muted">${new Date(n.time).toLocaleString()}</span> ${escapeHtml(n.text)}</li>`).reverse().join('')}</ol>
@@ -247,7 +245,7 @@ function openNotifications(){
     </div>
   `);
   document.getElementById('dm-clear-notes').addEventListener('click', ()=>{
-    localStorage.removeItem(NOTIFY_KEY);
+    dmNotes.length = 0;
     openNotifications();
   });
   document.getElementById('dm-back-btn').addEventListener('click', openDmTools);

--- a/scripts/shard-player.js
+++ b/scripts/shard-player.js
@@ -41,13 +41,7 @@ window.addEventListener('storage', e=>{
 });
 
 function logDM(text){
-  if(typeof window.logDMAction === 'function'){
-    window.logDMAction(text);
-  } else {
-    const arr = JSON.parse(localStorage.getItem('dmNotifications') || '[]');
-    arr.push({ time: Date.now(), text });
-    localStorage.setItem('dmNotifications', JSON.stringify(arr));
-  }
+  window.dispatchEvent(new CustomEvent('dm:notify', { detail: text }));
 }
 
 async function drawShards(){

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -57,13 +57,7 @@
   const CLOUD_STATE_URL = 'https://ccccg-7d6b6-default-rtdb.firebaseio.com/shardDeck.json';
   const CLOUD_LOCK_URL = 'https://ccccg-7d6b6-default-rtdb.firebaseio.com/shardDeckLock.json';
   function logDM(text){
-    if (typeof window.logDMAction === 'function') {
-      window.logDMAction(text);
-    } else {
-      const arr = JSON.parse(localStorage.getItem('dmNotifications') || '[]');
-      arr.push({ time: Date.now(), text });
-      localStorage.setItem('dmNotifications', JSON.stringify(arr));
-    }
+    window.dispatchEvent(new CustomEvent('dm:notify', { detail: text }));
   }
 
   function toast(msg){


### PR DESCRIPTION
## Summary
- Emit `dm:notify` events as the sole DM notification mechanism
- Store DM notes in-memory and remove localStorage usage
- Add tests ensuring event notifications and cloud-synced draws prevent duplicate cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beb2948d54832e921c1e134c4bdaa0