### PR TITLE
Ensure shard draw opens modal with animation

### DIFF
--- a/__tests__/shard_notifications.test.js
+++ b/__tests__/shard_notifications.test.js
@@ -17,7 +17,8 @@ describe('Shard draws notify DM', () => {
     localStorage.setItem('ccShardEnabled', '1');
     // stub shard draw
     window.CCShard = {
-      draw: () => [{ name: 'Test Shard' }]
+      draw: () => [{ name: 'Test Shard' }],
+      open: jest.fn()
     };
     // auto-confirm prompts
     window.confirm = jest.fn(() => true);
@@ -42,5 +43,6 @@ describe('Shard draws notify DM', () => {
     expect(localStorage.getItem('dmNotifications')).toBeNull();
     expect(notifyHandler).toHaveBeenCalled();
     expect(notifyHandler.mock.calls[0][0].detail).toMatch('Player drew shard');
+    expect(window.CCShard.open).toHaveBeenCalled();
   });
 });

--- a/scripts/shard-player.js
+++ b/scripts/shard-player.js
@@ -81,6 +81,10 @@ async function drawShards(){
     shardResults.appendChild(li);
   });
 
+  if(window.CCShard && typeof window.CCShard.open === 'function'){
+    window.CCShard.open();
+  }
+
   logDM(`Player drew shard${names.length>1?'s':''}: ${names.join(', ')}`);
   const draws = parseInt(localStorage.getItem(DRAW_COUNT_KEY) || '0',10) + 1;
   localStorage.setItem(DRAW_COUNT_KEY, draws.toString());


### PR DESCRIPTION
## Summary
- open the Shards of Many Fates modal after a player draws shards so the lightning flash plays
- test that shard draws notify the DM and open the modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beb8b85c4c832e999e222d00181d6e