### PR TITLE
Enhance DM tools with logout and TSoMF improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -812,6 +812,7 @@
 <button id="dm-login" class="dm-login-btn" aria-label="DM Tools" hidden></button>
 <div id="dm-tools-menu" class="dm-tools-menu" hidden>
   <button id="dm-tools-tsomf" class="btn-sm">TSoMF</button>
+  <button id="dm-tools-logout" class="btn-sm">Logout</button>
 </div>
 <div class="overlay hidden" id="modal-somf-dm" aria-hidden="true">
   <section id="somf-dm" class="modal somf-dm">
@@ -819,9 +820,8 @@
       <h3>DM • Shards</h3>
       <div class="somf-dm__hdr-controls">
         <label class="somf-switch"><input id="somfDM-live" type="checkbox" checked><span>Live</span></label>
-        <label class="somf-switch"><input id="somfDM-sfx" type="checkbox" checked><span>Sound</span></label>
         <label class="somf-switch"><input id="somfDM-desktop" type="checkbox"><span>Desktop</span></label>
-        <label class="somf-switch"><input id="somfDM-playerCard" type="checkbox" checked><span>Player Card</span></label>
+        <label class="somf-switch"><input id="somfDM-playerCard" type="checkbox" checked><span>Reveal Shards</span><span id="somfDM-playerCard-state">On</span></label>
         <button id="somfDM-refresh" class="somf-btn">Refresh</button>
         <button id="somfDM-close" class="somf-btn somf-ghost">Close</button>
       </div>
@@ -845,6 +845,8 @@
         <aside class="somf-dm__left">
           <h4>Incoming Draws</h4>
           <ol id="somfDM-incoming" class="somf-dm__list"></ol>
+          <h4>Resolved</h4>
+          <ol id="somfDM-resolved" class="somf-dm__list"></ol>
         </aside>
         <main class="somf-dm__main">
           <div id="somfDM-noticeView" class="somf-dm__card"></div>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -4,6 +4,7 @@ const linkBtn = document.getElementById('dm-login-link');
 const dmBtn = document.getElementById('dm-login');
 const menu = document.getElementById('dm-tools-menu');
 const tsomfBtn = document.getElementById('dm-tools-tsomf');
+const logoutBtn = document.getElementById('dm-tools-logout');
 
 function updateButtons(){
   const loggedIn = sessionStorage.getItem('dmLoggedIn') === '1';
@@ -18,6 +19,11 @@ function login(){
     sessionStorage.setItem('dmLoggedIn','1');
     updateButtons();
   }
+}
+
+function logout(){
+  sessionStorage.removeItem('dmLoggedIn');
+  updateButtons();
 }
 
 function toggleMenu(){
@@ -36,6 +42,11 @@ document.addEventListener('click', e => {
 tsomfBtn?.addEventListener('click', () => {
   menu.hidden = true;
   window.openSomfDM?.();
+});
+
+logoutBtn?.addEventListener('click', () => {
+  menu.hidden = true;
+  logout();
 });
 
 updateButtons();


### PR DESCRIPTION
## Summary
- Add logout button to DM tools menu
- Streamline TSoMF DM modal and always play draw notifications
- Populate shard info, resolved list, and NPC templates; animate shard reveals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf2733380c832e81abaeb81dc5102a