### PR TITLE
Rework DM Shards modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -819,11 +819,15 @@
     <header class="somf-dm__hdr">
       <h3>DM • Shards</h3>
       <div class="somf-dm__hdr-controls">
-        <label class="somf-switch"><input id="somfDM-live" type="checkbox" checked><span>Live</span></label>
-        <label class="somf-switch"><input id="somfDM-desktop" type="checkbox"><span>Desktop</span></label>
-        <label class="somf-switch"><input id="somfDM-playerCard" type="checkbox" checked><span>Reveal Shards</span><span id="somfDM-playerCard-state">On</span></label>
-        <button id="somfDM-refresh" class="somf-btn">Refresh</button>
-        <button id="somfDM-close" class="somf-btn somf-ghost">Close</button>
+        <div class="somf-dm__toggles">
+          <label class="somf-switch"><input id="somfDM-live" type="checkbox" checked><span>Live</span></label>
+          <label class="somf-switch"><input id="somfDM-desktop" type="checkbox"><span>Desktop</span></label>
+          <label class="somf-switch"><input id="somfDM-playerCard" type="checkbox" checked><span>Reveal Shards</span><span id="somfDM-playerCard-state">On</span></label>
+        </div>
+        <div class="somf-dm__actions">
+          <button id="somfDM-reset" class="somf-btn">Reset</button>
+          <button id="somfDM-close" class="somf-btn somf-ghost">Close</button>
+        </div>
       </div>
     </header>
 

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -218,7 +218,7 @@
     npcsTab: $('#somfDM-tab-npcs'),
     live: $('#somfDM-live'),
     desktop: $('#somfDM-desktop'),
-    refresh: $('#somfDM-refresh'),
+    reset: $('#somfDM-reset'),
     campaign: $('#somfDM-campaign'),
     total: $('#somfDM-total'),
     remaining: $('#somfDM-remaining'),
@@ -568,7 +568,7 @@
     }
   }
 
-  D.refresh?.addEventListener('click', loadAndRender);
+  D.reset?.addEventListener('click', loadAndRender);
 
   let _inited=false;
   function initDMOnce(){

--- a/styles/main.css
+++ b/styles/main.css
@@ -753,8 +753,10 @@ select[required]:valid{
 
 /* DM Tool (Shards of Many Fates) */
 .somf-dm{background:var(--surface);color:var(--text);border:1px solid var(--line);border-radius:var(--radius);padding:12px;margin:0;width:100%;max-width:800px;max-height:calc(var(--vh,1vh)*100 - 32px);overflow:auto;-webkit-overflow-scrolling:touch}
-.somf-dm__hdr{display:flex;flex-direction:column;align-items:flex-start;gap:8px;margin-bottom:8px}
-.somf-dm__hdr-controls{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
+.somf-dm__hdr{display:flex;flex-direction:column;align-items:stretch;gap:8px;margin-bottom:8px}
+.somf-dm__hdr-controls{display:flex;flex-direction:column;gap:8px}
+.somf-dm__toggles{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
+.somf-dm__actions{display:flex;flex-wrap:wrap;gap:8px;justify-content:flex-end}
 .somf-switch{display:inline-flex;align-items:center;gap:6px}
 .somf-dm__tabs{display:flex;gap:6px;margin:8px 0}
 .somf-dm__tabs button{padding:6px 10px;border:1px solid #253247;background:#0d141c;color:#cfe7ff;border-radius:6px;cursor:pointer}


### PR DESCRIPTION
## Summary
- restructure DM Shards header to separate toggles from action buttons
- add responsive styles for new sections
- rename refresh control to reset and update logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf41b45290832ebc31958d6ed8a7eb