### PR TITLE
Rework DM Shards modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,8 +184,8 @@
           <button id="sp-full" class="btn-sm">Reset SP</button>
         </div>
         <button id="long-rest" class="btn-sm">Long Rest</button>
-        <div class="sp-box">
-          <label for="sp-check"><input type="checkbox" id="sp-check"/> Story Point <span id="sp-status">Available</span></label>
+        <div class="cap-box">
+          <label for="cap-check"><input type="checkbox" id="cap-check"/> Cinematic Action Point <span id="cap-status">Available</span></label>
         </div>
       </fieldset>
     </div>
@@ -819,11 +819,15 @@
     <header class="somf-dm__hdr">
       <h3>DM • Shards</h3>
       <div class="somf-dm__hdr-controls">
-        <label class="somf-switch"><input id="somfDM-live" type="checkbox" checked><span>Live</span></label>
-        <label class="somf-switch"><input id="somfDM-desktop" type="checkbox"><span>Desktop</span></label>
-        <label class="somf-switch"><input id="somfDM-playerCard" type="checkbox" checked><span>Reveal Shards</span><span id="somfDM-playerCard-state">On</span></label>
-        <button id="somfDM-refresh" class="somf-btn">Refresh</button>
-        <button id="somfDM-close" class="somf-btn somf-ghost">Close</button>
+        <div class="somf-dm__toggles">
+          <label class="somf-switch"><input id="somfDM-live" type="checkbox" checked><span>Live</span></label>
+          <label class="somf-switch"><input id="somfDM-desktop" type="checkbox"><span>Desktop</span></label>
+          <label class="somf-switch"><input id="somfDM-playerCard" type="checkbox" checked><span>Reveal Shards</span><span id="somfDM-playerCard-state">On</span></label>
+        </div>
+        <div class="somf-dm__actions">
+          <button id="somfDM-reset" class="somf-btn">Reset</button>
+          <button id="somfDM-close" class="somf-btn somf-ghost">Close</button>
+        </div>
       </div>
     </header>
 

--- a/ruleshelp.txt
+++ b/ruleshelp.txt
@@ -92,7 +92,7 @@ SP Cost Guide
 - 4 SP: Strong AoE, control.
 - 5 SP: Ultimate (10-turn cooldown).
 
-Story Point
+Cinematic Action Point
 - 1 per session. May:
   • Auto-succeed a roll.
   • Interrupt initiative.
@@ -160,7 +160,7 @@ A4: Your most iconic ability (2–3 SP), tied to your Origin/identity.
 Q5: Can I mix Power Styles?
 A5: Yes. Only the primary grants the perk.
 
-Q6: What are Story Points?
+Q6: What are Cinematic Action Points?
 A6: 1 per session. Auto-succeed, flashback, interrupt initiative, or rescue.
 
 Q7: What is TC?

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -633,8 +633,8 @@ const elXP = $('xp');
 const elXPBar = $('xp-bar');
 const elXPPill = $('xp-pill');
 const elTier = $('tier');
-const elSPCheck = $('sp-check');
-const elSPStatus = $('sp-status');
+const elCAPCheck = $('cap-check');
+const elCAPStatus = $('cap-status');
 const elDeathSaves = $('death-saves');
 
 let hpRolls = [];
@@ -643,18 +643,18 @@ if (elHPRoll) {
   if (initial) hpRolls = [initial];
 }
 
-if (elSPCheck && elSPStatus) {
-  elSPCheck.addEventListener('change', () => {
-    if (elSPCheck.checked) {
-      if (confirm('Use Story Point?')) {
-        elSPStatus.textContent = 'Used';
-        elSPCheck.disabled = true;
+if (elCAPCheck && elCAPStatus) {
+  elCAPCheck.addEventListener('change', () => {
+    if (elCAPCheck.checked) {
+      if (confirm('Use Cinematic Action Point?')) {
+        elCAPStatus.textContent = 'Used';
+        elCAPCheck.disabled = true;
       } else {
-        elSPCheck.checked = false;
+        elCAPCheck.checked = false;
       }
     } else {
       // Prevent clearing without long rest
-      elSPCheck.checked = true;
+      elCAPCheck.checked = true;
     }
   });
 }
@@ -914,8 +914,8 @@ $('long-rest').addEventListener('click', ()=>{
     cb.checked = false;
     cb.removeAttribute('checked');
   });
-  if (elSPCheck) elSPCheck.disabled = false;
-  if (elSPStatus) elSPStatus.textContent = 'Available';
+  if (elCAPCheck) elCAPCheck.disabled = false;
+  if (elCAPStatus) elCAPStatus.textContent = 'Available';
   activeStatuses.clear();
 });
 function renderHPRollList(){

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -218,7 +218,7 @@
     npcsTab: $('#somfDM-tab-npcs'),
     live: $('#somfDM-live'),
     desktop: $('#somfDM-desktop'),
-    refresh: $('#somfDM-refresh'),
+    reset: $('#somfDM-reset'),
     campaign: $('#somfDM-campaign'),
     total: $('#somfDM-total'),
     remaining: $('#somfDM-remaining'),
@@ -568,7 +568,7 @@
     }
   }
 
-  D.refresh?.addEventListener('click', loadAndRender);
+  D.reset?.addEventListener('click', loadAndRender);
 
   let _inited=false;
   function initDMOnce(){

--- a/styles/main.css
+++ b/styles/main.css
@@ -446,7 +446,7 @@ progress::-moz-progress-bar{
 
 .sp-field #sp-temp{flex:0 0 60px;max-width:60px;}
 .sp-field #long-rest{width:100%;margin-top:8px;}
-.sp-field .sp-box{margin-top:8px;}
+.sp-field .cap-box{margin-top:8px;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:8px;display:flex;flex-direction:column;gap:10px;transition:box-shadow .3s ease-in-out;background:color-mix(in srgb,var(--surface) 5%,transparent);background-color:color-mix(in srgb,var(--surface) 5%,transparent);-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);margin-left:auto;margin-right:auto;width:100%;max-width:var(--content-width);font-size:1.1rem}
 .card[draggable]{cursor:grab}
 .card:focus-within{box-shadow:0 0 0 2px var(--accent),var(--shadow)}
@@ -753,8 +753,10 @@ select[required]:valid{
 
 /* DM Tool (Shards of Many Fates) */
 .somf-dm{background:var(--surface);color:var(--text);border:1px solid var(--line);border-radius:var(--radius);padding:12px;margin:0;width:100%;max-width:800px;max-height:calc(var(--vh,1vh)*100 - 32px);overflow:auto;-webkit-overflow-scrolling:touch}
-.somf-dm__hdr{display:flex;flex-direction:column;align-items:flex-start;gap:8px;margin-bottom:8px}
-.somf-dm__hdr-controls{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
+.somf-dm__hdr{display:flex;flex-direction:column;align-items:stretch;gap:8px;margin-bottom:8px}
+.somf-dm__hdr-controls{display:flex;flex-direction:column;gap:8px}
+.somf-dm__toggles{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
+.somf-dm__actions{display:flex;flex-wrap:wrap;gap:8px;justify-content:flex-end}
 .somf-switch{display:inline-flex;align-items:center;gap:6px}
 .somf-dm__tabs{display:flex;gap:6px;margin:8px 0}
 .somf-dm__tabs button{padding:6px 10px;border:1px solid #253247;background:#0d141c;color:#cfe7ff;border-radius:6px;cursor:pointer}


### PR DESCRIPTION
## Summary
- restructure DM Shards header to separate toggles from action buttons
- add responsive styles for new sections
- rename refresh control to reset and update logic
- restore Cinematic Action Point terminology outside Shards of Many Fates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf41b45290832ebc31958d6ed8a7eb