### PR TITLE
Add bright flash and lightning strike animation when drawing cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -889,6 +889,8 @@
 <div id="coin-animation" aria-hidden="true" hidden></div>
 <div id="sp-animation" aria-hidden="true" hidden></div>
 <div id="load-animation" aria-hidden="true" hidden>📂</div>
+<div id="draw-lightning" aria-hidden="true" hidden></div>
+<div id="draw-flash" aria-hidden="true" hidden></div>
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script type="module" src="scripts/main.js"></script>
 <script type="module" src="scripts/dm.js"></script>

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -126,18 +126,33 @@
   function closePlayerModal(){ PUI.modal.hidden=true; }
 
   async function playShardAnimation(){
-    const anim=document.getElementById('load-animation');
-    if(!anim) return;
-    anim.hidden=false;
+    const flash=document.getElementById('draw-flash');
+    const lightning=document.getElementById('draw-lightning');
+    if(!flash) return;
+    flash.hidden=false;
+    if(lightning){
+      lightning.hidden=false;
+      lightning.innerHTML='';
+      for(let i=0;i<3;i++){
+        const b=document.createElement('div');
+        b.className='bolt';
+        b.style.left=`${10+Math.random()*80}%`;
+        b.style.top=`${Math.random()*60}%`;
+        b.style.transform=`rotate(${Math.random()*30-15}deg)`;
+        b.style.animationDelay=`${i*0.1}s`;
+        lightning.appendChild(b);
+      }
+    }
     await new Promise(res=>{
-      anim.classList.add('show');
+      flash.classList.add('show');
       const done=()=>{
-        anim.classList.remove('show');
-        anim.hidden=true;
-        anim.removeEventListener('animationend', done);
+        flash.classList.remove('show');
+        flash.hidden=true;
+        if(lightning){ lightning.hidden=true; lightning.innerHTML=''; }
+        flash.removeEventListener('animationend', done);
         res();
       };
-      anim.addEventListener('animationend', done);
+      flash.addEventListener('animationend', done);
     });
   }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -441,6 +441,46 @@ progress::-moz-progress-bar{
   30%{transform:translateY(0);opacity:1;}
   100%{transform:translateY(20px);opacity:0;}
 }
+#draw-lightning{
+  position:fixed;
+  inset:0;
+  pointer-events:none;
+  z-index:3500;
+}
+#draw-lightning .bolt{
+  position:absolute;
+  width:20px;
+  height:80px;
+  background:#fff;
+  clip-path:polygon(35% 0,65% 0,55% 35%,100% 35%,30% 100%,45% 60%,0 60%);
+  filter:drop-shadow(0 0 6px #fff);
+  opacity:0;
+  animation:boltStrike .6s ease-in-out forwards;
+}
+@keyframes boltStrike{
+  0%{opacity:0;transform:scale(.8);}
+  10%{opacity:1;transform:scale(1);}
+  100%{opacity:0;transform:scale(1);}
+}
+#draw-flash{
+  position:fixed;
+  inset:0;
+  background:#fff;
+  pointer-events:none;
+  opacity:0;
+  z-index:4000;
+}
+#draw-flash.show{
+  animation:drawFlash 1s ease-in-out forwards;
+}
+@keyframes drawFlash{
+  0%{opacity:0;}
+  25%{opacity:.8;}
+  50%{opacity:0;}
+  75%{opacity:.8;}
+  90%{opacity:1;}
+  100%{opacity:0;}
+}
 .sp-grid{display:grid;width:100%;grid-template-columns:repeat(3,1fr);gap:8px;}
 .sp-grid .btn-sm{width:100%;}
 


### PR DESCRIPTION
## Summary
- Layer animated lightning bolts over the draw flash
- Drop folder animation from shard draws per reviewer feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf4aa376b8832e8a83f902dbf3b7ae