### PR TITLE
Fix DM tabs to show content

### DIFF
--- a/index.html
+++ b/index.html
@@ -834,14 +834,14 @@
     </header>
 
     <nav class="somf-dm__tabs">
-      <button data-tab="cards" class="somf-dm-tabbtn somf-dm-active">Shards List</button>
+      <button data-tab="cards" class="somf-dm-tabbtn active">Shards List</button>
       <button data-tab="resolve" class="somf-dm-tabbtn">Resolve</button>
       <button data-tab="npcs" class="somf-dm-tabbtn">NPCs</button>
     </nav>
 
-    <section id="somfDM-tab-cards" class="somf-dm-tab somf-dm__tab somf-dm-show"></section>
+    <section id="somfDM-tab-cards" class="somf-dm-tab somf-dm__tab active"></section>
 
-    <section id="somfDM-tab-resolve" class="somf-dm-tab somf-dm__tab" hidden>
+    <section id="somfDM-tab-resolve" class="somf-dm-tab somf-dm__tab">
       <div class="somf-dm__row">
         <div class="somf-kv"><span class="somf-k">Campaign</span><span id="somfDM-campaign" class="somf-v">—</span></div>
         <div class="somf-kv"><span class="somf-k">Total Draws</span><span id="somfDM-total" class="somf-v">—</span></div>
@@ -866,7 +866,7 @@
       <ol id="somfDM-resolveOptions" class="somf-dm__list"></ol>
     </section>
 
-    <section id="somfDM-tab-npcs" class="somf-dm-tab somf-dm__tab" hidden>
+    <section id="somfDM-tab-npcs" class="somf-dm-tab somf-dm__tab">
       <ul id="somfDM-npcList" class="somf-dm__list"></ul>
     </section>
   </section>

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -428,13 +428,13 @@
   // Tabs
   D.tabs.forEach(b=>{
     b.addEventListener('click', ()=>{
-      D.tabs.forEach(x=>{ x.classList.remove('somf-dm-active'); x.style.background='#0d141c'; });
-      b.classList.add('somf-dm-active'); b.style.background='#0b2a3a';
+      D.tabs.forEach(x=> x.classList.remove('active'));
+      b.classList.add('active');
+      [D.cardTab,D.resTab,D.npcsTab].forEach(el=> el.classList.remove('active'));
       const t = b.dataset.tab;
-      [D.cardTab,D.resTab,D.npcsTab].forEach(el=> el.hidden=true);
-      if (t==='cards') D.cardTab.hidden=false;
-      if (t==='resolve') D.resTab.hidden=false;
-      if (t==='npcs') D.npcsTab.hidden=false;
+      if (t==='cards') D.cardTab.classList.add('active');
+      if (t==='resolve') D.resTab.classList.add('active');
+      if (t==='npcs') D.npcsTab.classList.add('active');
     });
   });
 


### PR DESCRIPTION
## Summary
- Ensure DM tools tabs always display their content by toggling `active` classes instead of the hidden attribute
- Mark default Shards List tab active so content is visible without a draw

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bffeae3014832eb5a58fcdedd39702