### PR TITLE
Improve TSoMF DM modal usability and login

### DIFF
--- a/index.html
+++ b/index.html
@@ -814,6 +814,13 @@
   <button id="dm-tools-tsomf" class="btn-sm">TSoMF</button>
   <button id="dm-tools-logout" class="btn-sm">Logout</button>
 </div>
+<div class="overlay hidden" id="dm-login-modal" aria-hidden="true">
+  <section class="modal">
+    <h3>DM Login</h3>
+    <input id="dm-login-pin" type="password" inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code">
+    <div class="actions"><button id="dm-login-submit" class="somf-btn">Enter</button></div>
+  </section>
+</div>
 <div class="overlay hidden" id="modal-somf-dm" aria-hidden="true">
   <section id="somf-dm" class="modal somf-dm">
     <button id="somfDM-close" class="x" aria-label="Close">
@@ -842,17 +849,10 @@
     <section id="somfDM-tab-cards" class="somf-dm-tab somf-dm__tab active"></section>
 
     <section id="somfDM-tab-resolve" class="somf-dm-tab somf-dm__tab">
-      <div class="somf-dm__row">
-        <div class="somf-kv"><span class="somf-k">Campaign</span><span id="somfDM-campaign" class="somf-v">—</span></div>
-        <div class="somf-kv"><span class="somf-k">Total Draws</span><span id="somfDM-total" class="somf-v">—</span></div>
-        <div class="somf-kv"><span class="somf-k">Remaining</span><span id="somfDM-remaining" class="somf-v">—</span></div>
-      </div>
       <div class="somf-dm__resolve">
         <aside class="somf-dm__left">
           <h4>Incoming Draws</h4>
           <ol id="somfDM-incoming" class="somf-dm__list"></ol>
-          <h4>Resolved</h4>
-          <ol id="somfDM-resolved" class="somf-dm__list"></ol>
         </aside>
         <main class="somf-dm__main">
           <div id="somfDM-noticeView" class="somf-dm__card"></div>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -5,6 +5,9 @@ const dmBtn = document.getElementById('dm-login');
 const menu = document.getElementById('dm-tools-menu');
 const tsomfBtn = document.getElementById('dm-tools-tsomf');
 const logoutBtn = document.getElementById('dm-tools-logout');
+const loginModal = document.getElementById('dm-login-modal');
+const loginPin = document.getElementById('dm-login-pin');
+const loginSubmit = document.getElementById('dm-login-submit');
 
 function updateButtons(){
   const loggedIn = sessionStorage.getItem('dmLoggedIn') === '1';
@@ -13,11 +16,28 @@ function updateButtons(){
   if(!loggedIn && menu) menu.hidden = true;
 }
 
-function login(){
-  const pin = prompt('DM PIN');
-  if(pin === DM_PIN){
+function openLogin(){
+  if(!loginModal || !loginPin) return;
+  loginModal.classList.remove('hidden');
+  loginModal.setAttribute('aria-hidden','false');
+  loginPin.value='';
+  loginPin.focus();
+}
+
+function closeLogin(){
+  if(!loginModal) return;
+  loginModal.classList.add('hidden');
+  loginModal.setAttribute('aria-hidden','true');
+}
+
+function attemptLogin(){
+  if(loginPin.value === DM_PIN){
     sessionStorage.setItem('dmLoggedIn','1');
     updateButtons();
+    closeLogin();
+  } else {
+    loginPin.value='';
+    loginPin.focus();
   }
 }
 
@@ -30,7 +50,7 @@ function toggleMenu(){
   if(menu) menu.hidden = !menu.hidden;
 }
 
-linkBtn?.addEventListener('click', login);
+linkBtn?.addEventListener('click', openLogin);
 dmBtn?.addEventListener('click', toggleMenu);
 
 document.addEventListener('click', e => {
@@ -48,5 +68,9 @@ logoutBtn?.addEventListener('click', () => {
   menu.hidden = true;
   logout();
 });
+
+loginSubmit?.addEventListener('click', attemptLogin);
+loginPin?.addEventListener('keydown', e=>{ if(e.key==='Enter') attemptLogin(); });
+loginModal?.addEventListener('click', e=>{ if(e.target===loginModal) closeLogin(); });
 
 updateButtons();

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -384,12 +384,8 @@
     resTab: $('#somfDM-tab-resolve'),
     npcsTab: $('#somfDM-tab-npcs'),
     reset: $('#somfDM-reset'),
-    campaign: $('#somfDM-campaign'),
-    total: $('#somfDM-total'),
-    remaining: $('#somfDM-remaining'),
     cardCount: $('#somfDM-cardCount'),
     incoming: $('#somfDM-incoming'),
-    resolvedList: $('#somfDM-resolved'),
     noticeView: $('#somfDM-noticeView'),
     markResolved: $('#somfDM-markResolved'),
     spawnNPC: $('#somfDM-spawnNPC'),
@@ -615,22 +611,15 @@
 
   // Counts + incoming
   async function refreshCounts(){
-    D.campaign.textContent = CID();
-    let deckLen=PLATES.length, total=0;
+    let deckLen = PLATES.length;
     if (db()){
       const deckSnap = await db().ref(path.deck(CID())).get();
       const deck = deckSnap.exists()? deckSnap.val(): [];
       deckLen = Array.isArray(deck)? deck.length : PLATES.length;
-      const auditsSnap = await db().ref(path.audits(CID())).get();
-      total = auditsSnap.exists()? Object.keys(auditsSnap.val()).length : 0;
     } else {
       const deck = getLocal(LSK.deck(CID()))||[];
       deckLen = Array.isArray(deck)? deck.length : PLATES.length;
-      const audits = getLocal(LSK.audits(CID()))||[];
-      total = audits.length;
     }
-    D.total.textContent = String(total);
-    D.remaining.textContent = String(deckLen);
     if(D.cardCount) D.cardCount.textContent = `${deckLen}/${PLATES.length}`;
   }
 
@@ -708,16 +697,6 @@
     await loadAndRender();
   }
 
-  function renderResolved(list){
-    D.resolvedList.innerHTML='';
-    const resolvedSet = new Set();
-    list.forEach(r=> (r.ids||[]).forEach(id=> resolvedSet.add(id)) );
-    PLATES.forEach(p=>{
-      const li=document.createElement('li');
-      li.innerHTML = `<strong>${p.name}</strong><div style="opacity:.8">${resolvedSet.has(p.id)?'Resolved':'Unresolved'}</div>`;
-      D.resolvedList.appendChild(li);
-    });
-  }
 
   async function pushResolutionBatch(n){
     if (db()){
@@ -734,8 +713,6 @@
     renderNPCList();
     const notices = await loadNotices();
     renderIncoming(notices);
-    const resolved = await loadResolutions();
-    renderResolved(resolved);
     renderResolveOptions();
     await refreshHiddenToggle();
   }

--- a/styles/main.css
+++ b/styles/main.css
@@ -830,6 +830,10 @@ select[required]:valid{
 .somf-rolls{display:flex;flex-wrap:wrap;gap:6px;margin-top:6px}
 .somf-tag{font-size:12px;padding:2px 6px;border:1px solid #1b2532;border-radius:4px;background:#0b1119}
 .somf-dm__toasts{position:fixed;right:12px;bottom:12px;display:flex;flex-direction:column;gap:8px;z-index:9999}
+#modal-somf-dm{padding:0}
+#modal-somf-dm .somf-dm{max-width:none;max-height:none;width:100%;height:100%;border-radius:0;display:flex;flex-direction:column;overflow:hidden}
+#modal-somf-dm .somf-dm__tab{flex:1;overflow:auto}
+#dm-login-modal input{width:100%;margin:8px 0;padding:8px;border:1px solid var(--line);border-radius:var(--radius);background:var(--surface);color:var(--text)}
 .somf-toast{background:#0b1119;color:#e6f1ff;border:1px solid #1b2532;border-radius:8px;padding:10px 12px;min-width:260px;box-shadow:0 8px 24px #0008}
 .somf-toast strong{display:block;margin-bottom:4px}
 


### PR DESCRIPTION
## Summary
- Allow TSoMF DM modal to occupy full screen and scroll
- Simplify Resolve tab by removing campaign and draw counters
- Secure DM login with masked numeric PIN

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0036ae310832eb134c436cb0ed351