### PR TITLE
feat: sync draws with cloud and clickable DM alerts

### DIFF
--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -34,6 +34,7 @@ function attemptLogin(){
   if(loginPin.value === DM_PIN){
     sessionStorage.setItem('dmLoggedIn','1');
     updateButtons();
+    window.initSomfDM?.();
     closeLogin();
   } else {
     loginPin.value='';
@@ -74,3 +75,6 @@ loginPin?.addEventListener('keydown', e=>{ if(e.key==='Enter') attemptLogin(); }
 loginModal?.addEventListener('click', e=>{ if(e.target===loginModal) closeLogin(); });
 
 updateButtons();
+if(sessionStorage.getItem('dmLoggedIn')==='1'){
+  window.initSomfDM?.();
+}


### PR DESCRIPTION
## Summary
- start DM sync on login and expose initializer
- allow DM notifications to open resolve tab and auto-select latest draw
- make draw alerts clickable and ensure incoming list highlights newest draw

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c009990340832ea6c36cfe8c119da2