### PR TITLE
feat: expand shard deck to 24 cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -844,6 +844,7 @@
       <button data-tab="cards" class="somf-dm-tabbtn active">Shards List</button>
       <button data-tab="resolve" class="somf-dm-tabbtn">Resolve</button>
       <button data-tab="npcs" class="somf-dm-tabbtn">NPCs</button>
+      <button data-tab="items" class="somf-dm-tabbtn">Items</button>
     </nav>
 
     <section id="somfDM-tab-cards" class="somf-dm-tab somf-dm__tab active"></section>
@@ -868,6 +869,10 @@
 
     <section id="somfDM-tab-npcs" class="somf-dm-tab somf-dm__tab">
       <ul id="somfDM-npcList" class="somf-dm__list"></ul>
+    </section>
+
+    <section id="somfDM-tab-items" class="somf-dm-tab somf-dm__tab">
+      <ul id="somfDM-itemList" class="somf-dm__list"></ul>
     </section>
   </section>
 </div>


### PR DESCRIPTION
## Summary
- add comprehensive SOMF deck definition with items, NPCs and 24 shards
- expose new deck via PLATES for runtime use
- refresh DM tool NPC roster and add Items tab for deck gear

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c03bdff9cc832ea9cc23576f213c6b