### PR TITLE
Guard DM login against sessionStorage failures

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -1,0 +1,32 @@
+import '../scripts/dm.js';
+
+describe('DM login link', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="dm-login-wrapper">
+        <button id="dm-login-link" type="button"></button>
+      </div>
+      <button id="dm-login" hidden></button>
+      <div id="dm-tools-menu" hidden></div>
+      <div class="overlay hidden" id="dm-login-modal" aria-hidden="true">
+        <input id="dm-login-pin" />
+        <button id="dm-login-submit"></button>
+      </div>`;
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: {
+        getItem(){ throw new Error('denied'); },
+        setItem(){ throw new Error('denied'); },
+        removeItem(){ throw new Error('denied'); }
+      }
+    });
+  });
+
+  test('opens modal even if sessionStorage unavailable', () => {
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    const link = document.getElementById('dm-login-link');
+    link.click();
+    const modal = document.getElementById('dm-login-modal');
+    expect(modal.classList.contains('hidden')).toBe(false);
+  });
+});

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -10,8 +10,32 @@ document.addEventListener('DOMContentLoaded', () => {
   const loginPin = document.getElementById('dm-login-pin');
   const loginSubmit = document.getElementById('dm-login-submit');
 
+  function isLoggedIn(){
+    try {
+      return sessionStorage.getItem('dmLoggedIn') === '1';
+    } catch {
+      return false;
+    }
+  }
+
+  function setLoggedIn(){
+    try {
+      sessionStorage.setItem('dmLoggedIn','1');
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function clearLoggedIn(){
+    try {
+      sessionStorage.removeItem('dmLoggedIn');
+    } catch {
+      /* ignore */
+    }
+  }
+
   function updateButtons(){
-    const loggedIn = sessionStorage.getItem('dmLoggedIn') === '1';
+    const loggedIn = isLoggedIn();
     if(dmBtn) dmBtn.hidden = !loggedIn;
     if(linkBtn) linkBtn.hidden = loggedIn;
     if(!loggedIn && menu) menu.hidden = true;
@@ -33,7 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function attemptLogin(){
     if(loginPin.value === DM_PIN){
-      sessionStorage.setItem('dmLoggedIn','1');
+      setLoggedIn();
       updateButtons();
       window.initSomfDM?.();
       closeLogin();
@@ -44,7 +68,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function logout(){
-    sessionStorage.removeItem('dmLoggedIn');
+    clearLoggedIn();
     updateButtons();
   }
 
@@ -76,7 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
   loginModal?.addEventListener('click', e=>{ if(e.target===loginModal) closeLogin(); });
 
   updateButtons();
-  if(sessionStorage.getItem('dmLoggedIn')==='1'){
+  if(isLoggedIn()){
     window.initSomfDM?.();
   }
 });


### PR DESCRIPTION
## Summary
- Handle sessionStorage errors in DM login flow
- Add regression test ensuring DM login modal opens even when sessionStorage is unavailable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0511a4614832ea33dd1b485e3ae33