### PR TITLE
fix: guard sessionStorage access

### DIFF
--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -1416,7 +1416,11 @@ function renderCardList(){
   }
 
   initPlayerHidden();
-  if (sessionStorage.getItem('dmLoggedIn') === '1') initDM();
+  try {
+    if (sessionStorage.getItem('dmLoggedIn') === '1') initDM();
+  } catch {
+    /* ignore */
+  }
   window.initSomfDM = initDM;
 
 })();


### PR DESCRIPTION
## Summary
- avoid crashing when sessionStorage is unavailable so DM tools initialize correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0568b80c8832eb2ed549898d1f14c