### PR TITLE
Ensure draw and DM login buttons initialize correctly

### DIFF
--- a/__tests__/draw_button.test.js
+++ b/__tests__/draw_button.test.js
@@ -1,0 +1,16 @@
+import { jest } from '@jest/globals';
+import '../shard-of-many-fates.js';
+
+describe('player draw button', () => {
+  test('clicking draw triggers confirmation after DOM ready', () => {
+    document.body.innerHTML = `
+      <input id="somf-min-count" value="1">
+      <button id="somf-min-draw" type="button"></button>
+    `;
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    document.getElementById('somf-min-draw').click();
+    expect(confirmSpy).toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+});

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
       <div class="somf-row">
         <label for="somf-min-count" class="somf-label">Shards</label>
         <input id="somf-min-count" type="number" inputmode="numeric" pattern="[0-9]*" min="1" max="22" value="1" class="somf-input">
-        <button id="somf-min-draw" class="somf-btn somf-primary">Draw Shards</button>
+        <button id="somf-min-draw" type="button" class="somf-btn somf-primary">Draw Shards</button>
       </div>
     </section>
 
@@ -898,7 +898,7 @@
 <div id="draw-flash" aria-hidden="true" hidden></div>
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script type="module" src="scripts/main.js"></script>
-<script type="module" src="scripts/dm.js"></script>
+<script src="scripts/dm.js"></script>
 <script src="shard-of-many-fates.js"></script>
 
 </body>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -1,6 +1,6 @@
 const DM_PIN = '1231';
 
-document.addEventListener('DOMContentLoaded', () => {
+function initDMLogin(){
   const linkBtn = document.getElementById('dm-login-link');
   const dmBtn = document.getElementById('dm-login');
   const menu = document.getElementById('dm-tools-menu');
@@ -103,4 +103,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if(isLoggedIn()){
     window.initSomfDM?.();
   }
-});
+}
+
+initDMLogin();
+document.addEventListener('DOMContentLoaded', initDMLogin);

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -3,7 +3,9 @@
    - Optional Firebase RTDB for shared deck + notices
    - LocalStorage fallback for solo/offline testing
    ========================================================================= */
-(function(){
+window.SOMF_MIN = window.SOMF_MIN || {};
+
+function initSomf(){
   const $ = s=>document.querySelector(s);
   const $$ = s=>Array.from(document.querySelectorAll(s));
 
@@ -664,7 +666,7 @@
       { "id": "STAR", "name": "The Star", "polarity": "good", "effect": [ { "type": "ability_score_increase_perm", "choices": ["STR","DEX","CON","INT","WIS","CHA"], "value": 2, "cap": 20 }, { "type": "skill_bonus_perm", "target_skill_choice": true, "value": 2 } ], "resolution": "Apply permanent changes; obey ability cap." },
       { "id": "MOON", "name": "The Moon", "polarity": "good", "effect": [ { "type": "choose_one", "options": [ { "xp_delta": 3000 }, { "credits_delta": 15000 }, { "remove_one_negative_shard_curse": true } ] } ], "resolution": "Record chosen boon and apply." },
       { "id": "COMET", "name": "The Comet", "polarity": "good", "effect": [ { "type": "flag_next_combat_bounty", "condition": "drawer_deals_final_blow_to_highest_hp_enemy", "rewards": [ { "type": "xp_delta", "value": 1500 }, { "type": "grant_item", "item_id": "COMET_SPURS", "quantity": 1 } ] } ], "resolution": "Check condition at end of combat; grant rewards if met." },
-      { "id": "VIZIER", "name": "The Vizier", "polarity": "good", "effect": [ { "type": "declare_two_mechanical_weaknesses_on_next_boss": true }, { "type": "downtime_advantage", "task": "Research", "uses": 1 } ], "resolution": "GM states two concrete weaknesses; mark downtime advantage." },
+      { "id": "VIZIER", "name": "The Vizier", "polarity": "good", "effect": [ { "type": "declare_two_mechanical_weaknesses_on_next_boss" }, { "type": "downtime_advantage", "task": "Research", "uses": 1 } ], "resolution": "GM states two concrete weaknesses; mark downtime advantage." },
       { "id": "THRONE", "name": "The Throne", "polarity": "good", "effect": [ { "type": "grant_item", "item_id": "CMD_BEACON", "quantity": 1 } ], "resolution": "Add Beacon; must be activated at start of round 1 if used." },
       { "id": "ASCENDANT", "name": "The Ascendant", "polarity": "good", "effect": [ { "type": "ability_score_increase_perm", "choices": ["STR","DEX","CON","INT","WIS","CHA"], "value": 1, "count": 2, "cap": 20 }, { "type": "grant_free_boost_per_encounter", "count_encounters": 3, "value": "1d4" } ], "resolution": "Apply permanent +1 to two different abilities; track 3 free boosts." },
       { "id": "HALO", "name": "The Halo", "polarity": "good", "effect": [ { "type": "grant_item", "item_id": "ASCENDANT_HALO", "quantity": 1 } ], "resolution": "Add legendary utility and its uses." },
@@ -1423,5 +1425,10 @@ function renderCardList(){
   }
   window.initSomfDM = initDM;
 
-})();
+}
+
+document.addEventListener('DOMContentLoaded', initSomf);
+if(document.readyState !== 'loading'){
+  initSomf();
+}
 


### PR DESCRIPTION
## Summary
- Guard Shards of Many Fates runtime so UI hooks register after DOM is ready
- Ensure DM login script initializes both immediately and on DOMContentLoaded
- Mark draw button as type="button" and add regression test for draw click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c05f1676ec832eaae9bff52f4eb624