### PR TITLE
Fix shard draw modal and DM login feedback

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -21,4 +21,31 @@ describe('dm login', () => {
     document.getElementById('dm-login-link').click();
     expect(document.getElementById('dm-login-modal').classList.contains('hidden')).toBe(false);
   });
+
+  test('successful login unlocks tools and shows toast', async () => {
+    document.body.innerHTML = `
+      <button id="dm-login-link"></button>
+      <button id="dm-login" hidden></button>
+      <div id="dm-tools-menu" hidden></div>
+      <button id="dm-tools-tsomf"></button>
+      <button id="dm-tools-logout"></button>
+      <div id="dm-login-modal" class="hidden" aria-hidden="true">
+        <input id="dm-login-pin">
+        <button id="dm-login-submit"></button>
+      </div>
+    `;
+    window.toast = jest.fn();
+    await import('../scripts/dm.js');
+    document.getElementById('dm-login-link').click();
+    document.getElementById('dm-login-pin').value = '1231';
+    document.getElementById('dm-login-submit').click();
+    expect(window.toast).toHaveBeenCalledWith('DM tools unlocked','success');
+    const dmBtn = document.getElementById('dm-login');
+    const menu = document.getElementById('dm-tools-menu');
+    expect(dmBtn.hidden).toBe(false);
+    expect(menu.hidden).toBe(true);
+    dmBtn.click();
+    expect(menu.hidden).toBe(false);
+    delete window.toast;
+  });
 });

--- a/__tests__/draw_button.test.js
+++ b/__tests__/draw_button.test.js
@@ -25,4 +25,18 @@ describe('player draw button', () => {
     document.dispatchEvent(new Event('DOMContentLoaded'));
     expect(document.activeElement).not.toBe(count);
   });
+
+  test('clicking draw blurs the shard input', () => {
+    document.body.innerHTML = `
+      <input id="somf-min-count">
+      <button id="somf-min-draw" type="button"></button>
+    `;
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    const count = document.getElementById('somf-min-count');
+    count.focus();
+    document.getElementById('somf-min-draw').click();
+    expect(document.activeElement).not.toBe(count);
+    confirmSpy.mockRestore();
+  });
 });

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -61,15 +61,18 @@ function initDMLogin(){
       updateButtons();
       if (window.initSomfDM) window.initSomfDM();
       closeLogin();
+      if (typeof toast === 'function') toast('DM tools unlocked','success');
     } else {
       loginPin.value='';
       loginPin.focus();
+      if (typeof toast === 'function') toast('Invalid PIN','error');
     }
   }
 
   function logout(){
     clearLoggedIn();
     updateButtons();
+    if (typeof toast === 'function') toast('Logged out','info');
   }
 
   function toggleMenu(){

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -688,7 +688,7 @@ function initSomf(){
       { "id": "LEGEND_INQUISITOR_SILAS", "name": "Legendary Shard — Inquisitor Silas", "polarity": "legendary", "effect": [ { "type": "spawn_archenemy_permanent", "npc_id": "ENEMY_ARCHNEMESIS_SILAS", "tier": 3 }, { "type": "faction_rep_delta", "faction": "Conclave", "value": -1 } ], "resolution": "Silas marks the drawer for doctrinal judgment and recurs until defeated." }
     ]
   };
-  const PLATES = SOMF_DECK.shards;
+  const PLATES = OLD_PLATES;
   const plateById = Object.fromEntries(PLATES.map(p => [p.id, p]));
 
   /* ---------- Helpers ---------- */
@@ -873,7 +873,10 @@ function initSomf(){
     openPlayerModal(); renderCurrent();
   }
   if (PUI.drawBtn) {
-    PUI.drawBtn.addEventListener('click', ()=> doDraw());
+    PUI.drawBtn.addEventListener('click', ()=>{
+      if (PUI.count) PUI.count.blur();
+      doDraw();
+    });
   }
 
   const playerCard = $('#somf-min');


### PR DESCRIPTION
## Summary
- show toast messages for DM login, invalid pin, and logout
- restore shard draw modal details and blur shard count input
- test draw input blur and DM login button unlock behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0661439bc832e84b6259b4cc1f35b