### PR TITLE
Fix unresponsive DM login button

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -22,6 +22,24 @@ describe('dm login', () => {
     expect(document.getElementById('dm-login-modal').classList.contains('hidden')).toBe(false);
   });
 
+  test('pointer interaction opens modal', async () => {
+    document.body.innerHTML = `
+      <button id="dm-login-link"></button>
+      <button id="dm-login" hidden></button>
+      <div id="dm-tools-menu" hidden></div>
+      <button id="dm-tools-tsomf"></button>
+      <button id="dm-tools-logout"></button>
+      <div id="dm-login-modal" class="hidden" aria-hidden="true">
+        <input id="dm-login-pin">
+        <button id="dm-login-submit"></button>
+      </div>
+    `;
+    await import('../scripts/dm.js');
+    const evt = new Event('pointerdown', {bubbles: true});
+    document.getElementById('dm-login-link').dispatchEvent(evt);
+    expect(document.getElementById('dm-login-modal').classList.contains('hidden')).toBe(false);
+  });
+
   test('successful login unlocks tools and shows toast', async () => {
     document.body.innerHTML = `
       <button id="dm-login-link"></button>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -79,7 +79,15 @@ function initDMLogin(){
     if(menu) menu.hidden = !menu.hidden;
   }
 
-  if (linkBtn) linkBtn.addEventListener('click', openLogin);
+  if (linkBtn){
+    linkBtn.addEventListener('click', openLogin);
+    linkBtn.addEventListener('pointerdown', e => {
+      // some mobile browsers don't fire click on invisible elements
+      // so we open the login on pointer interaction as well
+      e.preventDefault();
+      openLogin();
+    });
+  }
   if (dmBtn) dmBtn.addEventListener('click', toggleMenu);
 
   document.addEventListener('click', e => {

--- a/styles/main.css
+++ b/styles/main.css
@@ -785,7 +785,7 @@ select[required]:valid{
 .dm-login-btn::before{content:'DM'}
 .dm-login-btn[hidden]{display:none}
 .dm-login-wrapper{position:relative;left:0;right:0;bottom:0;height:40px;text-align:center}
-#dm-login-link{position:absolute;left:50%;bottom:0;transform:translateX(-50%);width:120px;height:40px;opacity:0;border:none;background:none;cursor:pointer}
+#dm-login-link{position:absolute;left:50%;bottom:0;transform:translateX(-50%);width:120px;height:40px;opacity:0;border:none;background:none;cursor:pointer;z-index:1}
 .dm-tools-menu{position:fixed;bottom:80px;left:18px;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:2000}
 .dm-tools-menu[hidden]{display:none}
 .dm-tools-menu button{background:transparent;color:var(--text);border:none;padding:8px 12px;text-align:left;min-width:160px}


### PR DESCRIPTION
## Summary
- open the DM login modal on pointer events to support mobile tapping
- ensure hidden DM login link sits on top of other footer elements
- test DM login via pointer interactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c069d0d824832eac594fea52ddcf67