### PR TITLE
Rename legacy Shawn save to DM

### DIFF
--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -13,6 +13,18 @@ import {
 
 const PINNED = { 'DM': '1231' };
 
+// Migrate legacy save named "Shawn" to the new DM name.
+try {
+  const legacy = localStorage.getItem('save:Shawn');
+  if (legacy && !localStorage.getItem('save:DM')) {
+    localStorage.setItem('save:DM', legacy);
+    localStorage.removeItem('save:Shawn');
+    if (localStorage.getItem('last-save') === 'Shawn') {
+      localStorage.setItem('last-save', 'DM');
+    }
+  }
+} catch {}
+
 async function verifyPin(name) {
   const pin = PINNED[name];
   if (!pin) return;


### PR DESCRIPTION
## Summary
- migrate legacy local save named Shawn to DM so DM PIN and tools apply
- test rename migration to confirm DM character handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0919d89dc832ea6a93e34920e6dda