### PR TITLE
Handle legacy Player Shawn save migration

### DIFF
--- a/__tests__/characters.test.js
+++ b/__tests__/characters.test.js
@@ -68,26 +68,28 @@ describe('character storage', () => {
     expect(data).toEqual({ hp: 20 });
   });
 
-  test('renames legacy Shawn character to DM', async () => {
-    localStorage.setItem('save:Shawn', JSON.stringify({ hp: 5 }));
-    localStorage.setItem('last-save', 'Shawn');
-    fetch.mockResolvedValue({ ok: true, status: 200, json: async () => null });
-    window.dmRequireLogin = jest.fn().mockResolvedValue(true);
+  for (const legacyName of ['Shawn', 'Player :Shawn']) {
+    test(`renames legacy ${legacyName} character to DM`, async () => {
+      localStorage.setItem(`save:${legacyName}`, JSON.stringify({ hp: 5 }));
+      localStorage.setItem('last-save', legacyName);
+      fetch.mockResolvedValue({ ok: true, status: 200, json: async () => null });
+      window.dmRequireLogin = jest.fn().mockResolvedValue(true);
 
-    const { listCharacters, loadCharacter } = await import('../scripts/characters.js');
+      const { listCharacters, loadCharacter } = await import('../scripts/characters.js');
 
-    expect(localStorage.getItem('save:Shawn')).toBeNull();
-    expect(localStorage.getItem('save:DM')).toBe(JSON.stringify({ hp: 5 }));
-    expect(localStorage.getItem('last-save')).toBe('DM');
+      expect(localStorage.getItem(`save:${legacyName}`)).toBeNull();
+      expect(localStorage.getItem('save:DM')).toBe(JSON.stringify({ hp: 5 }));
+      expect(localStorage.getItem('last-save')).toBe('DM');
 
-    const chars = await listCharacters();
-    expect(chars).toContain('DM');
+      const chars = await listCharacters();
+      expect(chars).toContain('DM');
 
-    const data = await loadCharacter('DM');
-    expect(data).toEqual({ hp: 5 });
+      const data = await loadCharacter('DM');
+      expect(data).toEqual({ hp: 5 });
 
-    delete window.dmRequireLogin;
-  });
+      delete window.dmRequireLogin;
+    });
+  }
 });
 
 const keyPath = 'serviceAccountKey.json';

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -13,13 +13,21 @@ import {
 
 const PINNED = { 'DM': '1231' };
 
-// Migrate legacy save named "Shawn" to the new DM name.
+// Migrate legacy DM saves to the new "DM" name.
+// Older versions stored the DM character under names like "Shawn"
+// or "Player :Shawn". Ensure any of these variants are renamed.
 try {
-  const legacy = localStorage.getItem('save:Shawn');
-  if (legacy && !localStorage.getItem('save:DM')) {
-    localStorage.setItem('save:DM', legacy);
-    localStorage.removeItem('save:Shawn');
-    if (localStorage.getItem('last-save') === 'Shawn') {
+  const legacyNames = ['Shawn', 'Player :Shawn'];
+  for (const name of legacyNames) {
+    const legacy = localStorage.getItem(`save:${name}`);
+    if (!legacy) continue;
+    // Only create the DM save if it doesn't already exist to avoid
+    // overwriting newer data.
+    if (!localStorage.getItem('save:DM')) {
+      localStorage.setItem('save:DM', legacy);
+    }
+    localStorage.removeItem(`save:${name}`);
+    if (localStorage.getItem('last-save') === name) {
       localStorage.setItem('last-save', 'DM');
     }
   }


### PR DESCRIPTION
## Summary
- rename legacy DM saves named `Shawn` or `Player :Shawn` to `DM`
- add tests to ensure both old save names migrate correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09cb740b4832e8a44e3dba669d4d0