### PR TITLE
Rename Shawn character to DM with PIN migration

### DIFF
--- a/__tests__/characters.test.js
+++ b/__tests__/characters.test.js
@@ -68,15 +68,15 @@ describe('character storage', () => {
     expect(data).toEqual({ hp: 20 });
   });
 
-  test('renames legacy Shawn character to DM', async () => {
-    localStorage.setItem('save:Shawn', JSON.stringify({ hp: 5 }));
-    localStorage.setItem('last-save', 'Shawn');
+  test('renames legacy Player :Shawn character to DM', async () => {
+    localStorage.setItem('save:Player :Shawn', JSON.stringify({ hp: 5 }));
+    localStorage.setItem('last-save', 'Player :Shawn');
     fetch.mockResolvedValue({ ok: true, status: 200, json: async () => null });
     window.dmRequireLogin = jest.fn().mockResolvedValue(true);
 
     const { listCharacters, loadCharacter } = await import('../scripts/characters.js');
 
-    expect(localStorage.getItem('save:Shawn')).toBeNull();
+    expect(localStorage.getItem('save:Player :Shawn')).toBeNull();
     expect(localStorage.getItem('save:DM')).toBe(JSON.stringify({ hp: 5 }));
     expect(localStorage.getItem('last-save')).toBe('DM');
 

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -13,16 +13,21 @@ import {
 
 const PINNED = { 'DM': '1231' };
 
-// Migrate legacy save named "Shawn" to the new DM name.
+// Migrate legacy save named "Shawn" or "Player :Shawn" to the new DM name.
 try {
-  const legacy = localStorage.getItem('save:Shawn');
-  if (legacy && !localStorage.getItem('save:DM')) {
-    localStorage.setItem('save:DM', legacy);
-    localStorage.removeItem('save:Shawn');
-    if (localStorage.getItem('last-save') === 'Shawn') {
+  ['Shawn', 'Player :Shawn'].forEach(old => {
+    const key = `save:${old}`;
+    const legacy = localStorage.getItem(key);
+    if (legacy && !localStorage.getItem('save:DM')) {
+      localStorage.setItem('save:DM', legacy);
+    }
+    if (legacy) {
+      localStorage.removeItem(key);
+    }
+    if (localStorage.getItem('last-save') === old) {
       localStorage.setItem('last-save', 'DM');
     }
-  }
+  });
 } catch {}
 
 async function verifyPin(name) {


### PR DESCRIPTION
## Summary
- migrate legacy Player :Shawn saves to DM with PIN protection
- add test for Player :Shawn migration and DM login

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09c91bb74832ebe1155b03ce35206