### PR TITLE
Default Player Shards tool to off on load

### DIFF
--- a/__tests__/player_shards_default.test.js
+++ b/__tests__/player_shards_default.test.js
@@ -1,0 +1,14 @@
+import '../shard-of-many-fates.js';
+
+describe('player shards tool default state', () => {
+  test('player card is hidden by default on load', async () => {
+    document.body.innerHTML = `
+      <section id="somf-min"></section>
+      <div id="somf-min-modal"></div>
+    `;
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await Promise.resolve();
+    const card = document.getElementById('somf-min');
+    expect(card.hidden).toBe(true);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
 <main id="main">
   <!-- COMBAT -->
   <fieldset data-tab="combat" class="card">
-    <section id="somf-min" class="somf-card">
+    <section id="somf-min" class="somf-card" hidden>
       <h3 class="somf-title">The Shards of Many Fates</h3>
       <div class="somf-row">
         <label for="somf-min-count" class="somf-label">Shards</label>

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -897,7 +897,7 @@ function initSomf(){
     if(db()){
       const ref = db().ref(path.hidden(CID()));
       const snap = await ref.get();
-      const initial = snap.exists()? !!snap.val(): false;
+      const initial = snap.exists()? !!snap.val(): true;
       setLocal(LSK.hidden(CID()), initial);
       await applyHiddenState(initial);
       ref.on('value', s=>{
@@ -907,7 +907,9 @@ function initSomf(){
         applyHiddenState(h);
       });
     }else{
-      await applyHiddenState(!!getLocal(LSK.hidden(CID())));
+      const saved = getLocal(LSK.hidden(CID()));
+      const initial = saved === null ? true : !!saved;
+      await applyHiddenState(initial);
       window.addEventListener('somf-local-hidden', e=> applyHiddenState(!!e.detail));
       window.addEventListener('storage', e=>{ if(e.key===LSK.hidden(CID())) applyHiddenState(!!JSON.parse(e.newValue)); });
     }
@@ -1017,12 +1019,13 @@ function initSomf(){
   });
 
   async function refreshHiddenToggle(){
-    let hidden=false;
+    let hidden;
     if(db()){
       const snap = await db().ref(path.hidden(CID())).get();
-      hidden = snap.exists()? !!snap.val() : false;
+      hidden = snap.exists()? !!snap.val() : true;
     } else {
-      hidden = !!getLocal(LSK.hidden(CID()));
+      const saved = getLocal(LSK.hidden(CID()));
+      hidden = saved === null ? true : !!saved;
     }
     if(D.playerCardToggle) {
       D.playerCardToggle.checked = !hidden;


### PR DESCRIPTION
## Summary
- Hide the Player Shards UI on initial load and default hidden state to true
- Update hidden-state refresh to treat missing values as hidden
- Add tests verifying the Player Shards tool is off by default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09f66db74832ea710e2eba466b7c7