### PR TITLE
Handle missing DM login UI

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -50,4 +50,33 @@ describe('dm login', () => {
     expect(menu.hidden).toBe(false);
     delete window.toast;
   });
+
+  test('falls back to prompt when modal elements missing', async () => {
+    document.body.innerHTML = '';
+    window.toast = jest.fn();
+    window.prompt = jest.fn(() => '1231');
+
+    jest.unstable_mockModule('../scripts/storage.js', () => ({
+      saveLocal: jest.fn(),
+      loadLocal: jest.fn(async () => ({})),
+      listLocalSaves: jest.fn(() => []),
+      deleteSave: jest.fn(),
+      saveCloud: jest.fn(),
+      loadCloud: jest.fn(async () => ({})),
+      listCloudSaves: jest.fn(async () => []),
+      listCloudBackups: jest.fn(async () => []),
+      loadCloudBackup: jest.fn(async () => ({})),
+      deleteCloud: jest.fn(),
+    }));
+
+    await import('../scripts/dm.js');
+    const { loadCharacter } = await import('../scripts/characters.js');
+
+    await loadCharacter('DM');
+
+    expect(window.prompt).toHaveBeenCalled();
+    expect(window.toast).toHaveBeenCalledWith('DM tools unlocked','success');
+    delete window.toast;
+    delete window.prompt;
+  });
 });

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -60,6 +60,24 @@ function initDMLogin(){
         resolve(true);
         return;
       }
+
+      // If the modal elements are missing, fall back to a simple prompt so
+      // the promise always resolves and loading doesn't hang.
+      if (!loginModal || !loginPin || !loginSubmit) {
+        const entered = typeof prompt === 'function' ? prompt('Enter DM PIN') : null;
+        if (entered === DM_PIN) {
+          setLoggedIn();
+          updateButtons();
+          if (window.initSomfDM) window.initSomfDM();
+          if (typeof toast === 'function') toast('DM tools unlocked','success');
+          resolve(true);
+        } else {
+          if (typeof toast === 'function') toast('Invalid PIN','error');
+          reject(new Error('Invalid PIN'));
+        }
+        return;
+      }
+
       openLogin();
       function cleanup(){
         loginSubmit?.removeEventListener('click', onSubmit);


### PR DESCRIPTION
## Summary
- Avoid hanging when DM login elements are missing by falling back to a prompt
- Add regression test for DM login fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a75922b8832ebbf643f75a2afffd