### PR TITLE
feat: enable dm login and notifications

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -37,7 +37,7 @@ describe('dm login', () => {
 
     const promise = loadCharacter('DM');
     expect(document.getElementById('dm-login-modal').classList.contains('hidden')).toBe(false);
-    document.getElementById('dm-login-pin').value = '1231';
+    document.getElementById('dm-login-pin').value = '123123';
     document.getElementById('dm-login-submit').click();
     await promise;
 
@@ -54,7 +54,7 @@ describe('dm login', () => {
   test('falls back to prompt when modal elements missing', async () => {
     document.body.innerHTML = '';
     window.toast = jest.fn();
-    window.prompt = jest.fn(() => '1231');
+    window.prompt = jest.fn(() => '123123');
 
     jest.unstable_mockModule('../scripts/storage.js', () => ({
       saveLocal: jest.fn(),

--- a/index.html
+++ b/index.html
@@ -809,6 +809,7 @@
 <button id="dm-login" class="dm-login-btn" aria-label="DM Tools" hidden></button>
 <div id="dm-tools-menu" class="dm-tools-menu" hidden>
   <button id="dm-tools-tsomf" class="btn-sm">TSoMF</button>
+  <button id="dm-tools-notifications" class="btn-sm">Notifications</button>
   <button id="dm-tools-logout" class="btn-sm">Logout</button>
 </div>
 <div class="overlay hidden" id="dm-login-modal" aria-hidden="true">
@@ -816,6 +817,12 @@
     <h3>DM Login</h3>
     <input id="dm-login-pin" type="password" inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code">
     <div class="actions"><button id="dm-login-submit" class="somf-btn">Enter</button></div>
+  </section>
+</div>
+<div class="overlay hidden" id="dm-notifications-modal" aria-hidden="true">
+  <section class="modal">
+    <h3>Notifications</h3>
+    <ol id="dm-notifications-list"></ol>
   </section>
 </div>
 <div class="overlay hidden" id="modal-somf-dm" aria-hidden="true">

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -11,7 +11,7 @@ import {
   deleteCloud,
 } from './storage.js';
 
-const PINNED = { 'DM': '1231' };
+const PINNED = { 'DM': '123123' };
 
 // Migrate legacy DM saves to the new "DM" name.
 // Older versions stored the DM character under names like "Shawn"
@@ -79,13 +79,17 @@ export async function listCharacters() {
 
 export async function loadCharacter(name) {
   await verifyPin(name);
+  let data;
   try {
-    return await loadLocal(name);
+    data = await loadLocal(name);
   } catch {}
-  const data = await loadCloud(name);
-  try {
-    await saveLocal(name, data);
-  } catch {}
+  if (!data) {
+    data = await loadCloud(name);
+    try {
+      await saveLocal(name, data);
+    } catch {}
+  }
+  window.dmNotify?.(`Loaded character ${name}`);
   return data;
 }
 

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -1,13 +1,31 @@
-const DM_PIN = '1231';
+const DM_PIN = '123123';
+const notifications = [];
 
 function initDMLogin(){
   const dmBtn = document.getElementById('dm-login');
   const menu = document.getElementById('dm-tools-menu');
   const tsomfBtn = document.getElementById('dm-tools-tsomf');
+  const notifyBtn = document.getElementById('dm-tools-notifications');
   const logoutBtn = document.getElementById('dm-tools-logout');
   const loginModal = document.getElementById('dm-login-modal');
   const loginPin = document.getElementById('dm-login-pin');
   const loginSubmit = document.getElementById('dm-login-submit');
+  const notifyModal = document.getElementById('dm-notifications-modal');
+  const notifyList = document.getElementById('dm-notifications-list');
+
+  window.dmNotify = function(detail){
+    const entry = {
+      ts: new Date().toLocaleString(),
+      char: (()=>{ try { return localStorage.getItem('last-save') || ''; } catch { return ''; } })(),
+      detail
+    };
+    notifications.push(entry);
+    if(notifyList){
+      const li = document.createElement('li');
+      li.textContent = `[${entry.ts}] ${entry.char}: ${detail}`;
+      notifyList.prepend(li);
+    }
+  };
 
   function isLoggedIn(){
     try {
@@ -79,6 +97,7 @@ function initDMLogin(){
       }
 
       openLogin();
+      if (typeof toast === 'function') toast('Enter DM PIN','info');
       function cleanup(){
         loginSubmit?.removeEventListener('click', onSubmit);
         loginPin?.removeEventListener('keydown', onKey);
@@ -117,6 +136,18 @@ function initDMLogin(){
     if(menu) menu.hidden = !menu.hidden;
   }
 
+  function openNotifications(){
+    if(!notifyModal) return;
+    notifyModal.classList.remove('hidden');
+    notifyModal.setAttribute('aria-hidden','false');
+  }
+
+  function closeNotifications(){
+    if(!notifyModal) return;
+    notifyModal.classList.add('hidden');
+    notifyModal.setAttribute('aria-hidden','true');
+  }
+
   if (dmBtn) dmBtn.addEventListener('click', toggleMenu);
 
   document.addEventListener('click', e => {
@@ -132,6 +163,15 @@ function initDMLogin(){
     });
   }
 
+  if (notifyBtn) {
+    notifyBtn.addEventListener('click', () => {
+      if (menu) menu.hidden = true;
+      openNotifications();
+    });
+  }
+
+  notifyModal?.addEventListener('click', e => { if(e.target===notifyModal) closeNotifications(); });
+
   if (logoutBtn) {
     logoutBtn.addEventListener('click', () => {
       if (menu) menu.hidden = true;
@@ -143,6 +183,13 @@ function initDMLogin(){
   if (isLoggedIn() && window.initSomfDM){
     window.initSomfDM();
   }
+
+  document.addEventListener('click', e => {
+    const t = e.target.closest('button,a');
+    if(!t) return;
+    const id = t.id || t.textContent?.trim() || 'interaction';
+    window.dmNotify?.(`Clicked ${id}`);
+  });
 
   window.dmRequireLogin = requireLogin;
 }

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -850,16 +850,17 @@ function initSomf(){
     if (!confirm('This cannot be undone, do you really wish to tempt Fate?')) return;
 
     const ids = [];
+    let names = [];
     if (db()){
       await rtdbInitDeckIfMissing();
       for (let i=0;i<n;i++) ids.push(await rtdbDrawOne());
-      const names = ids.map(id=> plateById[id]?.name || id);
+      names = ids.map(id=> plateById[id]?.name || id);
       // batch notice (for DM): count + ids + names
       await db().ref(path.notices(CID())).push({ ts: db().ServerValue.TIMESTAMP, count:n, ids, names });
     } else {
       for (let i=0;i<n;i++) ids.push(localDrawOne());
+      names = ids.map(id=> plateById[id]?.name || id);
       const notices = getLocal(LSK.notices(CID()))||[];
-      const names = ids.map(id=> plateById[id]?.name || id);
       const now = Date.now();
       const notice = { key: now.toString(), ts: now, count:n, ids, names };
       notices.unshift(notice);
@@ -867,6 +868,7 @@ function initSomf(){
       window.dispatchEvent(new CustomEvent('somf-local-notice', { detail: notice }));
     }
 
+    window.dmNotify?.(`Drew ${n} Shard(s): ${names.join(', ')} (unresolved)`);
     queue = ids.map(id=> plateById[id]);
     qi = 0;
     await playShardAnimation();


### PR DESCRIPTION
## Summary
- require PIN 123123 when loading DM and show DM tools button
- add floating DM tools menu with notifications panel and logging
- log shard draws and character loads in notification feed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ff5d4000832eb94118d81fc02f91