### PR TITLE
feat: make The DM sole admin character

### DIFF
--- a/__tests__/characters.test.js
+++ b/__tests__/characters.test.js
@@ -68,8 +68,8 @@ describe('character storage', () => {
     expect(data).toEqual({ hp: 20 });
   });
 
-  for (const legacyName of ['Shawn', 'Player :Shawn']) {
-    test(`renames legacy ${legacyName} character to DM`, async () => {
+  for (const legacyName of ['Shawn', 'Player :Shawn', 'DM']) {
+    test(`renames legacy ${legacyName} character to The DM`, async () => {
       localStorage.setItem(`save:${legacyName}`, JSON.stringify({ hp: 5 }));
       localStorage.setItem('last-save', legacyName);
       fetch.mockResolvedValue({ ok: true, status: 200, json: async () => null });
@@ -78,18 +78,28 @@ describe('character storage', () => {
       const { listCharacters, loadCharacter } = await import('../scripts/characters.js');
 
       expect(localStorage.getItem(`save:${legacyName}`)).toBeNull();
-      expect(localStorage.getItem('save:DM')).toBe(JSON.stringify({ hp: 5 }));
-      expect(localStorage.getItem('last-save')).toBe('DM');
+      expect(localStorage.getItem('save:The DM')).toBe(JSON.stringify({ hp: 5 }));
+      expect(localStorage.getItem('last-save')).toBe('The DM');
 
       const chars = await listCharacters();
-      expect(chars).toContain('DM');
+      expect(chars).toContain('The DM');
 
-      const data = await loadCharacter('DM');
+      const data = await loadCharacter('The DM');
       expect(data).toEqual({ hp: 5 });
 
       delete window.dmRequireLogin;
     });
   }
+
+  test('cannot delete The DM', async () => {
+    fetch.mockResolvedValue({ ok: true, status: 200, json: async () => null });
+    window.dmRequireLogin = jest.fn().mockResolvedValue(true);
+    const { setCurrentCharacter, saveCharacter, deleteCharacter } = await import('../scripts/characters.js');
+    setCurrentCharacter('The DM');
+    await saveCharacter({ hp: 5 }, 'The DM');
+    await expect(deleteCharacter('The DM')).rejects.toThrow('Cannot delete The DM');
+    delete window.dmRequireLogin;
+  });
 });
 
 const keyPath = 'serviceAccountKey.json';

--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -6,17 +6,17 @@ beforeEach(() => {
 });
 
 describe('dm login', () => {
-  test('loading DM character unlocks tools', async () => {
+  test('loading The DM character unlocks tools', async () => {
     document.body.innerHTML = `
-      <button id="dm-login" hidden></button>
-      <div id="dm-tools-menu" hidden></div>
-      <button id="dm-tools-tsomf"></button>
-      <button id="dm-tools-logout"></button>
-      <div id="dm-login-modal" class="hidden" aria-hidden="true">
-        <input id="dm-login-pin">
-        <button id="dm-login-submit"></button>
-      </div>
-    `;
+        <button id="dm-login" hidden></button>
+        <div id="dm-tools-menu" hidden></div>
+        <button id="dm-tools-tsomf"></button>
+        <button id="dm-tools-logout"></button>
+        <div id="dm-login-modal" class="hidden" aria-hidden="true">
+          <input id="dm-login-pin">
+          <button id="dm-login-submit"></button>
+        </div>
+      `;
     window.toast = jest.fn();
 
     jest.unstable_mockModule('../scripts/storage.js', () => ({
@@ -35,7 +35,7 @@ describe('dm login', () => {
     await import('../scripts/dm.js');
     const { loadCharacter } = await import('../scripts/characters.js');
 
-    const promise = loadCharacter('DM');
+    const promise = loadCharacter('The DM');
     expect(document.getElementById('dm-login-modal').classList.contains('hidden')).toBe(false);
     document.getElementById('dm-login-pin').value = '123123';
     document.getElementById('dm-login-submit').click();
@@ -51,7 +51,7 @@ describe('dm login', () => {
     delete window.toast;
   });
 
-  test('falls back to prompt when modal elements missing', async () => {
+  test('falls back to prompt when modal elements missing for The DM', async () => {
     document.body.innerHTML = '';
     window.toast = jest.fn();
     window.prompt = jest.fn(() => '123123');
@@ -72,7 +72,7 @@ describe('dm login', () => {
     await import('../scripts/dm.js');
     const { loadCharacter } = await import('../scripts/characters.js');
 
-    await loadCharacter('DM');
+    await loadCharacter('The DM');
 
     expect(window.prompt).toHaveBeenCalled();
     expect(window.toast).toHaveBeenCalledWith('DM tools unlocked','success');

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1295,7 +1295,7 @@ async function renderCharacterList(){
   try { names = await listCharacters(); }
   catch (e) { console.error('Failed to list characters', e); }
   const current = currentCharacter();
-  list.innerHTML = names.map(c=>`<div class="catalog-item${c===current?' active':''}"><button class="btn-sm" data-char="${c}">${c}</button><button class="btn-sm" data-del="${c}"></button></div>`).join('');
+  list.innerHTML = names.map(c=>`<div class="catalog-item${c===current?' active':''}"><button class="btn-sm" data-char="${c}">${c}</button>${c==='The DM'?'':'<button class="btn-sm" data-del="'+c+'"></button>'}</div>`).join('');
   applyDeleteIcons(list);
   selectedChar = current;
 }
@@ -1337,12 +1337,18 @@ if(charList){
       const item = loadBtn.closest('.catalog-item');
       if(item) item.classList.add('active');
       pendingLoad = { name: selectedChar };
-      const text = $('load-confirm-text');
-      if(text) text.textContent = `Are you sure you would like to load this character: ${pendingLoad.name}. All current progress will be lost if you haven't saved yet.`;
-      show('modal-load');
+      if(selectedChar === 'The DM'){
+        doLoad();
+      }else{
+        const text = $('load-confirm-text');
+        if(text) text.textContent = `Are you sure you would like to load this character: ${pendingLoad.name}. All current progress will be lost if you haven't saved yet.`;
+        show('modal-load');
+      }
     } else if(delBtn){
       const ch = delBtn.dataset.del;
-      if(confirm(`Delete ${ch}?`) && confirm('This cannot be undone. Are you sure?')){
+      if(ch === 'The DM'){
+        toast('Cannot delete The DM','error');
+      }else if(confirm(`Delete ${ch}?`) && confirm('This cannot be undone. Are you sure?')){
         deleteCharacter(ch).then(()=>{
           renderCharacterList();
           toast('Deleted','info');


### PR DESCRIPTION
## Summary
- migrate all legacy DM save names to the single "The DM" admin account guarded by the existing PIN and disallow its deletion
- bypass load warnings and hide deletion controls when selecting "The DM" in the character list
- update DM login and character tests for the new admin-only flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c10f4c81a0832e8d83804b21e0a0ab