### PR TITLE
fix: expose toast globally for dm login

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -135,6 +135,10 @@ function toast(msg,type='info'){
   playTone(type);
   setTimeout(()=>t.classList.remove('show'),5000);
 }
+// Expose toast globally so non-module scripts (e.g. dm.js) can display messages.
+// Without this assignment the login flow for special accounts like "The DM"
+// will silently skip notifications because `toast` isn't found on `window`.
+window.toast = toast;
 
 function debounce(fn, delay){
   let t;


### PR DESCRIPTION
## Summary
- expose global `toast` function so classic scripts can show notifications
- ensures DM/admin login displays success/error toasts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c11adb74e0832ea59802bab637d076