### PR TITLE
Ensure DM PIN modal becomes visible

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -31,12 +31,14 @@ describe('dm login', () => {
       loadCloudBackup: jest.fn(async () => ({})),
       deleteCloud: jest.fn(),
     }));
-
+    await import('../scripts/modal.js');
     await import('../scripts/dm.js');
     const { loadCharacter } = await import('../scripts/characters.js');
 
     const promise = loadCharacter('The DM');
-    expect(document.getElementById('dm-login-modal').classList.contains('hidden')).toBe(false);
+    const modal = document.getElementById('dm-login-modal');
+    expect(modal.classList.contains('hidden')).toBe(false);
+    expect(modal.style.display).toBe('flex');
     document.getElementById('dm-login-pin').value = '123123';
     document.getElementById('dm-login-submit').click();
     await promise;

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -59,6 +59,7 @@ function initDMLogin(){
 
   function openLogin(){
     if(!loginModal || !loginPin) return;
+    loginModal.style.display = 'flex';
     loginModal.classList.remove('hidden');
     loginModal.setAttribute('aria-hidden','false');
     loginPin.value='';
@@ -69,6 +70,7 @@ function initDMLogin(){
     if(!loginModal) return;
     loginModal.classList.add('hidden');
     loginModal.setAttribute('aria-hidden','true');
+    loginModal.style.display = 'none';
   }
 
   function requireLogin(){


### PR DESCRIPTION
## Summary
- Ensure DM login modal sets display style when opening and closing so it appears after toast prompts
- Add regression test covering modal hidden by global modal helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c122e6be24832e8d6bd82af8ca6e16