### PR TITLE
Ensure DM PIN modal becomes visible

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -31,12 +31,18 @@ describe('dm login', () => {
       loadCloudBackup: jest.fn(async () => ({})),
       deleteCloud: jest.fn(),
     }));
-
+    await import('../scripts/modal.js');
     await import('../scripts/dm.js');
     const { loadCharacter } = await import('../scripts/characters.js');
 
     const promise = loadCharacter('The DM');
-    expect(document.getElementById('dm-login-modal').classList.contains('hidden')).toBe(false);
+    const modal = document.getElementById('dm-login-modal');
+    expect(modal.classList.contains('hidden')).toBe(false);
+    expect(modal.style.display).toBe('flex');
+    const pin = document.getElementById('dm-login-pin');
+    expect(document.activeElement).toBe(pin);
+    expect(pin.type).toBe('password');
+    expect(pin.getAttribute('inputmode')).toBe('numeric');
     document.getElementById('dm-login-pin').value = '123123';
     document.getElementById('dm-login-submit').click();
     await promise;

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -59,8 +59,13 @@ function initDMLogin(){
 
   function openLogin(){
     if(!loginModal || !loginPin) return;
+    loginModal.style.display = 'flex';
     loginModal.classList.remove('hidden');
     loginModal.setAttribute('aria-hidden','false');
+    loginPin.type = 'password';
+    loginPin.setAttribute('inputmode','numeric');
+    loginPin.setAttribute('pattern','[0-9]*');
+    loginPin.setAttribute('autocomplete','one-time-code');
     loginPin.value='';
     loginPin.focus();
   }
@@ -69,6 +74,7 @@ function initDMLogin(){
     if(!loginModal) return;
     loginModal.classList.add('hidden');
     loginModal.setAttribute('aria-hidden','true');
+    loginModal.style.display = 'none';
   }
 
   function requireLogin(){


### PR DESCRIPTION
## Summary
- Ensure DM login modal sets display style when opening and closing so it appears after toast prompts
- Focus DM PIN field with numeric password attributes so mobile number pad opens and PIN stays hidden
- Add regression test covering modal visibility and PIN field properties

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c122e6be24832e8d6bd82af8ca6e16