### PR TITLE
Enable DM TSoMF scrolling and add close icons to modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -578,6 +578,11 @@
 
 <div class="overlay hidden" id="modal-load" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
     <p id="load-confirm-text"></p>
     <div class="actions">
       <button id="load-cancel" class="btn-sm">Cancel</button>
@@ -783,9 +788,13 @@
 <div id="somf-min-modal" class="somf-modal" hidden>
   <div class="somf-modal__backdrop"></div>
   <div class="somf-modal__card">
+    <button id="somf-min-close" class="somf-modal__x" aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
     <header class="somf-modal__hdr">
       <strong>Shard</strong>
-      <button id="somf-min-close" class="somf-btn somf-ghost">Close</button>
     </header>
     <div class="somf-modal__body">
       <h4 id="somf-min-name" class="somf-subttl">—</h4>
@@ -814,6 +823,11 @@
 </div>
 <div class="overlay hidden" id="dm-login-modal" aria-hidden="true">
   <section class="modal">
+    <button id="dm-login-close" class="x" aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
     <h3>DM Login</h3>
     <input id="dm-login-pin" type="password" inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code">
     <div class="actions"><button id="dm-login-submit" class="somf-btn">Enter</button></div>
@@ -821,6 +835,11 @@
 </div>
 <div class="overlay hidden" id="dm-notifications-modal" aria-hidden="true">
   <section class="modal">
+    <button id="dm-notifications-close" class="x" aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
     <h3>Notifications</h3>
     <ol id="dm-notifications-list"></ol>
   </section>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -10,8 +10,10 @@ function initDMLogin(){
   const loginModal = document.getElementById('dm-login-modal');
   const loginPin = document.getElementById('dm-login-pin');
   const loginSubmit = document.getElementById('dm-login-submit');
+  const loginClose = document.getElementById('dm-login-close');
   const notifyModal = document.getElementById('dm-notifications-modal');
   const notifyList = document.getElementById('dm-notifications-list');
+  const notifyClose = document.getElementById('dm-notifications-close');
 
   if (loginPin) {
     loginPin.type = 'password';
@@ -110,7 +112,8 @@ function initDMLogin(){
       function cleanup(){
         loginSubmit?.removeEventListener('click', onSubmit);
         loginPin?.removeEventListener('keydown', onKey);
-        loginModal?.removeEventListener('click', onCancel);
+        loginModal?.removeEventListener('click', onOverlay);
+        loginClose?.removeEventListener('click', onCancel);
       }
       function onSubmit(){
         if(loginPin.value === DM_PIN){
@@ -128,10 +131,12 @@ function initDMLogin(){
         }
       }
       function onKey(e){ if(e.key==='Enter') onSubmit(); }
-      function onCancel(e){ if(e.target===loginModal){ closeLogin(); cleanup(); reject(new Error('cancel')); } }
+      function onCancel(){ closeLogin(); cleanup(); reject(new Error('cancel')); }
+      function onOverlay(e){ if(e.target===loginModal) onCancel(); }
       loginSubmit?.addEventListener('click', onSubmit);
       loginPin?.addEventListener('keydown', onKey);
-      loginModal?.addEventListener('click', onCancel);
+      loginModal?.addEventListener('click', onOverlay);
+      loginClose?.addEventListener('click', onCancel);
     });
   }
 
@@ -182,6 +187,7 @@ function initDMLogin(){
   }
 
   notifyModal?.addEventListener('click', e => { if(e.target===notifyModal) closeNotifications(); });
+  notifyClose?.addEventListener('click', closeNotifications);
 
   if (logoutBtn) {
     logoutBtn.addEventListener('click', () => {

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -947,14 +947,14 @@ function initSomf(){
   };
   let _selectLatest = false;
   let _selectKey = null;
-  function preventTouch(e){ e.preventDefault(); }
+  function preventTouch(e){ if(e.target===D.root) e.preventDefault(); }
   function openDM(opts={}){
     if(!D.root) return;
     D.root.style.display='flex';
     D.root.classList.remove('hidden');
     D.root.setAttribute('aria-hidden','false');
     document.body.classList.add('modal-open');
-    document.addEventListener('touchmove', preventTouch, { passive: false });
+    D.root.addEventListener('touchmove', preventTouch, { passive: false });
     if(opts.selectLatest) _selectLatest = true;
     if(opts.selectKey) _selectKey = opts.selectKey;
     initDM();
@@ -975,7 +975,7 @@ function initSomf(){
     D.root.setAttribute('aria-hidden','true');
     D.root.style.display='none';
     document.body.classList.remove('modal-open');
-    document.removeEventListener('touchmove', preventTouch);
+    D.root.removeEventListener('touchmove', preventTouch);
   }
   D.root?.addEventListener('click', e=>{ if(e.target===D.root) closeDM(); });
   D.root?.addEventListener('touchstart', e=>{ if(e.target===D.root) closeDM(); });

--- a/styles/main.css
+++ b/styles/main.css
@@ -762,6 +762,10 @@ select[required]:valid{
 .somf-modal__hdr, .somf-modal__ftr { display:flex; align-items:center; gap:8px; padding:10px 12px; border-bottom:1px solid var(--line) }
 .somf-modal__ftr { border-top:1px solid var(--line); border-bottom:none }
 .somf-modal__body { padding:12px; overflow:auto }
+.somf-modal__x{position:absolute;top:8px;right:8px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition)}
+.somf-modal__x:hover{color:var(--accent)}
+.somf-modal__x svg{width:20px;height:20px}
+.somf-modal__x:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .somf-badge { font-size:12px; letter-spacing:.08em; text-transform:uppercase; color:var(--muted); opacity:.9 }
 .somf-subttl { margin:10px 0 6px 0; font-size:13px; color:var(--muted) }
 .somf-list { margin:0; padding-left:18px }
@@ -832,7 +836,7 @@ select[required]:valid{
 .somf-dm__queue li{background:#0b1119;color:#e6f1ff;border:1px solid #1b2532;border-radius:8px;padding:6px 10px;cursor:pointer;min-width:200px}
 #modal-somf-dm{padding:0}
 #modal-somf-dm .somf-dm{max-width:800px;max-height:calc(var(--vh,1vh)*100 - 32px);width:100%;height:100%;border-radius:var(--radius);display:flex;flex-direction:column;overflow:hidden}
-#modal-somf-dm .somf-dm__tab{flex:1;overflow:auto}
+#modal-somf-dm .somf-dm__tab{flex:1;overflow:auto;-webkit-overflow-scrolling:touch}
 
 #dm-notifications-modal .modal{display:flex;flex-direction:column}
 #dm-notifications-modal #dm-notifications-list{flex:1;overflow:auto}


### PR DESCRIPTION
## Summary
- Fix Shards of Many Fates DM modal to allow scrolling by restricting touchmove handler to the overlay.
- Add close "X" buttons to DM login, DM notifications, load confirmation, and player shard modals.
- Style new shard modal close button and ensure DM tabs support smooth scrolling.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c13a701cfc832e82f3f5336c652187