### PR TITLE
Persist proficiency selections for skills and saves

### DIFF
--- a/__tests__/proficiency_persist.test.js
+++ b/__tests__/proficiency_persist.test.js
@@ -1,0 +1,59 @@
+import { jest } from '@jest/globals';
+
+describe('proficiency persistence', () => {
+  test('skills and saves remain proficient after save/load', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
+    global.confirm = jest.fn().mockReturnValue(true);
+    global.CC = {};
+
+    document.body.innerHTML = '<div id="saves"></div><div id="skills"></div><button id="btn-save"></button>';
+    const realGet = document.getElementById.bind(document);
+    document.getElementById = (id) => realGet(id) || {
+      innerHTML: '',
+      value: '',
+      style: { setProperty: () => {}, getPropertyValue: () => '' },
+      classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+      setAttribute: () => {},
+      getAttribute: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      appendChild: () => {},
+      contains: () => false,
+      add: () => {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      focus: () => {},
+      click: () => {},
+      textContent: '',
+      disabled: false,
+      checked: false,
+      hidden: false
+    };
+
+    const { setCurrentCharacter, loadCharacter } = await import('../scripts/characters.js');
+    setCurrentCharacter('Hero');
+    await import('../scripts/main.js');
+
+    document.getElementById('save-str-prof').checked = true;
+    document.getElementById('skill-0-prof').checked = true;
+
+    document.getElementById('btn-save').click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const data = await loadCharacter('Hero');
+    expect(data.saveProfs).toContain('str');
+    expect(data.skillProfs).toContain(0);
+
+    document.getElementById('save-str-prof').checked = false;
+    document.getElementById('skill-0-prof').checked = false;
+    data.saveProfs.forEach(a => {
+      document.getElementById(`save-${a}-prof`).checked = true;
+    });
+    data.skillProfs.forEach(i => {
+      document.getElementById(`skill-${i}-prof`).checked = true;
+    });
+    expect(document.getElementById('save-str-prof').checked).toBe(true);
+    expect(document.getElementById('skill-0-prof').checked).toBe(true);
+  });
+});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1849,6 +1849,15 @@ function serialize(){
     qty: Number(getVal("[data-f='qty']", card) || 1),
     notes: getVal("[data-f='notes']", card) || ''
   }));
+  // Persist save and skill proficiencies explicitly so they restore reliably
+  data.saveProfs = ABILS.filter(a => {
+    const el = $('save-' + a + '-prof');
+    return el && el.checked;
+  });
+  data.skillProfs = SKILLS.map((_, i) => {
+    const el = $('skill-' + i + '-prof');
+    return el && el.checked ? i : null;
+  }).filter(i => i !== null);
   data.campaignLog = campaignLog;
   if (window.CC && CC.partials && Object.keys(CC.partials).length) {
     try { data.partials = JSON.parse(JSON.stringify(CC.partials)); } catch { data.partials = {}; }
@@ -1868,11 +1877,23 @@ const DEFAULT_STATE = serialize();
    }
  });
  Object.entries(data||{}).forEach(([k,v])=>{
-   if(perkSelects.includes(k)) return;
+   if(perkSelects.includes(k) || k==='saveProfs' || k==='skillProfs') return;
    const el=$(k);
    if (!el) return;
    if (el.type==='checkbox') el.checked=!!v; else el.value=v;
  });
+ if(data && Array.isArray(data.saveProfs)){
+   ABILS.forEach(a=>{
+     const el = $('save-'+a+'-prof');
+     if(el) el.checked = data.saveProfs.includes(a);
+   });
+ }
+ if(data && Array.isArray(data.skillProfs)){
+   SKILLS.forEach((_,i)=>{
+     const el = $('skill-'+i+'-prof');
+     if(el) el.checked = data.skillProfs.includes(i);
+   });
+ }
   (data && data.powers ? data.powers : []).forEach(p=> $('powers').appendChild(createCard('power', p)));
   (data && data.signatures ? data.signatures : []).forEach(s=> $('sigs').appendChild(createCard('sig', s)));
   (data && data.weapons ? data.weapons : []).forEach(w=> $('weapons').appendChild(createCard('weapon', w)));


### PR DESCRIPTION
## Summary
- store selected skill and saving throw proficiencies and restore them on load
- add regression test for saving/loading proficiency flags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c151aa02d0832eaa2004d38c1a09a7