### PR TITLE
fix(dm): share pin constant

### DIFF
--- a/__tests__/characters.test.js
+++ b/__tests__/characters.test.js
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import fs from 'fs';
+import { DM_PIN } from '../scripts/dm-pin.js';
 
 describe('character storage', () => {
   beforeEach(() => {
@@ -99,6 +100,15 @@ describe('character storage', () => {
     await saveCharacter({ hp: 5 }, 'The DM');
     await expect(deleteCharacter('The DM')).rejects.toThrow('Cannot delete The DM');
     delete window.dmRequireLogin;
+  });
+
+  test('allows The DM to save after PIN prompt', async () => {
+    window.prompt = jest.fn(() => DM_PIN);
+    const { setCurrentCharacter, saveCharacter } = await import('../scripts/characters.js');
+    setCurrentCharacter('The DM');
+    await saveCharacter({ hp: 7 });
+    expect(localStorage.getItem('save:The DM')).toBe(JSON.stringify({ hp: 7 }));
+    delete window.prompt;
   });
 });
 

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -11,7 +11,9 @@ import {
   deleteCloud,
 } from './storage.js';
 
-const PINNED = { 'The DM': '123123' };
+import { DM_PIN } from './dm-pin.js';
+
+const PINNED = { 'The DM': DM_PIN };
 
 // Migrate legacy DM saves to the new "The DM" name.
 // Older versions stored the DM character under names like "Shawn",

--- a/scripts/dm-pin.js
+++ b/scripts/dm-pin.js
@@ -1,0 +1,2 @@
+// Shared DM PIN used for authentication and character protection
+export const DM_PIN = '123123';

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -1,6 +1,5 @@
 import { listCharacters } from './characters.js';
-
-const DM_PIN = '123123';
+import { DM_PIN } from './dm-pin.js';
 const notifications = [];
 
 function initDMLogin(){


### PR DESCRIPTION
## Summary
- centralize DM PIN and use it in characters and DM login modules
- exercise DM save flow via PIN prompt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c178f60d48832eb732ea207c136e0b