### PR TITLE
Fix DM logout clearing character

### DIFF
--- a/__tests__/dm_character_tool.test.js
+++ b/__tests__/dm_character_tool.test.js
@@ -7,7 +7,9 @@ describe('DM character viewer tool', () => {
     }
 
     const listCharacters = jest.fn(async () => ['The DM']);
-    jest.unstable_mockModule('../scripts/characters.js', () => ({ listCharacters }));
+    const currentCharacter = jest.fn(() => null);
+    const setCurrentCharacter = jest.fn();
+    jest.unstable_mockModule('../scripts/characters.js', () => ({ listCharacters, currentCharacter, setCurrentCharacter }));
 
     sessionStorage.setItem('dmLoggedIn', '1');
 

--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 beforeEach(() => {
   jest.resetModules();
   sessionStorage.clear();
+  localStorage.clear();
 });
 
 describe('dm login', () => {
@@ -80,5 +81,26 @@ describe('dm login', () => {
     expect(window.toast).toHaveBeenCalledWith('DM tools unlocked','success');
     delete window.toast;
     delete window.prompt;
+  });
+
+  test('logout clears DM session and last save', async () => {
+    document.body.innerHTML = `
+        <button id="dm-login" hidden></button>
+        <div id="dm-tools-menu" hidden></div>
+        <button id="dm-tools-logout"></button>
+      `;
+    sessionStorage.setItem('dmLoggedIn', '1');
+    localStorage.setItem('last-save', 'The DM');
+
+    const { currentCharacter } = await import('../scripts/characters.js');
+    await import('../scripts/dm.js');
+
+    expect(currentCharacter()).toBe('The DM');
+
+    document.getElementById('dm-tools-logout').click();
+
+    expect(sessionStorage.getItem('dmLoggedIn')).toBeNull();
+    expect(currentCharacter()).toBeNull();
+    expect(localStorage.getItem('last-save')).toBeNull();
   });
 });

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -63,7 +63,13 @@ export function currentCharacter() {
 
 export function setCurrentCharacter(name) {
   currentName = name;
-  try { localStorage.setItem('last-save', name); } catch {}
+  try {
+    if (name === null) {
+      localStorage.removeItem('last-save');
+    } else {
+      localStorage.setItem('last-save', name);
+    }
+  } catch {}
 }
 
 export async function listCharacters() {

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -1,4 +1,4 @@
-import { listCharacters } from './characters.js';
+import { listCharacters, currentCharacter, setCurrentCharacter } from './characters.js';
 import { DM_PIN } from './dm-pin.js';
 const notifications = [];
 
@@ -147,6 +147,9 @@ function initDMLogin(){
 
   function logout(){
     clearLoggedIn();
+    if (currentCharacter() === 'The DM') {
+      setCurrentCharacter(null);
+    }
     updateButtons();
     if (typeof toast === 'function') toast('Logged out','info');
   }


### PR DESCRIPTION
## Summary
- reset last-save when DM logs out so new characters don't overwrite DM save
- clear DM character selection on logout
- add coverage for logout behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1d4d7724c832ea0832fa788c057c3