### PR TITLE
Record character name in campaign log entries

### DIFF
--- a/__tests__/campaign_log_character_name.test.js
+++ b/__tests__/campaign_log_character_name.test.js
@@ -1,0 +1,77 @@
+import { jest } from '@jest/globals';
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="abil-grid"></div>
+    <div id="saves"></div>
+    <div id="skills"></div>
+    <div id="powers"></div>
+    <div id="sigs"></div>
+    <div id="weapons"></div>
+    <div id="armors"></div>
+    <div id="items"></div>
+    <div id="campaign-log"></div>
+    <textarea id="campaign-entry"></textarea>
+    <button id="campaign-add"></button>
+    <div id="toast"></div>
+    <div id="save-animation"></div>
+    <button id="btn-save"></button>
+    <input id="superhero" />
+    <input id="secret" />
+  `;
+  const realGet = document.getElementById.bind(document);
+  document.getElementById = (id) =>
+    realGet(id) || {
+      innerHTML: '',
+      value: '',
+      style: { setProperty: () => {}, getPropertyValue: () => '' },
+      classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+      setAttribute: () => {},
+      getAttribute: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      appendChild: () => {},
+      contains: () => false,
+      add: () => {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      focus: () => {},
+      click: () => {},
+      textContent: '',
+      disabled: false,
+      checked: false,
+      hidden: false,
+    };
+}
+
+describe('campaign log includes character name', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    localStorage.clear();
+    setupDom();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => null,
+    });
+    window.confirm = jest.fn(() => true);
+    localStorage.setItem('last-save', 'Alice');
+    await import('../scripts/main.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+    delete window.confirm;
+  });
+
+  test('records current character name', () => {
+    const entry = document.getElementById('campaign-entry');
+    entry.value = 'Test note';
+    document.getElementById('campaign-add').click();
+    const stored = JSON.parse(localStorage.getItem('campaign-log'));
+    expect(stored[0].name).toBe('Alice');
+  });
+});
+

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1259,7 +1259,8 @@ if (btnCampaignAdd) {
   btnCampaignAdd.addEventListener('click', ()=>{
     const text = $('campaign-entry').value.trim();
     if(!text) return;
-    pushLog(campaignLog, {t:Date.now(), text}, 'campaign-log');
+    const name = currentCharacter();
+    pushLog(campaignLog, {t:Date.now(), name, text}, 'campaign-log');
     $('campaign-entry').value='';
     renderCampaignLog();
     pushHistory();
@@ -1269,7 +1270,7 @@ if (btnCampaignAdd) {
     $('campaign-log').innerHTML = campaignLog
       .slice()
       .reverse()
-      .map((e,i)=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div>${e.text}</div><div><button class="btn-sm" data-del="${i}"></button></div></div>`)
+      .map((e,i)=>`<div class="catalog-item"><div>${fmt(e.t)}${e.name ? ' ' + e.name : ''}</div><div>${e.text}</div><div><button class="btn-sm" data-del="${i}"></button></div></div>`)
       .join('');
     applyDeleteIcons($('campaign-log'));
   }


### PR DESCRIPTION
## Summary
- include active character name in stored campaign log entries
- show character name next to timestamp when rendering campaign logs
- test that campaign logs persist character name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d5fefa94832eb437a0061a90f3e6