### PR TITLE
Avoid DM PIN prompt on save

### DIFF
--- a/__tests__/characters.test.js
+++ b/__tests__/characters.test.js
@@ -1,6 +1,5 @@
 import { jest } from '@jest/globals';
 import fs from 'fs';
-import { DM_PIN } from '../scripts/dm-pin.js';
 
 describe('character storage', () => {
   beforeEach(() => {
@@ -102,11 +101,12 @@ describe('character storage', () => {
     delete window.dmRequireLogin;
   });
 
-  test('allows The DM to save after PIN prompt', async () => {
-    window.prompt = jest.fn(() => DM_PIN);
+  test('allows The DM to save without PIN prompt', async () => {
+    window.prompt = jest.fn();
     const { setCurrentCharacter, saveCharacter } = await import('../scripts/characters.js');
     setCurrentCharacter('The DM');
     await saveCharacter({ hp: 7 });
+    expect(window.prompt).not.toHaveBeenCalled();
     expect(localStorage.getItem('save:The DM')).toBe(JSON.stringify({ hp: 7 }));
     delete window.prompt;
   });

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -103,7 +103,6 @@ export async function loadCharacter(name) {
 
 export async function saveCharacter(data, name = currentCharacter()) {
   if (!name) throw new Error('No character selected');
-  await verifyPin(name);
   await saveLocal(name, data);
   try {
     await saveCloud(name, data);


### PR DESCRIPTION
## Summary
- Let characters save without requiring DM PIN
- Update tests to confirm saving The DM doesn't prompt for PIN

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1dcb1f848832e9bd0dddb43a4bddc