### PR TITLE
Require DM login only for DM saves

### DIFF
--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -11,9 +11,8 @@ import {
   deleteCloud,
 } from './storage.js';
 
-import { DM_PIN } from './dm-pin.js';
-
-const PINNED = { 'The DM': DM_PIN };
+// DM saves are protected by a login flow rather than a manual PIN entry.
+// Only "The DM" character triggers this flow.
 
 // Migrate legacy DM saves to the new "The DM" name.
 // Older versions stored the DM character under names like "Shawn",
@@ -36,17 +35,9 @@ try {
 } catch {}
 
 async function verifyPin(name) {
-  const pin = PINNED[name];
-  if (!pin) return;
-  if (name === 'The DM' && typeof window.dmRequireLogin === 'function') {
+  if (name !== 'The DM') return;
+  if (typeof window.dmRequireLogin === 'function') {
     await window.dmRequireLogin();
-    return;
-  }
-  const entered = typeof prompt === 'function'
-    ? prompt(`Enter PIN for ${name}`)
-    : null;
-  if (entered !== pin) {
-    throw new Error('Invalid PIN');
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove manual DM PIN handling and rely on login flow
- Trigger DM login only when saving "The DM" character
- Test that non-DM saves skip DM login

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1dcb1f848832e9bd0dddb43a4bddc