### PR TITLE
Fix DM character tool opens character modal

### DIFF
--- a/__tests__/dm_character_tool.test.js
+++ b/__tests__/dm_character_tool.test.js
@@ -1,5 +1,9 @@
 import { jest } from '@jest/globals';
 
+beforeEach(() => {
+  jest.resetModules();
+});
+
 describe('DM character viewer tool', () => {
   test('shows character modal from DM tools menu', async () => {
     if (!window.matchMedia) {
@@ -42,5 +46,54 @@ describe('DM character viewer tool', () => {
     expect(listCharacters).toHaveBeenCalled();
     const modal = document.getElementById('dm-characters-modal');
     expect(modal.classList.contains('hidden')).toBe(false);
+  });
+
+  test('clicking a character opens the character modal', async () => {
+    if (!window.matchMedia) {
+      window.matchMedia = () => ({ matches: false, addListener: () => {}, removeListener: () => {} });
+    }
+
+    const listCharacters = jest.fn(async () => ['Test']);
+    const currentCharacter = jest.fn(() => null);
+    const setCurrentCharacter = jest.fn();
+    jest.unstable_mockModule('../scripts/characters.js', () => ({ listCharacters, currentCharacter, setCurrentCharacter }));
+
+    sessionStorage.setItem('dmLoggedIn', '1');
+
+    document.body.innerHTML = `
+      <div id="dm-tools-menu"></div>
+      <button id="dm-tools-tsomf"></button>
+      <button id="dm-tools-notifications"></button>
+      <button id="dm-tools-characters"></button>
+      <button id="dm-tools-logout"></button>
+      <div id="dm-login"></div>
+      <div id="dm-login-modal"></div>
+      <input id="dm-login-pin" />
+      <button id="dm-login-submit"></button>
+      <button id="dm-login-close"></button>
+      <div id="dm-notifications-modal"></div>
+      <div id="dm-notifications-list"></div>
+      <button id="dm-notifications-close"></button>
+      <div id="dm-characters-modal" class="overlay hidden" aria-hidden="true">
+        <section class="modal dm-characters">
+          <button id="dm-characters-close"></button>
+          <ul id="dm-characters-list"></ul>
+        </section>
+      </div>
+      <div id="modal-load" class="overlay hidden" aria-hidden="true"></div>
+      <div id="modal-load-list" class="overlay hidden" aria-hidden="true"></div>
+      <div id="load-confirm-text"></div>
+    `;
+
+    window.openCharacterModal = jest.fn();
+
+    await import('../scripts/dm.js');
+
+    document.getElementById('dm-tools-characters').click();
+    await new Promise(r => setTimeout(r, 0));
+    const btn = document.querySelector('#dm-characters-list button');
+    btn.click();
+
+    expect(window.openCharacterModal).toHaveBeenCalledWith('Test');
   });
 });

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -180,7 +180,9 @@ function initDMLogin(){
     let names = [];
     try { names = await listCharacters(); }
     catch(e){ console.error('Failed to list characters', e); }
-    charList.innerHTML = names.map(n => `<li>${n}</li>`).join('');
+    charList.innerHTML = names
+      .map(n => `<li><button type="button">${n}</button></li>`)
+      .join('');
   }
 
   function closeCharacters(){
@@ -189,6 +191,14 @@ function initDMLogin(){
     charModal.setAttribute('aria-hidden','true');
     charModal.style.display = 'none';
   }
+
+  charList?.addEventListener('click', e => {
+    const btn = e.target.closest('button');
+    if (!btn) return;
+    const name = btn.textContent?.trim();
+    closeCharacters();
+    window.openCharacterModal?.(name);
+  });
 
   if (dmBtn) dmBtn.addEventListener('click', toggleMenu);
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1481,6 +1481,21 @@ if(loadAcceptBtn){ loadAcceptBtn.addEventListener('click', doLoad); }
 if(loadCancelBtn){ loadCancelBtn.addEventListener('click', ()=>{ hide('modal-load'); }); }
 qsa('[data-close]').forEach(b=> b.addEventListener('click', ()=>{ const ov=b.closest('.overlay'); if(ov) hide(ov.id); }));
 
+function openCharacterModalByName(name){
+  if(!name) return;
+  selectedChar = name;
+  pendingLoad = { name };
+  if(name === 'The DM'){
+    hide('modal-load-list');
+    doLoad();
+  }else{
+    const text = $('load-confirm-text');
+    if(text) text.textContent = `Are you sure you would like to load this character: ${name}. All current progress will be lost if you haven't saved yet.`;
+    show('modal-load');
+  }
+}
+window.openCharacterModal = openCharacterModalByName;
+
 /* ========= Card Helper ========= */
 const CARD_CONFIG = {
   power: {


### PR DESCRIPTION
## Summary
- make character names in DM Characters tool clickable and delegate to main character loader
- expose a global `openCharacterModal` helper used by DM tools
- test DM character selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1f43c5da0832e88d5d92dbc7bfd19