### PR TITLE
Ensure DM character cards show full info

### DIFF
--- a/__tests__/dm_character_tool.test.js
+++ b/__tests__/dm_character_tool.test.js
@@ -100,4 +100,77 @@ describe('DM character viewer tool', () => {
     expect(loadCharacter).toHaveBeenCalledWith('Test');
     expect(view.textContent).toContain('Test');
   });
+
+  test('character card displays all character data', async () => {
+    if (!window.matchMedia) {
+      window.matchMedia = () => ({ matches: false, addListener: () => {}, removeListener: () => {} });
+    }
+
+    const characterData = {
+      'hp-bar': '30/30',
+      tc: '12',
+      'sp-bar': '5/5',
+      str: 10,
+      dex: 12,
+      con: 14,
+      int: 8,
+      wis: 11,
+      cha: 13,
+      powers: [{ name: 'Fireball', sp: '2', range: '30', effect: 'boom', save: 'DEX' }],
+      signatures: [{ name: 'Signature', sp: '1', save: 'STR', special: 'Knockback', desc: 'Strong' }],
+      weapons: [{ name: 'Sword', damage: '1d8', range: 'melee' }],
+      armor: [{ name: 'Chainmail', slot: 'Body', bonus: 1, equipped: true }],
+      items: [{ name: 'Potion', qty: 2, notes: 'healing' }]
+    };
+
+    const listCharacters = jest.fn(async () => ['Hero']);
+    const currentCharacter = jest.fn(() => null);
+    const setCurrentCharacter = jest.fn();
+    const loadCharacter = jest.fn(async () => characterData);
+    jest.unstable_mockModule('../scripts/characters.js', () => ({ listCharacters, currentCharacter, setCurrentCharacter, loadCharacter }));
+
+    sessionStorage.setItem('dmLoggedIn', '1');
+
+    document.body.innerHTML = `
+      <div id="dm-tools-menu"></div>
+      <button id="dm-tools-tsomf"></button>
+      <button id="dm-tools-notifications"></button>
+      <button id="dm-tools-characters"></button>
+      <button id="dm-tools-logout"></button>
+      <div id="dm-login"></div>
+      <div id="dm-login-modal"></div>
+      <input id="dm-login-pin" />
+      <button id="dm-login-submit"></button>
+      <button id="dm-login-close"></button>
+      <div id="dm-notifications-modal"></div>
+      <div id="dm-notifications-list"></div>
+      <button id="dm-notifications-close"></button>
+      <div id="dm-characters-modal" class="overlay hidden" aria-hidden="true">
+        <section class="modal dm-characters">
+          <button id="dm-characters-close"></button>
+          <ul id="dm-characters-list"></ul>
+          <div id="dm-character-sheet"></div>
+        </section>
+      </div>
+      <div id="modal-load" class="overlay hidden" aria-hidden="true"></div>
+      <div id="modal-load-list" class="overlay hidden" aria-hidden="true"></div>
+      <div id="load-confirm-text"></div>
+    `;
+
+    await import('../scripts/dm.js');
+
+    document.getElementById('dm-tools-characters').click();
+    await new Promise(r => setTimeout(r, 0));
+    const btn = document.querySelector('#dm-characters-list button');
+    btn.click();
+    await new Promise(r => setTimeout(r, 0));
+    const view = document.getElementById('dm-character-sheet');
+    const text = view.textContent;
+    expect(text).toContain('Fireball');
+    expect(text).toContain('Signature');
+    expect(text).toContain('Sword');
+    expect(text).toContain('Chainmail');
+    expect(text).toContain('Potion x2');
+    expect(text).toContain('healing');
+  });
 });

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -213,12 +213,15 @@ function initDMLogin(){
       if(data.powers?.length){
         card.innerHTML+=`<div style="margin-top:6px"><span style=\"opacity:.8;font-size:12px\">Powers</span><ul style=\"margin:4px 0 0 18px;padding:0\">${data.powers.map(p=>`<li>${p.name}${p.sp?` (${p.sp} SP)`:''}${p.range?`, ${p.range}`:''}${p.effect?`, ${p.effect}`:''}${p.save?`, ${p.save}`:''}</li>`).join('')}</ul></div>`;
       }
+      if(data.signatures?.length){
+        card.innerHTML+=`<div style="margin-top:6px"><span style=\"opacity:.8;font-size:12px\">Signatures</span><ul style=\"margin:4px 0 0 18px;padding:0\">${data.signatures.map(s=>`<li>${s.name}${s.sp?` (${s.sp} SP)`:''}${s.save?`, ${s.save}`:''}${s.special?`, ${s.special}`:''}${s.desc?`, ${s.desc}`:''}</li>`).join('')}</ul></div>`;
+      }
       if(data.weapons?.length){
         card.innerHTML+=`<div style="margin-top:6px"><span style=\"opacity:.8;font-size:12px\">Weapons</span><div>${data.weapons.map(w=>`${w.name}${w.damage?` dmg ${w.damage}`:''}${w.range?` (${w.range})`:''}`).join('; ')}</div></div>`;
       }
       const gear=[];
-      (data.armors||[]).forEach(a=> gear.push(`${a.name}${a.slot?` (${a.slot})`:''}`));
-      (data.items||[]).forEach(i=> gear.push(`${i.name}${i.qty?` x${i.qty}`:''}`));
+      (data.armor||[]).forEach(a=> gear.push(`${a.name}${a.slot?` (${a.slot})`:''}${a.bonus?` +${a.bonus}`:''}${a.equipped?` [Equipped]`:''}`));
+      (data.items||[]).forEach(i=> gear.push(`${i.name}${i.qty?` x${i.qty}`:''}${i.notes?` (${i.notes})`:''}`));
       if(gear.length){
         card.innerHTML+=`<div style="margin-top:6px"><span style=\"opacity:.8;font-size:12px\">Gear</span><ul style=\"margin:4px 0 0 18px;padding:0\">${gear.map(g=>`<li>${g}</li>`).join('')}</ul></div>`;
       }


### PR DESCRIPTION
## Summary
- include signatures and all gear details in DM character cards
- add regression test to verify complete character data rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25a597088832e80378b10f78f4ef2