### PR TITLE
fix: remove deprecated responseMimeTypes field

### DIFF
--- a/scripts/wizard.js
+++ b/scripts/wizard.js
@@ -14,14 +14,11 @@ const firebaseConfig = {
 const firebaseApp = initializeApp(firebaseConfig);
 // Explicitly set the region used for Vertex AI requests
 const vertexAI = getVertexAI(firebaseApp, { location: "us-central1" });
+// `responseMimeTypes` is no longer supported by Vertex AI. The default
+// configuration already returns plain text and image parts when available,
+// so no generation config is provided here.
 const model = getGenerativeModel(vertexAI, {
   model: "gemini-1.5-flash",
-  generationConfig: {
-    // The Vertex AI API no longer accepts `responseMimeTypes`.
-    // Use the singular `responseMimeType` to request plain text
-    // responses while still allowing image parts when available.
-    responseMimeType: "text/plain",
-  },
 });
 
 async function sendPrompt() {


### PR DESCRIPTION
## Summary
- remove deprecated `responseMimeTypes` config when calling Vertex AI in Ask the Wizard
- rely on default settings to allow text and image responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c3640ebc832ea79c23bc760447c1