### PR TITLE
Improve DM character modal summaries

### DIFF
--- a/__tests__/dm_character_tool.test.js
+++ b/__tests__/dm_character_tool.test.js
@@ -93,8 +93,8 @@ describe('DM character viewer tool', () => {
 
     document.getElementById('dm-tools-characters').click();
     await new Promise(r => setTimeout(r, 0));
-    const btn = document.querySelector('#dm-characters-list button');
-    btn.click();
+    const link = document.querySelector('#dm-characters-list a');
+    link.click();
     await new Promise(r => setTimeout(r, 0));
     const view = document.getElementById('dm-character-sheet');
     expect(loadCharacter).toHaveBeenCalledWith('Test');
@@ -161,8 +161,8 @@ describe('DM character viewer tool', () => {
 
     document.getElementById('dm-tools-characters').click();
     await new Promise(r => setTimeout(r, 0));
-    const btn = document.querySelector('#dm-characters-list button');
-    btn.click();
+    const link = document.querySelector('#dm-characters-list a');
+    link.click();
     await new Promise(r => setTimeout(r, 0));
     const view = document.getElementById('dm-character-sheet');
     const text = view.textContent;
@@ -170,7 +170,9 @@ describe('DM character viewer tool', () => {
     expect(text).toContain('Signature');
     expect(text).toContain('Sword');
     expect(text).toContain('Chainmail');
-    expect(text).toContain('Potion x2');
+    expect(text).toContain('Potion');
+    expect(text).toContain('Qty');
+    expect(text).toContain('2');
     expect(text).toContain('healing');
   });
 });


### PR DESCRIPTION
## Summary
- Show DM character list entries as plain-text links
- Render character summaries with labeled fields for powers, gear, and more
- Update DM tools test to match new link-based list and detailed summaries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c4b4a548832e8b3901936390e453