### PR TITLE
Improve Vertex AI error message in wizard chat

### DIFF
--- a/__tests__/wizard_error.test.js
+++ b/__tests__/wizard_error.test.js
@@ -1,0 +1,17 @@
+import { formatVertexAIError } from "../scripts/wizard_helpers.js";
+
+describe("formatVertexAIError", () => {
+  test("handles vertexAI/api-not-enabled code", () => {
+    const err = { code: "vertexAI/api-not-enabled", message: "api not enabled" };
+    expect(formatVertexAIError(err)).toBe(
+      "There was an error talking to the tower. The Firebase Vertex AI API is not enabled. Enable it in the Firebase console's Vertex AI section."
+    );
+  });
+
+  test("handles generic errors", () => {
+    const err = { message: "unknown" };
+    expect(formatVertexAIError(err)).toBe(
+      "There was an error talking to the tower: unknown"
+    );
+  });
+});

--- a/scripts/wizard.js
+++ b/scripts/wizard.js
@@ -1,5 +1,6 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/11.0.0/firebase-app.js";
 import { getVertexAI, getGenerativeModel } from "https://www.gstatic.com/firebasejs/11.0.0/firebase-vertexai.js";
+import { formatVertexAIError } from "./wizard_helpers.js";
 
 // Firebase project configuration for Vertex AI access
 // NOTE: Do not expose the API key publicly in production.
@@ -43,7 +44,7 @@ async function sendPrompt() {
     }
   } catch (e) {
     console.error("Wizard error:", e);
-    appendMessage("Wizard", `There was an error talking to the tower: ${e.message}`);
+    appendMessage("Wizard", formatVertexAIError(e));
   }
 }
 

--- a/scripts/wizard_helpers.js
+++ b/scripts/wizard_helpers.js
@@ -1,0 +1,13 @@
+export function formatVertexAIError(e) {
+  const base = "There was an error talking to the tower";
+  if (e && e.code === "vertexAI/api-not-enabled") {
+    return (
+      base +
+      ". The Firebase Vertex AI API is not enabled. Enable it in the Firebase console's Vertex AI section."
+    );
+  }
+  if (e && e.message) {
+    return `${base}: ${e.message}`;
+  }
+  return base + ".";
+}


### PR DESCRIPTION
## Summary
- Gracefully handle Vertex AI API not enabled error in wizard chat
- Share error formatting helper and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c536270c832e86728aacb861f355