### PR TITLE
Refactor load modal character list

### DIFF
--- a/index.html
+++ b/index.html
@@ -540,13 +540,10 @@
       </svg>
     </button>
     <h3>All Characters</h3>
-    <div class="load-layout">
-      <div id="char-list" class="catalog"></div>
-      <div class="load-actions">
-        <button id="recover-save" class="btn-sm" type="button">Recover Save</button>
-        <button id="create-character" class="btn-sm" type="button">Create New</button>
-        <button id="save-current" class="btn-sm" type="button">Save</button>
-      </div>
+    <div id="char-list" class="catalog"></div>
+    <div class="actions">
+      <button id="recover-save" class="btn-sm" type="button">Recover Save</button>
+      <button id="create-character" class="btn-sm" type="button">Create New</button>
     </div>
   </div>
 </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1332,7 +1332,7 @@ async function renderCharacterList(){
   try { names = await listCharacters(); }
   catch (e) { console.error('Failed to list characters', e); }
   const current = currentCharacter();
-  list.innerHTML = names.map(c=>`<div class="catalog-item${c===current?' active':''}"><button class="btn-sm" data-char="${c}">${c}</button>${c==='The DM'?'':'<button class="btn-sm" data-del="'+c+'"></button>'}</div>`).join('');
+  list.innerHTML = names.map(c=>`<div class="catalog-item${c===current?' active':''}"><a href="#" data-char="${c}">${c}</a>${c==='The DM'?'':'<button class="btn-sm" data-del="'+c+'"></button>'}</div>`).join('');
   applyDeleteIcons(list);
   selectedChar = current;
 }
@@ -1370,9 +1370,10 @@ let selectedChar = null;
 const charList = $('char-list');
 if(charList){
   charList.addEventListener('click', e=>{
-    const loadBtn = e.target.closest('button[data-char]');
+    const loadBtn = e.target.closest('[data-char]');
     const delBtn = e.target.closest('button[data-del]');
     if(loadBtn){
+      e.preventDefault();
       selectedChar = loadBtn.dataset.char;
       qsa('#char-list .catalog-item').forEach(ci=> ci.classList.remove('active'));
       const item = loadBtn.closest('.catalog-item');
@@ -1436,13 +1437,6 @@ if(newCharBtn){
   });
 }
 
-const saveCurrentBtn = $('save-current');
-if(saveCurrentBtn){
-  saveCurrentBtn.addEventListener('click', async ()=>{
-    try{ await saveCharacter(serialize()); toast('Saved','success'); }
-    catch(e){ toast('Save failed','error'); }
-  });
-}
 
 
 const recoverListEl = $('recover-list');

--- a/styles/main.css
+++ b/styles/main.css
@@ -569,9 +569,7 @@ progress::-moz-progress-bar{
 .catalog-item.active{background:var(--accent);color:var(--text-on-accent)}
 .catalog-item.active .pill{border-color:var(--text-on-accent);color:var(--text-on-accent)}
 #char-list .catalog-item{grid-template-columns:1fr auto}
-.load-layout{display:flex;gap:16px;align-items:flex-start}
-.load-actions{display:flex;flex-direction:column;gap:10px;min-width:120px}
-.load-actions button{width:100%}
+#char-list .catalog-item a{color:inherit;text-decoration:none;display:block}
 .small{font-size:.9rem;color:var(--muted)}
 .overlay{position:fixed;top:0;left:0;right:0;height:calc(var(--vh,1vh)*100);display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.7);backdrop-filter:blur(2px);z-index:1000;padding:16px calc(20px + env(safe-area-inset-right)) calc(16px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left));opacity:1;pointer-events:auto;transition:opacity .3s ease-in-out;will-change:opacity}
 .overlay.hidden{opacity:0;pointer-events:none}


### PR DESCRIPTION
## Summary
- display saved characters as plain text links in full-width scrollable list
- move recover save and create new actions to modal footer and remove save button
- adjust scripts to handle link clicks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3ed881d68832ea19488900d678374