### PR TITLE
feat: add unified action log

### DIFF
--- a/__tests__/action_log.test.js
+++ b/__tests__/action_log.test.js
@@ -1,0 +1,113 @@
+import { jest } from '@jest/globals';
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="abil-grid"></div>
+    <div id="saves"></div>
+    <div id="skills"></div>
+    <div id="powers"></div>
+    <div id="sigs"></div>
+    <div id="weapons"></div>
+    <div id="armors"></div>
+    <div id="campaign-log"></div>
+    <textarea id="campaign-entry"></textarea>
+    <button id="campaign-add"></button>
+    <div id="log-action"></div>
+    <div id="full-log-action"></div>
+    <button id="btn-log"></button>
+    <button id="log-full"></button>
+    <button id="btn-campaign"></button>
+    <input id="cap-check" type="checkbox" />
+    <span id="cap-status">Available</span>
+    <input id="xp" value="0" />
+    <progress id="xp-bar"></progress>
+    <span id="xp-pill"></span>
+    <input id="tier" />
+    <span id="omni-rep-tier"></span>
+    <progress id="omni-rep-bar"></progress>
+    <p id="omni-rep-perk"></p>
+    <button id="omni-rep-gain"></button>
+    <button id="omni-rep-lose"></button>
+    <input type="hidden" id="omni-rep" value="200" />
+    <div id="toast"></div>
+    <div id="save-animation"></div>
+    <button id="btn-save"></button>
+    <input id="superhero" />
+    <input id="secret" />
+  `;
+  const realGet = document.getElementById.bind(document);
+  document.getElementById = (id) =>
+    realGet(id) || {
+      innerHTML: '',
+      value: '',
+      style: { setProperty: () => {}, getPropertyValue: () => '' },
+      classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+      setAttribute: () => {},
+      getAttribute: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      appendChild: () => {},
+      contains: () => false,
+      add: () => {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      focus: () => {},
+      click: () => {},
+      textContent: '',
+      disabled: false,
+      checked: false,
+      hidden: false,
+    };
+}
+
+describe('action log records key events', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    localStorage.clear();
+    setupDom();
+    window.matchMedia = jest.fn().mockReturnValue({ matches: true, addListener: () => {}, removeListener: () => {} });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => null,
+    });
+    window.confirm = jest.fn(() => true);
+    await import('../scripts/main.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+    delete window.confirm;
+  });
+
+  test('logs tier changes', () => {
+    const xp = document.getElementById('xp');
+    // initialize XP processing
+    xp.dispatchEvent(new Event('input'));
+    xp.value = '2000';
+    xp.dispatchEvent(new Event('input'));
+    const log = JSON.parse(localStorage.getItem('action-log'));
+    expect(log.some((e) => e.text.includes('Tier:'))).toBe(true);
+  });
+
+  test('logs faction reputation rank changes', () => {
+    const rep = document.getElementById('omni-rep');
+    rep.value = '295';
+    document.getElementById('omni-rep-gain').click();
+    const log = JSON.parse(localStorage.getItem('action-log'));
+    const last = log[log.length - 1];
+    expect(last.text).toBe('O.M.N.I. Reputation: Neutral -> Recognized');
+  });
+
+  test('logs Cinematic Action Point usage', () => {
+    const cap = document.getElementById('cap-check');
+    cap.checked = true;
+    cap.dispatchEvent(new Event('change'));
+    const log = JSON.parse(localStorage.getItem('action-log'));
+    const last = log[log.length - 1];
+    expect(last.text).toBe('Cinematic Action Point: Available -> Used');
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
       <div id="menu-actions" class="menu" hidden>
         <button id="btn-load" class="btn-sm">Load</button>
         <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
-        <button id="btn-log" class="btn-sm">Roll/Flip Log</button>
+        <button id="btn-log" class="btn-sm">Action Log</button>
         <button id="btn-campaign" class="btn-sm">Campaign Log</button>
         <button id="btn-rules" class="btn-sm">Rules</button>
         <button id="btn-help" class="btn-sm">Help</button>
@@ -689,11 +689,8 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
-    <h3>Recent Log</h3>
-    <div class="grid grid-2">
-      <div><h4 style="margin:0">Dice</h4><div id="log-dice" class="catalog"></div></div>
-      <div><h4 style="margin:0">Coins</h4><div id="log-coin" class="catalog"></div></div>
-    </div>
+    <h3>Action Log</h3>
+    <div id="log-action" class="catalog"></div>
     <div class="actions"><button id="log-full" class="btn-sm">Full Log</button><button class="btn-sm" data-close>Close</button></div>
   </div>
 </div>
@@ -724,11 +721,8 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
-    <h3>Full Log</h3>
-    <div class="grid grid-2">
-      <div><h4 style="margin:0">Dice</h4><div id="full-log-dice" class="catalog"></div></div>
-      <div><h4 style="margin:0">Coins</h4><div id="full-log-coin" class="catalog"></div></div>
-    </div>
+    <h3>Full Action Log</h3>
+    <div id="full-log-action" class="catalog"></div>
     <div class="actions"><button class="btn-sm" data-close>Close</button></div>
   </div>
 </div>

--- a/scripts/faction.js
+++ b/scripts/faction.js
@@ -100,9 +100,18 @@ export function setupFactionRepTracker(handlePerkEffects = () => {}, pushHistory
       const lose = $(`${f}-rep-lose`);
       if (!input || !gain || !lose) return;
       function change(delta) {
-        const next = Math.max(0, Math.min(maxVal, num(input.value) + delta));
+        const currentVal = num(input.value);
+        const oldTierIdx = Math.min(REP_TIERS.length - 1, Math.floor(currentVal / 100));
+        const oldTierName = REP_TIERS[oldTierIdx];
+        const next = Math.max(0, Math.min(maxVal, currentVal + delta));
         input.value = next;
         updateFactionRep(handlePerkEffects);
+        const newTierIdx = Math.min(REP_TIERS.length - 1, Math.floor(next / 100));
+        const newTierName = REP_TIERS[newTierIdx];
+        if (oldTierName !== newTierName) {
+          const facName = FACTION_NAME_MAP[f];
+          window.logAction?.(`${facName} Reputation: ${oldTierName} -> ${newTierName}`);
+        }
         if (typeof pushHistory === 'function') pushHistory();
       }
       gain.addEventListener('click', e => { e.preventDefault(); change(5); });


### PR DESCRIPTION
## Summary
- rename Roll/Flip Log to Action Log
- track dice rolls, coin flips, CAP usage, tier shifts, and faction reputation changes
- test new Action Log coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4236c1bf8832eb7fd2b6f42a8138b