### PR TITLE
Enable real-time cloud sync

### DIFF
--- a/__tests__/cloud_subscribe.test.js
+++ b/__tests__/cloud_subscribe.test.js
@@ -1,0 +1,25 @@
+import { jest } from '@jest/globals';
+import { subscribeCloudSaves } from '../scripts/storage.js';
+
+test('subscribeCloudSaves reacts to cloud events', () => {
+  let instance;
+  global.EventSource = class {
+    constructor(url) {
+      this.url = url;
+      this.listeners = {};
+      instance = this;
+    }
+    addEventListener(type, cb) {
+      this.listeners[type] = cb;
+    }
+    close() {
+      this.closed = true;
+    }
+  };
+
+  const handler = jest.fn();
+  subscribeCloudSaves(handler);
+  expect(handler).toHaveBeenCalledTimes(1); // initial cache
+  instance.listeners.put({ data: '{}' });
+  expect(handler).toHaveBeenCalledTimes(2);
+});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -13,6 +13,7 @@ import {
   renameCharacter,
 } from './characters.js';
 import { show, hide } from './modal.js';
+import { cacheCloudSaves, subscribeCloudSaves } from './storage.js';
 // Global CC object for cross-module state
 window.CC = window.CC || {};
 CC.partials = CC.partials || {};
@@ -2076,7 +2077,11 @@ applyDeleteIcons();
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   const swUrl = new URL('../sw.js', import.meta.url);
   navigator.serviceWorker.register(swUrl.href).catch(e => console.error('SW reg failed', e));
+  navigator.serviceWorker.addEventListener('message', e => {
+    if (e.data === 'cacheCloudSaves') cacheCloudSaves();
+  });
 }
+subscribeCloudSaves();
 
 // == Resonance Points (RP) Module ============================================
 CC.RP = (function () {


### PR DESCRIPTION
## Summary
- Listen to Firebase realtime updates with `EventSource` and refresh local caches automatically
- Hook service worker messages to trigger cloud cache updates
- Add unit test confirming realtime subscription fires on updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c47c323c44832ebb761f1f936312fb