### PR TITLE
Add hidden DM login link below footer

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -9,7 +9,7 @@ beforeEach(() => {
 describe('dm login', () => {
   test('loading The DM character unlocks tools', async () => {
     document.body.innerHTML = `
-        <button id="dm-login" hidden></button>
+        <button id="dm-login"></button>
         <div id="dm-tools-menu" hidden></div>
         <button id="dm-tools-tsomf"></button>
         <button id="dm-tools-logout"></button>
@@ -85,7 +85,7 @@ describe('dm login', () => {
 
   test('logout clears DM session and last save', async () => {
     document.body.innerHTML = `
-        <button id="dm-login" hidden></button>
+        <button id="dm-login"></button>
         <div id="dm-tools-menu" hidden></div>
         <button id="dm-tools-logout"></button>
       `;

--- a/index.html
+++ b/index.html
@@ -806,7 +806,7 @@
   <p>Product of XoVrom industries ® 2025</p>
 </footer>
 
-<button id="dm-login" class="dm-login-btn" aria-label="DM Tools" hidden></button>
+<button id="dm-login" class="dm-login-btn" aria-label="DM Tools"></button>
 <div id="dm-tools-menu" class="dm-tools-menu" hidden>
   <button id="dm-tools-tsomf" class="btn-sm">TSoMF</button>
   <button id="dm-tools-notifications" class="btn-sm">Notifications</button>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -70,7 +70,6 @@ function initDMLogin(){
 
   function updateButtons(){
     const loggedIn = isLoggedIn();
-    if (dmBtn) dmBtn.hidden = !loggedIn;
     if (!loggedIn && menu) menu.hidden = true;
   }
 
@@ -307,7 +306,13 @@ function initDMLogin(){
       }
     });
 
-  if (dmBtn) dmBtn.addEventListener('click', toggleMenu);
+  if (dmBtn) dmBtn.addEventListener('click', () => {
+    if (isLoggedIn()) {
+      toggleMenu();
+    } else {
+      requireLogin().catch(() => {});
+    }
+  });
 
   document.addEventListener('click', e => {
     if(menu && !menu.hidden && !menu.contains(e.target) && e.target !== dmBtn){

--- a/styles/main.css
+++ b/styles/main.css
@@ -856,9 +856,8 @@ select[required]:valid{
 .somf-hash { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; color:var(--accent) }
 
 /* DM login & tools menu */
-.dm-login-btn{position:fixed;bottom:33px;left:18px;width:44px;height:44px;margin:0;padding:0;display:flex;align-items:center;justify-content:center;border:1px solid var(--accent);border-radius:50%;background:var(--surface);box-shadow:var(--shadow);cursor:pointer;font-weight:700}
-.dm-login-btn::before{content:'DM'}
-.dm-login-btn[hidden]{display:none}
+.dm-login-btn{position:fixed;bottom:0;left:50%;transform:translateX(-50%);width:80px;height:30px;margin:0;padding:0;border:none;background:transparent;opacity:0;cursor:pointer;z-index:900}
+.dm-login-btn::before{content:''}
 .dm-tools-menu{position:fixed;bottom:80px;left:18px;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:2000}
 .dm-tools-menu[hidden]{display:none}
 .dm-tools-menu button{background:transparent;color:var(--text);border:none;padding:8px 12px;text-align:left;min-width:160px}


### PR DESCRIPTION
## Summary
- Add always-available DM login control centered beneath the footer and invisible to players
- Style DM login trigger as transparent click area
- Ensure DM login button opens login prompt when not authenticated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4948cd77c832eb8e373f474e4a77e