### PR TITLE
Integrate save into load modal and refresh cloud character list

### DIFF
--- a/__tests__/characters.test.js
+++ b/__tests__/characters.test.js
@@ -81,9 +81,6 @@ describe('character storage', () => {
       expect(localStorage.getItem('save:The DM')).toBe(JSON.stringify({ hp: 5 }));
       expect(localStorage.getItem('last-save')).toBe('The DM');
 
-      const chars = await listCharacters();
-      expect(chars).toContain('The DM');
-
       const data = await loadCharacter('The DM');
       expect(data).toEqual({ hp: 5 });
 

--- a/index.html
+++ b/index.html
@@ -29,14 +29,13 @@
         </svg>
       </button>
       <div id="menu-actions" class="menu" hidden>
-        <button id="btn-load" class="btn-sm">Load</button>
+        <button id="btn-load" class="btn-sm">Load / Save</button>
         <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
         <button id="btn-log" class="btn-sm">Action Log</button>
         <button id="btn-campaign" class="btn-sm">Campaign Log</button>
         <button id="btn-rules" class="btn-sm">Rules</button>
         <button id="btn-help" class="btn-sm">Help</button>
         <button id="btn-fun" class="btn-sm">Fun Tip</button>
-        <button id="btn-save" class="btn-sm">Save</button>
       </div>
     </div>
   </div>
@@ -542,6 +541,7 @@
     <h3>All Characters</h3>
     <div id="char-list" class="catalog"></div>
     <div class="actions">
+      <button id="btn-save" class="btn-sm" type="button">Save</button>
       <button id="recover-save" class="btn-sm" type="button">Recover Save</button>
       <button id="create-character" class="btn-sm" type="button">Create New</button>
     </div>

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -64,15 +64,12 @@ export function setCurrentCharacter(name) {
 }
 
 export async function listCharacters() {
-  const local = listLocalSaves().map(n => (n === 'DM' ? 'The DM' : n));
   try {
-    const cloud = (await listCloudSaves()).map(n => (n === 'DM' ? 'The DM' : n));
-    return Array.from(new Set([...local, ...cloud])).sort((a, b) =>
-      a.localeCompare(b)
-    );
+    const cloud = (await listCloudSaves()).map((n) => (n === 'DM' ? 'The DM' : n));
+    return cloud.sort((a, b) => a.localeCompare(b));
   } catch (e) {
     console.error('Failed to list cloud saves', e);
-    return Array.from(new Set(local)).sort((a, b) => a.localeCompare(b));
+    return [];
   }
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -560,7 +560,7 @@ progress::-moz-progress-bar{
 .card[draggable]{cursor:grab}
 .card:focus-within{box-shadow:0 0 0 2px var(--accent),var(--shadow)}
 .card.dragging{opacity:.5}
-.catalog{max-height:360px;overflow:auto;border:1px dashed var(--line);border-radius:10px;padding:6px}
+.catalog{max-height:360px;overflow-y:auto;overflow-x:hidden;border:1px dashed var(--line);border-radius:10px;padding:6px}
 .perk-list{margin:0;padding-left:20px;list-style:disc}
 .perk{margin:0}
 .feature-list{margin:0 0 12px;padding-left:20px;list-style:disc}


### PR DESCRIPTION
## Summary
- Move Save into the load character modal and rename menu option to "Load / Save"
- Render only cloud-backed characters in the load list and make the list scrollable
- Update tests for cloud-only character listing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4970e5b6c832eacd6ee427b451dba