### PR TITLE
Fix DM login toast dismissal and menu visibility

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -19,6 +19,7 @@ describe('dm login', () => {
         </div>
       `;
     window.toast = jest.fn();
+    window.dismissToast = jest.fn();
 
     jest.unstable_mockModule('../scripts/storage.js', () => ({
       saveLocal: jest.fn(),
@@ -45,13 +46,15 @@ describe('dm login', () => {
     await promise;
 
     expect(window.toast).toHaveBeenCalledWith('DM tools unlocked','success');
+    expect(window.dismissToast).toHaveBeenCalled();
     const dmBtn = document.getElementById('dm-login');
     const menu = document.getElementById('dm-tools-menu');
-    expect(dmBtn.hidden).toBe(false);
+    expect(dmBtn.style.opacity).toBe('1');
     expect(menu.hidden).toBe(true);
     dmBtn.click();
     expect(menu.hidden).toBe(false);
     delete window.toast;
+    delete window.dismissToast;
   });
 
   test('falls back to prompt when modal elements missing for The DM', async () => {

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -71,6 +71,7 @@ function initDMLogin(){
   function updateButtons(){
     const loggedIn = isLoggedIn();
     if (!loggedIn && menu) menu.hidden = true;
+    if (dmBtn) dmBtn.style.opacity = loggedIn ? '1' : '0';
   }
 
   function openLogin(){
@@ -105,6 +106,7 @@ function initDMLogin(){
           setLoggedIn();
           updateButtons();
           if (window.initSomfDM) window.initSomfDM();
+          if (typeof dismissToast === 'function') dismissToast();
           if (typeof toast === 'function') toast('DM tools unlocked','success');
           resolve(true);
         } else {
@@ -128,6 +130,7 @@ function initDMLogin(){
           updateButtons();
           if (window.initSomfDM) window.initSomfDM();
           closeLogin();
+          if (typeof dismissToast === 'function') dismissToast();
           if (typeof toast === 'function') toast('DM tools unlocked','success');
           cleanup();
           resolve(true);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -129,18 +129,29 @@ function playTone(type){
     osc.stop(audioCtx.currentTime + 0.15);
   }catch(e){ /* noop */ }
 }
-function toast(msg,type='info'){
-  const t=$('toast');
-  t.textContent=msg;
-  t.className=`toast ${type}`;
-  t.classList.add('show');
-  playTone(type);
-  setTimeout(()=>t.classList.remove('show'),5000);
-}
-// Expose toast globally so non-module scripts (e.g. dm.js) can display messages.
-// Without this assignment the login flow for special accounts like "The DM"
+ let toastTimeout;
+ function toast(msg,type='info'){
+   const t=$('toast');
+   t.textContent=msg;
+   t.className=`toast ${type}`;
+   t.classList.add('show');
+   playTone(type);
+   clearTimeout(toastTimeout);
+   toastTimeout = setTimeout(()=>t.classList.remove('show'),5000);
+ }
+
+ function dismissToast(){
+   const t=$('toast');
+   t.classList.remove('show');
+   clearTimeout(toastTimeout);
+ }
+
+// Expose toast utilities globally so non-module scripts (e.g. dm.js)
+// can display and control notifications.
+// Without these assignments the login flow for special accounts like "The DM"
 // will silently skip notifications because `toast` isn't found on `window`.
 window.toast = toast;
+window.dismissToast = dismissToast;
 
 function debounce(fn, delay){
   let t;


### PR DESCRIPTION
## Summary
- Add global `dismissToast` utility and track toast timeout
- Hide login prompt toast upon successful DM PIN entry
- Reveal DM tools button automatically after logging in

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c50630e4832e8b93cd25fae68264