### PR TITLE
Include backup-only characters in recovery list

### DIFF
--- a/__tests__/character_events.test.js
+++ b/__tests__/character_events.test.js
@@ -11,6 +11,7 @@ describe('character events', () => {
       loadCloud: jest.fn().mockRejectedValue(new Error('no')),
       listCloudSaves: jest.fn().mockResolvedValue([]),
       listCloudBackups: jest.fn().mockResolvedValue([]),
+      listCloudBackupNames: jest.fn().mockResolvedValue([]),
       loadCloudBackup: jest.fn().mockResolvedValue({}),
       deleteCloud: jest.fn()
     }));

--- a/__tests__/characters.test.js
+++ b/__tests__/characters.test.js
@@ -68,6 +68,25 @@ describe('character storage', () => {
     expect(data).toEqual({ hp: 20 });
   });
 
+  test('recovery list includes names from backups', async () => {
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ Hero: {} }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ Ghost: { 1: {} } }),
+      });
+
+    const { listRecoverableCharacters } = await import('../scripts/characters.js');
+
+    const names = await listRecoverableCharacters();
+    expect(names).toEqual(['Ghost', 'Hero']);
+  });
+
   for (const legacyName of ['Shawn', 'Player :Shawn', 'DM']) {
     test(`renames legacy ${legacyName} character to The DM`, async () => {
       localStorage.setItem(`save:${legacyName}`, JSON.stringify({ hp: 5 }));

--- a/__tests__/dm_list_modal.test.js
+++ b/__tests__/dm_list_modal.test.js
@@ -31,6 +31,7 @@ describe('DM load from character list', () => {
       currentCharacter: () => null,
       setCurrentCharacter: jest.fn(),
       listCharacters: jest.fn(async () => ['The DM']),
+      listRecoverableCharacters: jest.fn(async () => ['The DM']),
       loadCharacter,
       loadBackup: jest.fn(),
       listBackups: jest.fn(),

--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -30,6 +30,7 @@ describe('dm login', () => {
       loadCloud: jest.fn(async () => ({})),
       listCloudSaves: jest.fn(async () => []),
       listCloudBackups: jest.fn(async () => []),
+      listCloudBackupNames: jest.fn(async () => []),
       loadCloudBackup: jest.fn(async () => ({})),
       deleteCloud: jest.fn(),
     }));
@@ -71,6 +72,7 @@ describe('dm login', () => {
       loadCloud: jest.fn(async () => ({})),
       listCloudSaves: jest.fn(async () => []),
       listCloudBackups: jest.fn(async () => []),
+      listCloudBackupNames: jest.fn(async () => []),
       loadCloudBackup: jest.fn(async () => ({})),
       deleteCloud: jest.fn(),
     }));

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -7,6 +7,7 @@ import {
   loadCloud,
   listCloudSaves,
   listCloudBackups,
+  listCloudBackupNames,
   loadCloudBackup,
   deleteCloud,
 } from './storage.js';
@@ -69,6 +70,18 @@ export async function listCharacters() {
     return cloud.sort((a, b) => a.localeCompare(b));
   } catch (e) {
     console.error('Failed to list cloud saves', e);
+    return [];
+  }
+}
+
+export async function listRecoverableCharacters() {
+  try {
+    const saves = await listCharacters();
+    const backups = (await listCloudBackupNames()).map(n => (n === 'DM' ? 'The DM' : n));
+    const set = new Set([...saves, ...backups]);
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  } catch (e) {
+    console.error('Failed to list recoverable characters', e);
     return [];
   }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -11,6 +11,7 @@ import {
   deleteCharacter,
   saveCharacter,
   renameCharacter,
+  listRecoverableCharacters,
 } from './characters.js';
 import { show, hide } from './modal.js';
 import { cacheCloudSaves, subscribeCloudSaves } from './storage.js';
@@ -1367,7 +1368,7 @@ async function renderRecoverCharList(){
   const list = $('recover-char-list');
   if(!list) return;
   let names = [];
-  try { names = await listCharacters(); }
+  try { names = await listRecoverableCharacters(); }
   catch (e) { console.error('Failed to list characters', e); }
   list.innerHTML = names.map(c=>`<div class="catalog-item"><button class="btn-sm" data-char="${c}">${c}</button></div>`).join('');
 }

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -185,6 +185,22 @@ export async function listCloudBackups(name) {
   }
 }
 
+export async function listCloudBackupNames() {
+  try {
+    if (typeof fetch !== 'function') throw new Error('fetch not supported');
+    const res = await cloudFetch(`${CLOUD_HISTORY_URL}.json`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const val = await res.json();
+    return val ? Object.keys(val).map(k => decodeURIComponent(k)) : [];
+  } catch (e) {
+    if (e && e.message === 'fetch not supported') {
+      throw e;
+    }
+    console.error('Cloud history names failed', e);
+    return [];
+  }
+}
+
 export async function loadCloudBackup(name, ts) {
   try {
     if (typeof fetch !== 'function') throw new Error('fetch not supported');


### PR DESCRIPTION
## Summary
- show characters that only exist in backup history when recovering saves
- add storage helper for listing backup character names
- test recovering from backup-only characters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c92c9c80832e9616f0dc5fecac04