### PR TITLE
Handle quoted character names in save lists

### DIFF
--- a/__tests__/character_list_quotes.test.js
+++ b/__tests__/character_list_quotes.test.js
@@ -1,0 +1,82 @@
+import { jest } from '@jest/globals';
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="abil-grid"></div>
+    <div id="saves"></div>
+    <div id="skills"></div>
+    <div id="powers"></div>
+    <div id="sigs"></div>
+    <div id="weapons"></div>
+    <div id="armors"></div>
+    <div id="items"></div>
+    <div id="campaign-log"></div>
+    <div id="toast"></div>
+    <div id="save-animation"></div>
+    <button id="btn-save"></button>
+    <input id="superhero" />
+    <input id="secret" />
+    <div id="char-list"></div>
+    <div id="recover-char-list"></div>
+  `;
+  const realGet = document.getElementById.bind(document);
+  document.getElementById = (id) =>
+    realGet(id) || {
+      innerHTML: '',
+      value: '',
+      style: { setProperty: () => {}, getPropertyValue: () => '' },
+      classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+      setAttribute: () => {},
+      getAttribute: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      appendChild: () => {},
+      contains: () => false,
+      add: () => {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      focus: () => {},
+      click: () => {},
+      textContent: '',
+      disabled: false,
+      checked: false,
+      hidden: false,
+    };
+}
+
+describe('character list displays names with quotes', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    setupDom();
+    localStorage.clear();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200, text: async () => '', json: async () => null });
+    await jest.unstable_mockModule('../scripts/characters.js', () => ({
+      currentCharacter: jest.fn().mockReturnValue(null),
+      setCurrentCharacter: jest.fn(),
+      listCharacters: jest.fn().mockResolvedValue(['Nico "Specter" Alvarez']),
+      loadCharacter: jest.fn(),
+      loadBackup: jest.fn(),
+      listBackups: jest.fn().mockResolvedValue([]),
+      deleteCharacter: jest.fn(),
+      saveCharacter: jest.fn(),
+      renameCharacter: jest.fn(),
+      listRecoverableCharacters: jest.fn().mockResolvedValue([]),
+    }));
+    await import('../scripts/main.js');
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  test('renders quoted character names', async () => {
+    document.dispatchEvent(new CustomEvent('character-saved', { detail: 'Nico "Specter" Alvarez' }));
+    await new Promise(res => setTimeout(res, 0));
+    const anchor = Array.from(document.querySelectorAll('[data-char]')).find(
+      el => el.dataset.char === 'Nico "Specter" Alvarez'
+    );
+    expect(anchor).not.toBeNull();
+    expect(anchor.textContent).toBe('Nico "Specter" Alvarez');
+  });
+});
+

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1355,7 +1355,23 @@ async function renderCharacterList(){
   try { names = await listCharacters(); }
   catch (e) { console.error('Failed to list characters', e); }
   const current = currentCharacter();
-  list.innerHTML = names.map(c=>`<div class="catalog-item${c===current?' active':''}"><a href="#" data-char="${c}">${c}</a>${c==='The DM'?'':'<button class="btn-sm" data-del="'+c+'"></button>'}</div>`).join('');
+  list.innerHTML = '';
+  names.forEach(c => {
+    const item = document.createElement('div');
+    item.className = `catalog-item${c===current ? ' active' : ''}`;
+    const link = document.createElement('a');
+    link.href = '#';
+    link.dataset.char = c;
+    link.textContent = c;
+    item.appendChild(link);
+    if(c !== 'The DM'){
+      const btn = document.createElement('button');
+      btn.className = 'btn-sm';
+      btn.dataset.del = c;
+      item.appendChild(btn);
+    }
+    list.appendChild(item);
+  });
   applyDeleteIcons(list);
   selectedChar = current;
 }
@@ -1370,7 +1386,17 @@ async function renderRecoverCharList(){
   let names = [];
   try { names = await listRecoverableCharacters(); }
   catch (e) { console.error('Failed to list characters', e); }
-  list.innerHTML = names.map(c=>`<div class="catalog-item"><button class="btn-sm" data-char="${c}">${c}</button></div>`).join('');
+  list.innerHTML = '';
+  names.forEach(c => {
+    const item = document.createElement('div');
+    item.className = 'catalog-item';
+    const btn = document.createElement('button');
+    btn.className = 'btn-sm';
+    btn.dataset.char = c;
+    btn.textContent = c;
+    item.appendChild(btn);
+    list.appendChild(item);
+  });
 }
 
 async function renderRecoverList(name){


### PR DESCRIPTION
## Summary
- Build save lists using DOM APIs instead of HTML strings to support quotes in names
- Verify that quoted character names render correctly in the load list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4effbae7c832e8cd24066d7151be4