### PR TITLE
Fix DM login modal dismissal

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -48,6 +48,8 @@ describe('dm login', () => {
 
     expect(window.toast).toHaveBeenCalledWith('DM tools unlocked','success');
     expect(window.dismissToast).toHaveBeenCalled();
+    expect(modal.classList.contains('hidden')).toBe(true);
+    expect(modal.getAttribute('aria-hidden')).toBe('true');
     const dmBtn = document.getElementById('dm-login');
     const menu = document.getElementById('dm-tools-menu');
     expect(dmBtn.style.opacity).toBe('1');

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -1,5 +1,6 @@
 import { listCharacters, currentCharacter, setCurrentCharacter, loadCharacter } from './characters.js';
 import { DM_PIN } from './dm-pin.js';
+import { show, hide } from './modal.js';
 const notifications = [];
 
 function initDMLogin(){
@@ -71,23 +72,21 @@ function initDMLogin(){
   function updateButtons(){
     const loggedIn = isLoggedIn();
     if (!loggedIn && menu) menu.hidden = true;
-    if (dmBtn) dmBtn.style.opacity = loggedIn ? '1' : '0';
+    if (dmBtn){
+      dmBtn.style.opacity = loggedIn ? '1' : '0';
+    }
   }
 
   function openLogin(){
     if(!loginModal || !loginPin) return;
-    loginModal.style.display = 'flex';
-    loginModal.classList.remove('hidden');
-    loginModal.setAttribute('aria-hidden','false');
+    show('dm-login-modal');
     loginPin.value='';
     loginPin.focus();
   }
 
   function closeLogin(){
     if(!loginModal) return;
-    loginModal.classList.add('hidden');
-    loginModal.setAttribute('aria-hidden','true');
-    loginModal.style.display = 'none';
+    hide('dm-login-modal');
   }
 
   function requireLogin(){


### PR DESCRIPTION
## Summary
- Ensure DM login modal uses shared show/hide utilities so it closes automatically
- Verify DM Tools button becomes visible after successful PIN entry
- Add regression test for DM login dismissal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c585951a48832eb9f154d4a4a9c8a4