### PR TITLE
Add PIN protection toggle for character saves

### DIFF
--- a/__tests__/pin.test.js
+++ b/__tests__/pin.test.js
@@ -1,0 +1,18 @@
+import { setPin, hasPin, verifyPin, clearPin, movePin } from '../scripts/pin.js';
+
+test('set, verify, clear pin', async () => {
+  await setPin('Alice', '1234');
+  expect(hasPin('Alice')).toBe(true);
+  expect(await verifyPin('Alice', '1234')).toBe(true);
+  expect(await verifyPin('Alice', '0000')).toBe(false);
+  clearPin('Alice');
+  expect(hasPin('Alice')).toBe(false);
+});
+
+test('move pin between names', async () => {
+  await setPin('Old', '1111');
+  movePin('Old', 'New');
+  expect(hasPin('Old')).toBe(false);
+  expect(await verifyPin('New', '1111')).toBe(true);
+  clearPin('New');
+});

--- a/scripts/pin.js
+++ b/scripts/pin.js
@@ -1,0 +1,44 @@
+const KEY_PREFIX = 'pin:';
+
+function key(name) {
+  return KEY_PREFIX + name;
+}
+
+async function hashPin(pin) {
+  try {
+    if (crypto && crypto.subtle) {
+      const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(pin));
+      return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
+    }
+  } catch {}
+  return pin;
+}
+
+export async function setPin(name, pin) {
+  const hash = await hashPin(pin);
+  localStorage.setItem(key(name), hash);
+}
+
+export function hasPin(name) {
+  return localStorage.getItem(key(name)) !== null;
+}
+
+export async function verifyPin(name, pin) {
+  const stored = localStorage.getItem(key(name));
+  if (!stored) return false;
+  const hash = await hashPin(pin);
+  return stored === hash;
+}
+
+export function clearPin(name) {
+  localStorage.removeItem(key(name));
+}
+
+export function movePin(oldName, newName) {
+  const oldKey = key(oldName);
+  const val = localStorage.getItem(oldKey);
+  if (val) {
+    localStorage.setItem(key(newName), val);
+    localStorage.removeItem(oldKey);
+  }
+}


### PR DESCRIPTION
## Summary
- add padlock icon and toggle in character load modal
- support per-character PIN storage and verification
- cover PIN utilities with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c58a8426d4832eaa38705d7857618c