### PR TITLE
Handle DM tool init errors

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -63,6 +63,56 @@ describe('dm login', () => {
     delete window.dismissToast;
   });
 
+  test('login modal closes even if tools init fails', async () => {
+    document.body.innerHTML = `
+        <button id="dm-login"></button>
+        <div id="dm-tools-menu" hidden></div>
+        <button id="dm-tools-tsomf"></button>
+        <button id="dm-tools-logout"></button>
+        <div id="dm-login-modal" class="hidden" aria-hidden="true">
+          <input id="dm-login-pin">
+          <button id="dm-login-submit"></button>
+        </div>
+      `;
+    window.toast = jest.fn();
+    window.dismissToast = jest.fn();
+    window.initSomfDM = jest.fn(() => { throw new Error('fail'); });
+
+    jest.unstable_mockModule('../scripts/storage.js', () => ({
+      saveLocal: jest.fn(),
+      loadLocal: jest.fn(async () => ({})),
+      listLocalSaves: jest.fn(() => []),
+      deleteSave: jest.fn(),
+      saveCloud: jest.fn(),
+      loadCloud: jest.fn(async () => ({})),
+      listCloudSaves: jest.fn(async () => []),
+      listCloudBackups: jest.fn(async () => []),
+      listCloudBackupNames: jest.fn(async () => []),
+      loadCloudBackup: jest.fn(async () => ({})),
+      deleteCloud: jest.fn(),
+    }));
+    await import('../scripts/modal.js');
+    await import('../scripts/dm.js');
+    const { loadCharacter } = await import('../scripts/characters.js');
+
+    const promise = loadCharacter('The DM');
+    const modal = document.getElementById('dm-login-modal');
+    document.getElementById('dm-login-pin').value = '123123';
+    document.getElementById('dm-login-submit').click();
+    await promise;
+
+    expect(window.initSomfDM).toHaveBeenCalled();
+    expect(modal.classList.contains('hidden')).toBe(true);
+    const dmBtn = document.getElementById('dm-login');
+    const menu = document.getElementById('dm-tools-menu');
+    expect(menu.hidden).toBe(true);
+    dmBtn.click();
+    expect(menu.hidden).toBe(false);
+    delete window.toast;
+    delete window.dismissToast;
+    delete window.initSomfDM;
+  });
+
   test('falls back to prompt when modal elements missing for The DM', async () => {
     document.body.innerHTML = '';
     window.toast = jest.fn();

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -80,6 +80,14 @@ function initDMLogin(){
     }
   }
 
+  function initTools(){
+    try {
+      if (window.initSomfDM) window.initSomfDM();
+    } catch (e) {
+      console.error('Failed to init DM tools', e);
+    }
+  }
+
   function openLogin(){
     if(!loginModal || !loginPin) return;
     show('dm-login-modal');
@@ -108,7 +116,7 @@ function initDMLogin(){
           if (entered === DM_PIN) {
             setLoggedIn();
             updateButtons();
-            if (window.initSomfDM) window.initSomfDM();
+            initTools();
             if (typeof dismissToast === 'function') dismissToast();
             if (typeof toast === 'function') toast('DM tools unlocked','success');
             resolve(true);
@@ -132,7 +140,7 @@ function initDMLogin(){
         if(loginPin.value === DM_PIN){
           setLoggedIn();
           updateButtons();
-          if (window.initSomfDM) window.initSomfDM();
+          initTools();
           closeLogin();
           if (typeof dismissToast === 'function') dismissToast();
           if (typeof toast === 'function') toast('DM tools unlocked','success');
@@ -364,9 +372,7 @@ function initDMLogin(){
   }
 
   updateButtons();
-  if (isLoggedIn() && window.initSomfDM){
-    window.initSomfDM();
-  }
+  if (isLoggedIn()) initTools();
 
   document.addEventListener('click', e => {
     const t = e.target.closest('button,a');


### PR DESCRIPTION
## Summary
- prevent DM login modal from hanging by wrapping DM tool initialization in a safe helper
- add regression test for failed DM tool init

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c59ede07f0832e90f2f2aefca5a51e