### PR TITLE
Decouple DM login from The DM character

### DIFF
--- a/__tests__/characters.test.js
+++ b/__tests__/characters.test.js
@@ -92,7 +92,6 @@ describe('character storage', () => {
       localStorage.setItem(`save:${legacyName}`, JSON.stringify({ hp: 5 }));
       localStorage.setItem('last-save', legacyName);
       fetch.mockResolvedValue({ ok: true, status: 200, json: async () => null });
-      window.dmRequireLogin = jest.fn().mockResolvedValue(true);
 
       const { listCharacters, loadCharacter } = await import('../scripts/characters.js');
 
@@ -102,32 +101,25 @@ describe('character storage', () => {
 
       const data = await loadCharacter('The DM');
       expect(data).toEqual({ hp: 5 });
-
-      delete window.dmRequireLogin;
     });
   }
 
   test('cannot delete The DM', async () => {
     fetch.mockResolvedValue({ ok: true, status: 200, json: async () => null });
-    window.dmRequireLogin = jest.fn().mockResolvedValue(true);
     const { setCurrentCharacter, saveCharacter, deleteCharacter } = await import('../scripts/characters.js');
     setCurrentCharacter('The DM');
     await saveCharacter({ hp: 5 }, 'The DM');
     await expect(deleteCharacter('The DM')).rejects.toThrow('Cannot delete The DM');
-    delete window.dmRequireLogin;
   });
 
-  test('saving The DM requires DM login but no prompt', async () => {
+  test('saving The DM does not require DM login', async () => {
     window.dmRequireLogin = jest.fn().mockResolvedValue(true);
-    window.prompt = jest.fn();
     const { setCurrentCharacter, saveCharacter } = await import('../scripts/characters.js');
     setCurrentCharacter('The DM');
     await saveCharacter({ hp: 7 });
-    expect(window.dmRequireLogin).toHaveBeenCalled();
-    expect(window.prompt).not.toHaveBeenCalled();
+    expect(window.dmRequireLogin).not.toHaveBeenCalled();
     expect(localStorage.getItem('save:The DM')).toBe(JSON.stringify({ hp: 7 }));
     delete window.dmRequireLogin;
-    delete window.prompt;
   });
 
   test('saving another character does not require DM login', async () => {

--- a/__tests__/dm_list_modal.test.js
+++ b/__tests__/dm_list_modal.test.js
@@ -6,7 +6,7 @@ if (!window.matchMedia) {
 }
 
 describe('DM load from character list', () => {
-  test('hides character list before DM login', async () => {
+  test('shows confirmation when selecting The DM', async () => {
     const loadCharacter = jest.fn(async () => ({}));
     const hide = jest.fn();
     const show = jest.fn();
@@ -92,7 +92,8 @@ describe('DM load from character list', () => {
 
     document.querySelector('[data-char="The DM"]').click();
 
-    expect(hide).toHaveBeenCalledWith('modal-load-list');
-    expect(loadCharacter).toHaveBeenCalledWith('The DM');
+    expect(show).toHaveBeenCalledWith('modal-load');
+    expect(hide).not.toHaveBeenCalled();
+    expect(loadCharacter).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -7,7 +7,7 @@ beforeEach(() => {
 });
 
 describe('dm login', () => {
-  test('loading The DM character unlocks tools', async () => {
+  test('DM login unlocks tools', async () => {
     document.body.innerHTML = `
         <button id="dm-login"></button>
         <div id="dm-tools-menu" hidden></div>
@@ -36,9 +36,8 @@ describe('dm login', () => {
     }));
     await import('../scripts/modal.js');
     await import('../scripts/dm.js');
-    const { loadCharacter } = await import('../scripts/characters.js');
 
-    const promise = loadCharacter('The DM');
+    const promise = window.dmRequireLogin();
     const modal = document.getElementById('dm-login-modal');
     expect(modal.classList.contains('hidden')).toBe(false);
     expect(modal.style.display).toBe('flex');
@@ -93,9 +92,8 @@ describe('dm login', () => {
     }));
     await import('../scripts/modal.js');
     await import('../scripts/dm.js');
-    const { loadCharacter } = await import('../scripts/characters.js');
 
-    const promise = loadCharacter('The DM');
+    const promise = window.dmRequireLogin();
     const modal = document.getElementById('dm-login-modal');
     document.getElementById('dm-login-pin').value = '123123';
     document.getElementById('dm-login-submit').click();
@@ -113,7 +111,7 @@ describe('dm login', () => {
     delete window.initSomfDM;
   });
 
-  test('falls back to prompt when modal elements missing for The DM', async () => {
+  test('falls back to prompt when modal elements missing', async () => {
     document.body.innerHTML = '';
     window.toast = jest.fn();
     window.prompt = jest.fn(() => '123123');
@@ -133,9 +131,8 @@ describe('dm login', () => {
     }));
 
     await import('../scripts/dm.js');
-    const { loadCharacter } = await import('../scripts/characters.js');
 
-    await loadCharacter('The DM');
+    await window.dmRequireLogin();
 
     expect(window.prompt).toHaveBeenCalled();
     expect(window.toast).toHaveBeenCalledWith('DM tools unlocked','success');
@@ -143,7 +140,7 @@ describe('dm login', () => {
     delete window.prompt;
   });
 
-  test('logout clears DM session and last save', async () => {
+  test('logout clears DM session but keeps last save', async () => {
     document.body.innerHTML = `
         <button id="dm-login"></button>
         <div id="dm-tools-menu" hidden></div>
@@ -160,7 +157,7 @@ describe('dm login', () => {
     document.getElementById('dm-tools-logout').click();
 
     expect(sessionStorage.getItem('dmLoggedIn')).toBeNull();
-    expect(currentCharacter()).toBeNull();
-    expect(localStorage.getItem('last-save')).toBeNull();
+    expect(currentCharacter()).toBe('The DM');
+    expect(localStorage.getItem('last-save')).toBe('The DM');
   });
 });

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -13,9 +13,6 @@ import {
 } from './storage.js';
 import { hasPin, verifyPin as verifyStoredPin, clearPin, movePin } from './pin.js';
 
-// DM saves are protected by a login flow rather than a manual PIN entry.
-// Only "The DM" character triggers this flow.
-
 // Migrate legacy DM saves to the new "The DM" name.
 // Older versions stored the DM character under names like "Shawn",
 // "Player :Shawn", or simply "DM". Ensure any of these variants are renamed.
@@ -37,12 +34,6 @@ try {
 } catch {}
 
 async function verifyPin(name) {
-  if (name === 'The DM') {
-    if (typeof window.dmRequireLogin === 'function') {
-      await window.dmRequireLogin();
-    }
-    return;
-  }
   if (hasPin(name)) {
     const pin = await (window.pinPrompt ? window.pinPrompt('Enter PIN') : Promise.resolve(typeof prompt === 'function' ? prompt('Enter PIN') : null));
     if (pin === null || !(await verifyStoredPin(name, pin))) {

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -164,9 +164,6 @@ function initDMLogin(){
 
   function logout(){
     clearLoggedIn();
-    if (currentCharacter() === 'The DM') {
-      setCurrentCharacter(null);
-    }
     updateButtons();
     if (typeof toast === 'function') toast('Logged out','info');
   }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -164,8 +164,6 @@ function playTone(type){
 
 // Expose toast utilities globally so non-module scripts (e.g. dm.js)
 // can display and control notifications.
-// Without these assignments the login flow for special accounts like "The DM"
-// will silently skip notifications because `toast` isn't found on `window`.
 window.toast = toast;
 window.dismissToast = dismissToast;
 
@@ -1484,14 +1482,9 @@ if(charList){
       const item = loadBtn.closest('.catalog-item');
       if(item) item.classList.add('active');
       pendingLoad = { name: selectedChar };
-      if(selectedChar === 'The DM'){
-        hide('modal-load-list');
-        doLoad();
-      }else{
-        const text = $('load-confirm-text');
-        if(text) text.textContent = `Are you sure you would like to load this character: ${pendingLoad.name}. All current progress will be lost if you haven't saved yet.`;
-        show('modal-load');
-      }
+      const text = $('load-confirm-text');
+      if(text) text.textContent = `Are you sure you would like to load this character: ${pendingLoad.name}. All current progress will be lost if you haven't saved yet.`;
+      show('modal-load');
     } else if(lockBtn){
       const ch = lockBtn.dataset.lock;
       if(hasPin(ch)){
@@ -1611,14 +1604,9 @@ function openCharacterModalByName(name){
   if(!name) return;
   selectedChar = name;
   pendingLoad = { name };
-  if(name === 'The DM'){
-    hide('modal-load-list');
-    doLoad();
-  }else{
-    const text = $('load-confirm-text');
-    if(text) text.textContent = `Are you sure you would like to load this character: ${name}. All current progress will be lost if you haven't saved yet.`;
-    show('modal-load');
-  }
+  const text = $('load-confirm-text');
+  if(text) text.textContent = `Are you sure you would like to load this character: ${name}. All current progress will be lost if you haven't saved yet.`;
+  show('modal-load');
 }
 window.openCharacterModal = openCharacterModalByName;
 


### PR DESCRIPTION
## Summary
- stop triggering DM login when loading or saving "The DM"
- keep current character on DM logout
- handle "The DM" like any other character in load modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a45c990c832e90f5657a6a6c6f72