### PR TITLE
Fix DM Tools button unresponsive

### DIFF
--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -327,7 +327,7 @@ function initDMLogin(){
   });
 
   document.addEventListener('click', e => {
-    if(menu && !menu.hidden && !menu.contains(e.target) && e.target !== dmBtn){
+    if (menu && !menu.hidden && !menu.contains(e.target) && !dmBtn?.contains(e.target)) {
       menu.hidden = true;
     }
   });


### PR DESCRIPTION
## Summary
- fix DM Tools menu dismissal when clicking DM button by using contains check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5ab98a988832eb1e434c1d86dc1be