### PR TITLE
Use Firebase deck for Shards of Many Fates

### DIFF
--- a/index.html
+++ b/index.html
@@ -953,6 +953,7 @@
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 <script type="module" src="scripts/main.js"></script>
 <script type="module" src="scripts/dm.js"></script>
+<script type="module" src="scripts/somf-firebase.js"></script>
 <script src="shard-of-many-fates.js"></script>
 
 </body>

--- a/scripts/somf-firebase.js
+++ b/scripts/somf-firebase.js
@@ -1,0 +1,13 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getDatabase } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js';
+
+const firebaseConfig = {
+  databaseURL: 'https://ccccg-7d6b6-default-rtdb.firebaseio.com'
+};
+
+const app = initializeApp(firebaseConfig);
+const db = getDatabase(app);
+
+if (window.SOMF_MIN && typeof window.SOMF_MIN.setFirebase === 'function') {
+  window.SOMF_MIN.setFirebase(db);
+}


### PR DESCRIPTION
## Summary
- Initialize Firebase Realtime Database for Shards of Many Fates
- Load Firebase deck in DM and Player tool

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5d87cb908832eaff0b7d58733de84