### PR TITLE
Allow DM character summaries to bypass PIN locks

### DIFF
--- a/__tests__/characters.test.js
+++ b/__tests__/characters.test.js
@@ -131,6 +131,18 @@ describe('character storage', () => {
     expect(localStorage.getItem('save:Hero')).toBe(JSON.stringify({ hp: 3 }));
     delete window.dmRequireLogin;
   });
+
+  test('loading a pinned character can bypass pin prompt', async () => {
+    const { setPin } = await import('../scripts/pin.js');
+    const { loadCharacter } = await import('../scripts/characters.js');
+    localStorage.setItem('save:Hero', JSON.stringify({ hp: 10 }));
+    await setPin('Hero', '1234');
+    window.pinPrompt = jest.fn().mockResolvedValue('1234');
+    const data = await loadCharacter('Hero', { bypassPin: true });
+    expect(window.pinPrompt).not.toHaveBeenCalled();
+    expect(data).toEqual({ hp: 10 });
+    delete window.pinPrompt;
+  });
 });
 
 const keyPath = 'serviceAccountKey.json';

--- a/__tests__/dm_character_tool.test.js
+++ b/__tests__/dm_character_tool.test.js
@@ -97,7 +97,7 @@ describe('DM character viewer tool', () => {
     link.click();
     await new Promise(r => setTimeout(r, 0));
     const view = document.getElementById('dm-character-sheet');
-    expect(loadCharacter).toHaveBeenCalledWith('Test');
+    expect(loadCharacter).toHaveBeenCalledWith('Test', { bypassPin: true });
     expect(view.textContent).toContain('Test');
   });
 
@@ -166,6 +166,7 @@ describe('DM character viewer tool', () => {
     await new Promise(r => setTimeout(r, 0));
     const view = document.getElementById('dm-character-sheet');
     const text = view.textContent;
+    expect(loadCharacter).toHaveBeenCalledWith('Hero', { bypassPin: true });
     expect(text).toContain('Fireball');
     expect(text).toContain('Signature');
     expect(text).toContain('Sword');

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -86,8 +86,10 @@ export async function listRecoverableCharacters() {
   }
 }
 
-export async function loadCharacter(name) {
-  await verifyPin(name);
+export async function loadCharacter(name, { bypassPin = false } = {}) {
+  if (!bypassPin) {
+    await verifyPin(name);
+  }
   let data;
   try {
     data = await loadLocal(name);

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -309,7 +309,7 @@ function initDMLogin(){
       const name = link.textContent?.trim();
       if (!name || !charView) return;
       try {
-        const data = await loadCharacter(name);
+        const data = await loadCharacter(name, { bypassPin: true });
         charView.innerHTML='';
         charView.appendChild(characterCard(data, name));
         openCharacterView();


### PR DESCRIPTION
## Summary
- let `loadCharacter` skip PIN verification when requested
- load character summaries in DM tools without PIN prompt
- test that bypassed PINs still load correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5ea24c164832ea095b36c6c74b8f7