### PR TITLE
Label DM actions in notifications and logs

### DIFF
--- a/__tests__/action_log_dm.test.js
+++ b/__tests__/action_log_dm.test.js
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="log-action"></div>
+    <div id="full-log-action"></div>
+  `;
+  const realGet = document.getElementById.bind(document);
+  document.getElementById = (id) =>
+    realGet(id) || {
+      innerHTML: '',
+      value: '',
+      style: { setProperty: () => {}, getPropertyValue: () => '' },
+      classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+      setAttribute: () => {},
+      getAttribute: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      appendChild: () => {},
+      contains: () => false,
+      add: () => {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      focus: () => {},
+      click: () => {},
+      textContent: '',
+      disabled: false,
+      checked: false,
+      hidden: false,
+    };
+}
+
+describe('action log marks DM actions', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    localStorage.clear();
+    sessionStorage.clear();
+    setupDom();
+    window.matchMedia = jest.fn().mockReturnValue({ matches: true, addListener: () => {}, removeListener: () => {} });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => null,
+    });
+    window.confirm = jest.fn(() => true);
+    await import('../scripts/main.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+    delete window.confirm;
+  });
+
+  test('prefixes entries with DM when logged in', () => {
+    sessionStorage.setItem('dmLoggedIn', '1');
+    window.logAction('Test event');
+    const log = JSON.parse(localStorage.getItem('action-log'));
+    const last = log[log.length - 1];
+    expect(last.text).toBe('DM: Test event');
+  });
+});
+

--- a/__tests__/dm_notifications_dm.test.js
+++ b/__tests__/dm_notifications_dm.test.js
@@ -1,0 +1,51 @@
+import { jest } from '@jest/globals';
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="dm-tools-menu"></div>
+    <button id="dm-tools-notifications"></button>
+    <button id="dm-login"></button>
+    <div id="dm-login-modal"></div>
+    <input id="dm-login-pin" />
+    <button id="dm-login-submit"></button>
+    <button id="dm-login-close"></button>
+    <div id="dm-notifications-modal"></div>
+    <div id="dm-notifications-list"></div>
+    <button id="dm-notifications-close"></button>
+  `;
+}
+
+describe('dmNotify labels actions as DM when logged in', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    localStorage.clear();
+    sessionStorage.clear();
+    if (!window.matchMedia) {
+      window.matchMedia = () => ({ matches: false, addListener: () => {}, removeListener: () => {} });
+    }
+
+    const listCharacters = jest.fn(async () => []);
+    const currentCharacter = jest.fn(() => null);
+    const setCurrentCharacter = jest.fn();
+    const loadCharacter = jest.fn(async () => ({}));
+    jest.unstable_mockModule('../scripts/characters.js', () => ({
+      listCharacters,
+      currentCharacter,
+      setCurrentCharacter,
+      loadCharacter,
+    }));
+
+    setupDom();
+
+    await import('../scripts/dm.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    sessionStorage.setItem('dmLoggedIn', '1');
+  });
+
+  test('uses DM tag', () => {
+    window.dmNotify('testing');
+    const list = document.getElementById('dm-notifications-list');
+    expect(list.textContent).toContain('DM: testing');
+  });
+});
+

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -34,7 +34,15 @@ function initDMLogin(){
   window.dmNotify = function(detail){
     const entry = {
       ts: new Date().toLocaleString(),
-      char: (()=>{ try { return localStorage.getItem('last-save') || ''; } catch { return ''; } })(),
+      char: (()=>{
+        try {
+          return sessionStorage.getItem('dmLoggedIn') === '1'
+            ? 'DM'
+            : (localStorage.getItem('last-save') || '');
+        } catch {
+          return '';
+        }
+      })(),
       detail
     };
     notifications.push(entry);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1091,6 +1091,11 @@ function renderFullLogs(){
   $('full-log-action').innerHTML = actionLog.slice().reverse().map(e=>`<div class="catalog-item"><div>${fmt(e.t)}</div><div>${e.text}</div></div>`).join('');
 }
 function logAction(text){
+  try{
+    if(sessionStorage.getItem('dmLoggedIn') === '1'){
+      text = `DM: ${text}`;
+    }
+  }catch{}
   pushLog(actionLog, {t:Date.now(), text}, 'action-log');
   renderLogs();
   renderFullLogs();


### PR DESCRIPTION
## Summary
- Mark DM actions in notifications and action log when logged in
- Add tests ensuring logs use DM label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c61ae55c3c832eb37871b375a20418