### PR TITLE
fix: ensure DM tools init Firebase

### DIFF
--- a/scripts/somf-firebase.js
+++ b/scripts/somf-firebase.js
@@ -8,6 +8,18 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getDatabase(app);
 
-if (window.SOMF_MIN && typeof window.SOMF_MIN.setFirebase === 'function') {
+// The main runtime defines a global helper (SOMF_MIN.setFirebase) during its
+// own initialization. This file loads before that script, so the helper may not
+// exist yet. Previously this meant the database was never wired up, which
+// caused the DM tools (shards toggle, shard/NPC/item lists) to silently fail
+// because `window._somf_db` remained undefined. To support either load order we
+// assign the database directly if the helper hasn't been registered yet.
+
+window.SOMF_MIN = window.SOMF_MIN || {};
+if (typeof window.SOMF_MIN.setFirebase === 'function') {
   window.SOMF_MIN.setFirebase(db);
+} else {
+  // Fallback for early load: store the db so the runtime can use it once
+  // initialized.
+  window._somf_db = db;
 }


### PR DESCRIPTION
## Summary
- ensure DM Firebase setup works regardless of script load order

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c61b98734c832eafacc2c6c13af8ba