### PR TITLE
Fix distorted logos

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,11 +6,11 @@
 <meta name="description" content="Mobile-optimized character tracker for the Catalyst Core RPG."/>
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
-<link rel="icon" href="images/LOGO%20ICON.png" type="image/png"/>
-<link rel="apple-touch-icon" href="images/LOGO%20ICON.png"/>
-<link rel="shortcut icon" href="images/LOGO%20ICON.png" type="image/png"/>
-<meta property="og:image" content="images/LOGO%20ICON.png"/>
-<meta name="twitter:image" content="images/LOGO%20ICON.png"/>
+<link rel="icon" type="image/png" sizes="32x32" href="images/LOGO.PNG"/>
+<link rel="apple-touch-icon" sizes="180x180" href="images/LOGO.PNG"/>
+<link rel="shortcut icon" type="image/png" sizes="32x32" href="images/LOGO.PNG"/>
+<meta property="og:image" content="images/LOGO.PNG"/>
+<meta name="twitter:image" content="images/LOGO.PNG"/>
 <meta name="theme-color" content="#0e1117"/>
 <meta name="color-scheme" content="dark light"/>
 <title>Catalyst Core</title>
@@ -25,7 +25,7 @@
 
 <header>
   <div class="top">
-    <span class="tabs-title"><img src="images/LOGO%20ICON.png" alt="Catalyst Core logo" class="logo"/>Catalyst Core</span>
+    <span class="tabs-title"><img src="images/LOGO.PNG" alt="Catalyst Core logo" class="logo"/>Catalyst Core</span>
     <div class="dropdown">
       <button id="btn-menu" class="icon" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">

--- a/styles/main.css
+++ b/styles/main.css
@@ -70,7 +70,8 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 
 .tabs-title .logo{
   height:36px;
-  width:auto;
+  width:36px;
+  object-fit:contain;
   cursor:pointer;
 }
 .theme-light .tabs-title .logo{


### PR DESCRIPTION
## Summary
- Use square `LOGO.PNG` for favicon and header logo
- Set explicit favicon sizes and constrain header logo to a square to prevent distortion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7ab40e388832ea922fc708495c5fa