### PR TITLE
feat: add credits tracker

### DIFF
--- a/__tests__/credits_cloud.test.js
+++ b/__tests__/credits_cloud.test.js
@@ -1,0 +1,88 @@
+import { jest } from '@jest/globals';
+
+if (!window.matchMedia) {
+  window.matchMedia = () => ({ matches: false, addListener: () => {}, removeListener: () => {} });
+}
+
+describe('credits autosave to cloud', () => {
+  test('saves character when credits updated', async () => {
+    const saveCharacter = jest.fn().mockResolvedValue();
+
+    jest.unstable_mockModule('../scripts/helpers.js', () => ({
+      $: (id) => document.getElementById(id),
+      qs: (sel) => document.querySelector(sel),
+      qsa: (sel) => Array.from(document.querySelectorAll(sel)),
+      num: Number,
+      mod: () => 0,
+      calculateArmorBonus: () => 0,
+      revertAbilityScore: () => 0,
+    }));
+
+    jest.unstable_mockModule('../scripts/faction.js', () => ({
+      setupFactionRepTracker: () => {},
+      ACTION_HINTS: {},
+      updateFactionRep: () => {},
+    }));
+
+    jest.unstable_mockModule('../scripts/characters.js', () => ({
+      currentCharacter: () => 'Alice',
+      setCurrentCharacter: jest.fn(),
+      listCharacters: jest.fn(),
+      loadCharacter: jest.fn(),
+      loadBackup: jest.fn(),
+      listBackups: jest.fn(),
+      deleteCharacter: jest.fn(),
+      saveCharacter,
+      renameCharacter: jest.fn(),
+      listRecoverableCharacters: jest.fn(),
+    }));
+
+    jest.unstable_mockModule('../scripts/modal.js', () => ({ show: jest.fn(), hide: jest.fn() }));
+
+    jest.unstable_mockModule('../scripts/storage.js', () => ({ cacheCloudSaves: () => {}, subscribeCloudSaves: () => {} }));
+
+    global.toast = jest.fn();
+    global.confirm = jest.fn(() => true);
+    global.fetch = jest.fn().mockResolvedValue({ text: async () => '' });
+
+    document.body.innerHTML = `
+      <input id="credits" value="0" />
+      <span id="credits-total-pill"></span>
+      <span id="credits-total-modal"></span>
+      <button id="credits-open"></button>
+      <input id="credits-amt" />
+      <select id="credits-mode"><option value="add" selected>Add</option></select>
+      <button id="credits-submit"></button>
+    `;
+
+    const realGet = document.getElementById.bind(document);
+    document.getElementById = (id) => realGet(id) || {
+      innerHTML: '',
+      value: '',
+      style: { setProperty: () => {}, getPropertyValue: () => '' },
+      classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+      setAttribute: () => {},
+      getAttribute: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      appendChild: () => {},
+      contains: () => false,
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      focus: () => {},
+      click: () => {},
+      textContent: '',
+      disabled: false,
+      checked: false,
+      hidden: false,
+      add: () => {},
+    };
+
+    await import('../scripts/main.js');
+
+    document.getElementById('credits-amt').value = '50';
+    document.getElementById('credits-submit').click();
+
+    expect(saveCharacter).toHaveBeenCalled();
+  });
+});

--- a/index.html
+++ b/index.html
@@ -446,6 +446,14 @@
         <ul id="origin-perks" class="perk-list"></ul>
       </div>
       <div class="card">
+        <label for="credits">Credits</label>
+        <div class="inline">
+          <span id="credits-total-pill" class="pill">0</span>
+          <button id="credits-open" class="btn-sm" type="button">Manage</button>
+        </div>
+        <input id="credits" type="hidden" value="0"/>
+      </div>
+      <div class="card">
         <label>Faction Reputation</label>
           <div class="grid grid-1 faction-rep">
             <div>
@@ -534,6 +542,26 @@
 
 </main>
 
+<div class="overlay hidden" id="modal-credits" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Credits</h3>
+    <p>Total: <span id="credits-total-modal" class="pill">0</span></p>
+    <div class="inline">
+      <label for="credits-amt" class="sr-only">Amount</label>
+      <input id="credits-amt" type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Amount"/>
+      <select id="credits-mode">
+        <option value="add">Add</option>
+        <option value="subtract">Subtract</option>
+      </select>
+      <button id="credits-submit" class="btn-sm" type="button">Calculate</button>
+    </div>
+  </div>
+</div>
 
 <div class="overlay hidden" id="modal-load-list" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -724,6 +724,9 @@ const elTier = $('tier');
 const elCAPCheck = $('cap-check');
 const elCAPStatus = $('cap-status');
 const elDeathSaves = $('death-saves');
+const elCredits = $('credits');
+const elCreditsPill = $('credits-total-pill');
+const elCreditsModal = $('credits-total-modal');
 
 let hpRolls = [];
 if (elHPRoll) {
@@ -938,6 +941,41 @@ $('xp-submit').addEventListener('click', ()=>{
   if(!amt) return;
   const mode = $('xp-mode').value;
   setXP(num(elXP.value) + (mode==='add'? amt : -amt));
+});
+
+function updateCreditsDisplay(){
+  if (elCreditsPill) elCreditsPill.textContent = num(elCredits.value)||0;
+  if (elCreditsModal) elCreditsModal.textContent = num(elCredits.value)||0;
+}
+
+function setCredits(v){
+  const prev = num(elCredits.value)||0;
+  const total = Math.max(0, v);
+  elCredits.value = total;
+  updateCreditsDisplay();
+  const diff = total - prev;
+  if(diff !== 0){
+    window.dmNotify?.(`Credits ${diff>0?'gained':'spent'} ${Math.abs(diff)} (now ${total})`);
+    pushHistory();
+    const name = currentCharacter();
+    if (name) {
+      saveCharacter(serialize(), name).catch(e => {
+        console.error('Credits cloud save failed', e);
+      });
+    }
+  }
+}
+
+if (elCredits) updateCreditsDisplay();
+const elCreditsOpen = $('credits-open');
+if (elCreditsOpen) elCreditsOpen.addEventListener('click', ()=>{ updateCreditsDisplay(); show('modal-credits'); });
+
+$('credits-submit').addEventListener('click', ()=>{
+  const amt = num($('credits-amt').value)||0;
+  if(!amt) return;
+  const mode = $('credits-mode').value;
+  setCredits(num(elCredits.value) + (mode==='add'? amt : -amt));
+  $('credits-amt').value='';
 });
 
 
@@ -2078,6 +2116,7 @@ const DEFAULT_STATE = serialize();
   }
   updateDerived();
   updateFactionRep(handlePerkEffects);
+  updateCreditsDisplay();
 }
 
 /* ========= autosave + history ========= */


### PR DESCRIPTION
## Summary
- add Credits card and modal to Character & Story tab
- implement JS logic to update and persist credit total
- back up Credits changes to the cloud

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7d8fdb470832e9d0d8f17dcffc9bd