### PR TITLE
Add offline queue for character pin sync

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2235,6 +2235,7 @@ if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   navigator.serviceWorker.register(swUrl.href).catch(e => console.error('SW reg failed', e));
   navigator.serviceWorker.addEventListener('message', e => {
     if (e.data === 'cacheCloudSaves') cacheCloudSaves();
+    if (e.data === 'pins-updated') applyLockIcons();
   });
   navigator.serviceWorker.ready
     .then(reg => {


### PR DESCRIPTION
## Summary
- add offline detection and service worker queueing for character PIN set, clear, and move actions so they sync once connectivity is restored
- extend the service worker outbox to persist queued PIN operations, flush them alongside saves, and notify clients when PIN data changes
- refresh lock icons when background PIN sync completes and cover the new queuing path with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca3bd1533c832e901119bbc37405c3