### PR TITLE
Enable automatic reload after service worker updates

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2234,8 +2234,14 @@ if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   const swUrl = new URL('../sw.js', import.meta.url);
   navigator.serviceWorker.register(swUrl.href).catch(e => console.error('SW reg failed', e));
   navigator.serviceWorker.addEventListener('message', e => {
-    if (e.data === 'cacheCloudSaves') cacheCloudSaves();
-    if (e.data === 'pins-updated') applyLockIcons();
+    const { data } = e;
+    const type = typeof data === 'string' ? data : data?.type;
+    if (!type) return;
+    if (type === 'cacheCloudSaves') cacheCloudSaves();
+    if (type === 'pins-updated') applyLockIcons();
+    if (type === 'sw-updated') {
+      window.location.reload();
+    }
   });
   navigator.serviceWorker.ready
     .then(reg => {

--- a/sw.js
+++ b/sw.js
@@ -42,6 +42,7 @@ const OUTBOX_STORE = 'cloud-saves';
 const OUTBOX_PINS_STORE = 'cloud-pins';
 
 let flushPromise = null;
+let notifyClientsOnActivate = false;
 
 function encodePath(name) {
   return name
@@ -239,20 +240,27 @@ async function flushOutbox() {
 }
 
 self.addEventListener('install', e => {
+  notifyClientsOnActivate = Boolean(self.registration?.active);
   self.skipWaiting();
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
 });
 
 self.addEventListener('activate', e => {
   e.waitUntil(
-    Promise.all([
-      caches
-        .keys()
-        .then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))),
-      flushOutbox().catch(() => {}),
-    ])
+    (async () => {
+      await Promise.all([
+        caches
+          .keys()
+          .then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))),
+        flushOutbox().catch(() => {}),
+      ]);
+      await self.clients.claim();
+      if (notifyClientsOnActivate) {
+        await broadcast({ type: 'sw-updated' });
+        notifyClientsOnActivate = false;
+      }
+    })()
   );
-  self.clients.claim();
 });
 
 self.addEventListener('fetch', e => {


### PR DESCRIPTION
## Summary
- notify clients when a new service worker activates so open tabs can refresh themselves
- reload the UI when the update broadcast arrives to keep background windows current automatically

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca4d921560832eb6242dff010eae22