### PR TITLE
Surface background content updates across UI

### DIFF
--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -985,6 +985,15 @@ function initSomf(){
     return t;
   }
 
+  window.addEventListener('cc:content-updated', evt => {
+    const detail = evt?.detail || {};
+    const msg =
+      typeof detail.message === 'string' && detail.message
+        ? detail.message
+        : 'Codex content updated with new data.';
+    toast(`<strong>Codex Update</strong> ${msg}`);
+  });
+
   D.playerCardToggle?.addEventListener('change', async ()=>{
     const hidden = !D.playerCardToggle.checked;
     if(D.playerCardState) D.playerCardState.textContent = D.playerCardToggle.checked ? 'On' : 'Off';


### PR DESCRIPTION
## Summary
- log background content updates to the action log, toast system, and DM queue before reloading, and dispatch a shared `cc:content-updated` event
- persist DM notifications across reloads and drain any queued system notices so service worker updates surface in the modal history
- show a Shards of Many Fates toast for new content and attach message metadata to the service worker update broadcast

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca4d921560832eb6242dff010eae22