### PR TITLE
Ensure service worker activation refreshes clients

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2310,6 +2310,19 @@ applyLockIcons();
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   const swUrl = new URL('../sw.js', import.meta.url);
   navigator.serviceWorker.register(swUrl.href).catch(e => console.error('SW reg failed', e));
+  let hadController = Boolean(navigator.serviceWorker.controller);
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (serviceWorkerUpdateHandled) return;
+    if (!hadController) {
+      hadController = true;
+      return;
+    }
+    announceContentUpdate({
+      message: 'New Codex content is available.',
+      updatedAt: Date.now(),
+      source: 'controllerchange',
+    });
+  });
   navigator.serviceWorker.addEventListener('message', e => {
     const { data } = e;
     const payload = (data && typeof data === 'object') ? data : { type: data };

--- a/sw.js
+++ b/sw.js
@@ -108,7 +108,10 @@ async function deleteOutboxEntry(id, storeName = OUTBOX_STORE) {
 }
 
 async function broadcast(message) {
-  const clients = await self.clients.matchAll({ type: 'window' });
+  const clients = await self.clients.matchAll({
+    type: 'window',
+    includeUncontrolled: true,
+  });
   clients.forEach(client => client.postMessage(message));
 }
 


### PR DESCRIPTION
## Summary
- notify all windows, including uncontrolled ones, when the service worker activates so open tabs receive the update broadcast
- listen for service worker controller changes in the UI and trigger the existing content update flow to reload background tabs automatically

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca6345865c832e83e376f8f7c2f90f