### PR TITLE
Add Public Opinion faction to reputation tracker

### DIFF
--- a/__tests__/faction_rep.test.js
+++ b/__tests__/faction_rep.test.js
@@ -2,6 +2,10 @@ import { jest } from '@jest/globals';
 import { setupFactionRepTracker } from '../scripts/faction.js';
 
 describe('faction reputation tracker', () => {
+  afterEach(() => {
+    delete window.logAction;
+  });
+
   test('gain button updates value and pushes history', () => {
     document.body.innerHTML = `
       <div>
@@ -68,5 +72,47 @@ describe('faction reputation tracker', () => {
     const tier = document.getElementById('omni-rep-tier');
     expect(tier.style.getPropertyValue('--progress-color')).toBe(expectedColor);
     expect(pushHistory).toHaveBeenCalled();
+  });
+
+  test('public opinion uses tier ladder and single-point adjustments', () => {
+    document.body.innerHTML = `
+      <div>
+        <progress id="public-rep-bar" max="100" value="0"></progress>
+        <span id="public-rep-tier"></span>
+        <p id="public-rep-perk"></p>
+        <button id="public-rep-gain"></button>
+        <button id="public-rep-lose"></button>
+        <input type="hidden" id="public-rep" value="12" />
+      </div>
+    `;
+    const pushHistory = jest.fn();
+    const handlePerkEffects = jest.fn();
+    window.logAction = jest.fn();
+
+    setupFactionRepTracker(handlePerkEffects, pushHistory);
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const repInput = document.getElementById('public-rep');
+    const bar = document.getElementById('public-rep-bar');
+    expect(repInput.value).toBe('12');
+    expect(bar.max).toBe(30);
+    expect(bar.value).toBe(22);
+    const tier = document.getElementById('public-rep-tier');
+    expect(tier.textContent).toBe('Trusted');
+    const perk = document.getElementById('public-rep-perk');
+    expect(perk.textContent).toContain('Persuasion checks with civilians');
+
+    document.getElementById('public-rep-gain').click();
+    expect(repInput.value).toBe('13');
+    expect(bar.value).toBe(23);
+    expect(tier.textContent).toBe('Beloved');
+    expect(window.logAction).toHaveBeenCalledWith('Public Opinion Reputation: Trusted -> Beloved');
+
+    document.getElementById('public-rep-lose').click();
+    expect(repInput.value).toBe('12');
+    expect(bar.value).toBe(22);
+    expect(tier.textContent).toBe('Trusted');
+    expect(pushHistory).toHaveBeenCalledTimes(2);
+    expect(handlePerkEffects).toHaveBeenCalled();
   });
 });

--- a/index.html
+++ b/index.html
@@ -508,6 +508,19 @@
               </div>
               <input type="hidden" id="greyline-rep" value="200"/>
             </div>
+            <div>
+              <div class="inline faction-header">
+                <span class="pill pill-sm">Public Opinion</span>
+                <span id="public-rep-tier" class="pill pill-sm">Unknown</span>
+              </div>
+              <progress id="public-rep-bar" max="100" value="0"></progress>
+              <p id="public-rep-perk" class="perk"></p>
+              <div class="inline">
+                <button id="public-rep-gain" class="btn-sm">Gain</button>
+                <button id="public-rep-lose" class="btn-sm">Lose</button>
+              </div>
+              <input type="hidden" id="public-rep" value="0"/>
+            </div>
           </div>
       </div>
 

--- a/scripts/faction.js
+++ b/scripts/faction.js
@@ -1,5 +1,7 @@
 import { $, num } from './helpers.js';
 
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
 export const COMMON_REP_TIERS = {
   Hostile: ['You are hunted, sabotaged, or attacked on sight.'],
   Untrusted: ['Faction denies you resources, spreads bad PR.'],
@@ -15,18 +17,116 @@ export const FACTION_REP_PERKS = {
   'P.F.V.': { ...COMMON_REP_TIERS },
   'Cosmic Conclave': { ...COMMON_REP_TIERS },
   'Greyline PMC': { ...COMMON_REP_TIERS },
-};
-
-export const FACTIONS = ['omni', 'pfv', 'conclave', 'greyline'];
-
-export const FACTION_NAME_MAP = {
-  omni: 'O.M.N.I.',
-  pfv: 'P.F.V.',
-  conclave: 'Cosmic Conclave',
-  greyline: 'Greyline PMC',
+  'Public Opinion': {
+    Beloved: [
+      'Civilians trust you on sight. Reduce Persuasion and Deception DCs with civilians by 5. One scene per session, a crowd or witness will take a personal risk to help you. Local officials default to cooperation unless there is direct harm.',
+    ],
+    Trusted: [
+      'Persuasion checks with civilians are at advantage when the stakes involve safety or rescue. You can clear an area fast, no questions asked. First responder NPCs share operational updates if asked politely.',
+    ],
+    Noticed: [
+      'Bystanders give you the benefit of the doubt. Minor favors are easy—camera access from a shop owner, a rushed statement from a witness. Reduce one crowd-control or de-escalation DC by 2 per scene.',
+    ],
+    Unknown: ['No modifier. People judge you by the moment.'],
+    Distrusted: [
+      'Civilians are wary. Persuasion vs. civilians is at disadvantage if you are masked or armed unless you take time to explain. Expect phones out and hostile streaming.',
+    ],
+    Feared: [
+      'Crowds scatter or obstruct. Intimidation gains advantage while Persuasion suffers a –5 DC penalty. Officials require proof or warrants. Collateral damage is amplified by the media.',
+    ],
+    Villainized: [
+      'Mobs form, rumors spread, and you are blamed by default. Deception to hide identity is at disadvantage around locals. Police set perimeters against you—not for you. Expect ambush interviews and hostile headlines.',
+    ],
+  },
 };
 
 export const REP_TIERS = Object.keys(COMMON_REP_TIERS);
+
+const COMMON_MAX_REP = REP_TIERS.length * 100 - 1;
+const COMMON_STEP = 5;
+const COMMON_DEFAULT = 200;
+
+const createCommonFaction = (id, name) => {
+  const config = {
+    id,
+    name,
+    min: 0,
+    max: COMMON_MAX_REP,
+    defaultValue: COMMON_DEFAULT,
+    step: COMMON_STEP,
+  };
+  config.clamp = value => clamp(num(value), config.min, config.max);
+  config.getProgressValue = value => config.clamp(value) - config.min;
+  config.getProgressMax = () => config.max - config.min;
+  config.getRatio = value => {
+    const max = config.getProgressMax();
+    return max === 0 ? 0 : config.getProgressValue(value) / max;
+  };
+  config.getTier = value => {
+    const clamped = config.clamp(value);
+    const tierIdx = Math.min(REP_TIERS.length - 1, Math.floor(clamped / 100));
+    const tierName = REP_TIERS[tierIdx];
+    const perks = (FACTION_REP_PERKS[name] && FACTION_REP_PERKS[name][tierName]) || [];
+    return { name: tierName, perks };
+  };
+  return config;
+};
+
+const PUBLIC_OPINION_MIN = -10;
+const PUBLIC_OPINION_MAX = 20;
+const PUBLIC_OPINION_STEP = 1;
+
+const PUBLIC_OPINION_LADDER = [
+  { min: PUBLIC_OPINION_MIN, name: 'Villainized' },
+  { min: -7, name: 'Feared' },
+  { min: -3, name: 'Distrusted' },
+  { min: 0, name: 'Unknown' },
+  { min: 4, name: 'Noticed' },
+  { min: 8, name: 'Trusted' },
+  { min: 13, name: 'Beloved' },
+];
+
+const createPublicOpinionFaction = () => {
+  const config = {
+    id: 'public',
+    name: 'Public Opinion',
+    min: PUBLIC_OPINION_MIN,
+    max: PUBLIC_OPINION_MAX,
+    defaultValue: 0,
+    step: PUBLIC_OPINION_STEP,
+  };
+  config.clamp = value => clamp(num(value), config.min, config.max);
+  config.getProgressValue = value => config.clamp(value) - config.min;
+  config.getProgressMax = () => config.max - config.min;
+  config.getRatio = value => {
+    const max = config.getProgressMax();
+    return max === 0 ? 0 : config.getProgressValue(value) / max;
+  };
+  config.getTier = value => {
+    const clamped = config.clamp(value);
+    let tier = PUBLIC_OPINION_LADDER[0];
+    for (const candidate of PUBLIC_OPINION_LADDER) {
+      if (clamped >= candidate.min) {
+        tier = candidate;
+      } else {
+        break;
+      }
+    }
+    const perks = (FACTION_REP_PERKS[config.name] && FACTION_REP_PERKS[config.name][tier.name]) || [];
+    return { name: tier.name, perks };
+  };
+  return config;
+};
+
+export const FACTIONS = [
+  createCommonFaction('omni', 'O.M.N.I.'),
+  createCommonFaction('pfv', 'P.F.V.'),
+  createCommonFaction('conclave', 'Cosmic Conclave'),
+  createCommonFaction('greyline', 'Greyline PMC'),
+  createPublicOpinionFaction(),
+];
+
+export const FACTION_NAME_MAP = Object.fromEntries(FACTIONS.map(({ id, name }) => [id, name]));
 
 export const ACTION_HINTS = [
   'once per',
@@ -42,43 +142,39 @@ export const ACTION_HINTS = [
 ];
 
 export function updateFactionRep(handlePerkEffects = () => {}) {
-  FACTIONS.forEach(f => {
-    const input = $(`${f}-rep`);
-    const bar = $(`${f}-rep-bar`);
-    const tierEl = $(`${f}-rep-tier`);
-    const perkEl = $(`${f}-rep-perk`);
+  FACTIONS.forEach(config => {
+    const { id, name } = config;
+    const input = $(`${id}-rep`);
+    const bar = $(`${id}-rep-bar`);
+    const tierEl = $(`${id}-rep-tier`);
+    const perkEl = $(`${id}-rep-perk`);
     if (!input || !bar || !tierEl || !perkEl) return;
-    let val = Math.max(0, num(input.value));
-    const maxVal = REP_TIERS.length * 100 - 1;
-    if (val > maxVal) val = maxVal;
-    input.value = val;
-    const tierIdx = Math.min(REP_TIERS.length - 1, Math.floor(val / 100));
-    const tierName = REP_TIERS[tierIdx];
-    // Display the full reputation total on the progress element so players
-    // see overall advancement instead of only the progress within the current
-    // tier. Update both the DOM properties and attributes so that CSS
-    // selectors or assistive technology reading the raw attributes stay in
-    // sync with the underlying values.
-    bar.max = maxVal;
-    bar.value = val;
-    bar.setAttribute('max', String(maxVal));
-    bar.setAttribute('value', String(val));
-    const ratio = val / maxVal;
+    const rawValue = input.value === '' ? config.defaultValue : input.value;
+    const clamped = config.clamp(rawValue);
+    input.value = String(clamped);
+    const progressValue = config.getProgressValue(clamped);
+    const progressMax = config.getProgressMax();
+    bar.max = progressMax;
+    bar.value = progressValue;
+    bar.setAttribute('max', String(progressMax));
+    bar.setAttribute('value', String(progressValue));
+    const ratio = config.getRatio(clamped);
     const hue = 120 * ratio;
     const color = `hsl(${hue}, 70%, 50%)`;
     bar.style.setProperty('--progress-color', color);
+    const tierInfo = config.getTier(clamped);
+    const tierName = tierInfo.name || '';
     tierEl.textContent = tierName;
     tierEl.style.setProperty('--progress-color', color);
     perkEl.innerHTML = '';
-    const facName = FACTION_NAME_MAP[f];
-    const perks = (FACTION_REP_PERKS[facName] && FACTION_REP_PERKS[facName][tierName]) || [];
+    const perks = Array.isArray(tierInfo.perks) ? tierInfo.perks : [];
     const perk = perks[0];
     if (perk) {
       const text = typeof perk === 'string' ? perk : String(perk);
       const lower = text.toLowerCase();
       const isAction = ACTION_HINTS.some(k => lower.includes(k));
       if (isAction) {
-        const id = `${f}-rep-perk-act`;
+        const id = `${config.id}-rep-perk-act`;
         perkEl.innerHTML = `<label class="inline"><input type="checkbox" id="${id}"/> ${text}</label>`;
         const cb = perkEl.querySelector(`#${id}`);
         if (cb) {
@@ -99,29 +195,27 @@ export function updateFactionRep(handlePerkEffects = () => {}) {
 
 export function setupFactionRepTracker(handlePerkEffects = () => {}, pushHistory) {
   const init = () => {
-    const maxVal = REP_TIERS.length * 100 - 1;
-    FACTIONS.forEach(f => {
-      const input = $(`${f}-rep`);
-      const gain = $(`${f}-rep-gain`);
-      const lose = $(`${f}-rep-lose`);
+    FACTIONS.forEach(config => {
+      const { id, name } = config;
+      const input = $(`${id}-rep`);
+      const gain = $(`${id}-rep-gain`);
+      const lose = $(`${id}-rep-lose`);
       if (!input || !gain || !lose) return;
+      const step = config.step ?? COMMON_STEP;
       function change(delta) {
-        const currentVal = num(input.value);
-        const oldTierIdx = Math.min(REP_TIERS.length - 1, Math.floor(currentVal / 100));
-        const oldTierName = REP_TIERS[oldTierIdx];
-        const next = Math.max(0, Math.min(maxVal, currentVal + delta));
-        input.value = next;
+        const currentVal = config.clamp(input.value);
+        const oldTierName = config.getTier(currentVal).name;
+        const next = config.clamp(currentVal + delta);
+        input.value = String(next);
         updateFactionRep(handlePerkEffects);
-        const newTierIdx = Math.min(REP_TIERS.length - 1, Math.floor(next / 100));
-        const newTierName = REP_TIERS[newTierIdx];
+        const newTierName = config.getTier(next).name;
         if (oldTierName !== newTierName) {
-          const facName = FACTION_NAME_MAP[f];
-          window.logAction?.(`${facName} Reputation: ${oldTierName} -> ${newTierName}`);
+          window.logAction?.(`${name} Reputation: ${oldTierName} -> ${newTierName}`);
         }
         if (typeof pushHistory === 'function') pushHistory();
       }
-      gain.addEventListener('click', e => { e.preventDefault(); change(5); });
-      lose.addEventListener('click', e => { e.preventDefault(); change(-5); });
+      gain.addEventListener('click', e => { e.preventDefault(); change(step); });
+      lose.addEventListener('click', e => { e.preventDefault(); change(-step); });
     });
     updateFactionRep(handlePerkEffects);
   };


### PR DESCRIPTION
## Summary
- add a configurable Public Opinion faction with its own reputation ladder and perk text
- surface Public Opinion controls in the faction reputation section of the sheet
- expand faction tracker tests to cover the Public Opinion ladder and 1-point adjustments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca89175e9c832e9539ffb090fc5729