### PR TITLE
Align Public Opinion reputation with standard factions

### DIFF
--- a/__tests__/credits_cloud.test.js
+++ b/__tests__/credits_cloud.test.js
@@ -22,6 +22,7 @@ describe('credits autosave to cloud', () => {
       setupFactionRepTracker: () => {},
       ACTION_HINTS: {},
       updateFactionRep: () => {},
+      migratePublicOpinionSnapshot: (data) => data,
     }));
 
     jest.unstable_mockModule('../scripts/characters.js', () => ({

--- a/__tests__/dm_list_modal.test.js
+++ b/__tests__/dm_list_modal.test.js
@@ -25,6 +25,7 @@ describe('DM load from character list', () => {
       setupFactionRepTracker: () => {},
       ACTION_HINTS: {},
       updateFactionRep: () => {},
+      migratePublicOpinionSnapshot: (data) => data,
     }));
 
     jest.unstable_mockModule('../scripts/characters.js', () => ({

--- a/__tests__/faction_rep.test.js
+++ b/__tests__/faction_rep.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { setupFactionRepTracker } from '../scripts/faction.js';
+import { setupFactionRepTracker, migratePublicOpinionSnapshot } from '../scripts/faction.js';
 
 describe('faction reputation tracker', () => {
   afterEach(() => {
@@ -74,7 +74,7 @@ describe('faction reputation tracker', () => {
     expect(pushHistory).toHaveBeenCalled();
   });
 
-  test('public opinion uses tier ladder and single-point adjustments', () => {
+  test('public opinion uses common rules and five-point adjustments', () => {
     document.body.innerHTML = `
       <div>
         <progress id="public-rep-bar" max="100" value="0"></progress>
@@ -82,7 +82,7 @@ describe('faction reputation tracker', () => {
         <p id="public-rep-perk"></p>
         <button id="public-rep-gain"></button>
         <button id="public-rep-lose"></button>
-        <input type="hidden" id="public-rep" value="12" />
+        <input type="hidden" id="public-rep" value="495" />
       </div>
     `;
     const pushHistory = jest.fn();
@@ -94,25 +94,37 @@ describe('faction reputation tracker', () => {
 
     const repInput = document.getElementById('public-rep');
     const bar = document.getElementById('public-rep-bar');
-    expect(repInput.value).toBe('12');
-    expect(bar.max).toBe(30);
-    expect(bar.value).toBe(22);
+    expect(repInput.value).toBe('495');
+    expect(bar.max).toBe(699);
+    expect(bar.value).toBe(495);
     const tier = document.getElementById('public-rep-tier');
     expect(tier.textContent).toBe('Trusted');
     const perk = document.getElementById('public-rep-perk');
     expect(perk.textContent).toContain('Persuasion checks with civilians');
 
     document.getElementById('public-rep-gain').click();
-    expect(repInput.value).toBe('13');
-    expect(bar.value).toBe(23);
-    expect(tier.textContent).toBe('Beloved');
-    expect(window.logAction).toHaveBeenCalledWith('Public Opinion Reputation: Trusted -> Beloved');
+    expect(repInput.value).toBe('500');
+    expect(bar.value).toBe(500);
+    expect(tier.textContent).toBe('Favored');
+    expect(window.logAction).toHaveBeenCalledWith('Public Opinion Reputation: Trusted -> Favored');
 
     document.getElementById('public-rep-lose').click();
-    expect(repInput.value).toBe('12');
-    expect(bar.value).toBe(22);
+    expect(repInput.value).toBe('495');
+    expect(bar.value).toBe(495);
     expect(tier.textContent).toBe('Trusted');
     expect(pushHistory).toHaveBeenCalledTimes(2);
     expect(handlePerkEffects).toHaveBeenCalled();
+  });
+
+  test('migrates legacy public opinion values to the new scale', () => {
+    const snapshot = {
+      'public-rep': '-3',
+      'public-rep-bar': '7',
+    };
+
+    migratePublicOpinionSnapshot(snapshot);
+
+    expect(snapshot['public-rep']).toBe('150');
+    expect(snapshot['public-rep-bar']).toBe('150');
   });
 });

--- a/index.html
+++ b/index.html
@@ -511,7 +511,7 @@
             <div>
               <div class="inline faction-header">
                 <span class="pill pill-sm">Public Opinion</span>
-                <span id="public-rep-tier" class="pill pill-sm">Unknown</span>
+                <span id="public-rep-tier" class="pill pill-sm">Neutral</span>
               </div>
               <progress id="public-rep-bar" max="100" value="0"></progress>
               <p id="public-rep-perk" class="perk"></p>
@@ -519,7 +519,7 @@
                 <button id="public-rep-gain" class="btn-sm">Gain</button>
                 <button id="public-rep-lose" class="btn-sm">Lose</button>
               </div>
-              <input type="hidden" id="public-rep" value="0"/>
+              <input type="hidden" id="public-rep" value="200"/>
             </div>
           </div>
       </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,6 @@
 /* ========= helpers ========= */
 import { $, qs, qsa, num, mod, calculateArmorBonus, revertAbilityScore } from './helpers.js';
-import { setupFactionRepTracker, ACTION_HINTS, updateFactionRep } from './faction.js';
+import { setupFactionRepTracker, ACTION_HINTS, updateFactionRep, migratePublicOpinionSnapshot } from './faction.js';
 import {
   currentCharacter,
   setCurrentCharacter,
@@ -2144,8 +2144,9 @@ function serialize(){
   return data;
 }
 const DEFAULT_STATE = serialize();
- function deserialize(data){
- $('powers').innerHTML=''; $('sigs').innerHTML=''; $('weapons').innerHTML=''; $('armors').innerHTML=''; $('items').innerHTML='';
+function deserialize(data){
+  migratePublicOpinionSnapshot(data);
+  $('powers').innerHTML=''; $('sigs').innerHTML=''; $('weapons').innerHTML=''; $('armors').innerHTML=''; $('items').innerHTML='';
  const perkSelects=['alignment','classification','power-style','origin'];
  perkSelects.forEach(id=>{
    const el=$(id);


### PR DESCRIPTION
## Summary
- align the Public Opinion faction with the common reputation scale, including updated perks and legacy data migration
- adjust the sheet defaults and tests so Public Opinion shares the same layout, mechanics, and persistence as the other factions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca8bbb4704832ebbc13858c6ffc72b