### PR TITLE
Embed credits management controls in tracker card

### DIFF
--- a/__tests__/credits_cloud.test.js
+++ b/__tests__/credits_cloud.test.js
@@ -49,11 +49,12 @@ describe('credits autosave to cloud', () => {
     document.body.innerHTML = `
       <input id="credits" value="0" />
       <span id="credits-total-pill"></span>
-      <span id="credits-total-modal"></span>
-      <button id="credits-open"></button>
       <input id="credits-amt" />
-      <select id="credits-mode"><option value="add" selected>Add</option></select>
-      <button id="credits-submit"></button>
+      <select id="credits-mode">
+        <option value="add" selected>Add Credits</option>
+        <option value="subtract">Spend Credits</option>
+      </select>
+      <button id="credits-submit" type="button"></button>
     `;
 
     const realGet = document.getElementById.bind(document);

--- a/index.html
+++ b/index.html
@@ -449,7 +449,15 @@
         <label for="credits">Credits</label>
         <div class="inline">
           <span id="credits-total-pill" class="pill">0</span>
-          <button id="credits-open" class="btn-sm" type="button">Manage</button>
+        </div>
+        <div class="inline">
+          <label for="credits-amt" class="sr-only">Amount</label>
+          <input id="credits-amt" type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Amount"/>
+          <select id="credits-mode">
+            <option value="add">Add Credits</option>
+            <option value="subtract">Spend Credits</option>
+          </select>
+          <button id="credits-submit" class="btn-sm" type="button">Apply</button>
         </div>
         <input id="credits" type="hidden" value="0"/>
       </div>
@@ -555,26 +563,6 @@
 
 </main>
 
-<div class="overlay hidden" id="modal-credits" aria-hidden="true">
-  <div class="modal" role="dialog" aria-modal="true">
-    <button class="x" data-close aria-label="Close">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
-      </svg>
-    </button>
-    <h3>Credits</h3>
-    <p>Total: <span id="credits-total-modal" class="pill">0</span></p>
-    <div class="inline">
-      <label for="credits-amt" class="sr-only">Amount</label>
-      <input id="credits-amt" type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Amount"/>
-      <select id="credits-mode">
-        <option value="add">Add</option>
-        <option value="subtract">Subtract</option>
-      </select>
-      <button id="credits-submit" class="btn-sm" type="button">Calculate</button>
-    </div>
-  </div>
-</div>
 
 <div class="overlay hidden" id="modal-load-list" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -726,7 +726,6 @@ const elCAPStatus = $('cap-status');
 const elDeathSaves = $('death-saves');
 const elCredits = $('credits');
 const elCreditsPill = $('credits-total-pill');
-const elCreditsModal = $('credits-total-modal');
 
 let hpRolls = [];
 if (elHPRoll) {
@@ -945,7 +944,6 @@ $('xp-submit').addEventListener('click', ()=>{
 
 function updateCreditsDisplay(){
   if (elCreditsPill) elCreditsPill.textContent = num(elCredits.value)||0;
-  if (elCreditsModal) elCreditsModal.textContent = num(elCredits.value)||0;
 }
 
 function setCredits(v){
@@ -967,8 +965,6 @@ function setCredits(v){
 }
 
 if (elCredits) updateCreditsDisplay();
-const elCreditsOpen = $('credits-open');
-if (elCreditsOpen) elCreditsOpen.addEventListener('click', ()=>{ updateCreditsDisplay(); show('modal-credits'); });
 
 $('credits-submit').addEventListener('click', ()=>{
   const amt = num($('credits-amt').value)||0;

--- a/styles/main.css
+++ b/styles/main.css
@@ -274,8 +274,7 @@ progress::-moz-progress-bar{
   .roll-flip-grid .inline>button{flex:0 0 auto;width:auto;}
 }
 #flip{flex:1;width:100%;display:block;}
-#credits-total-pill,
-#credits-total-modal{
+#credits-total-pill{
   font-size:1rem;
   letter-spacing:.04em;
 }


### PR DESCRIPTION
## Summary
- embed the credits adjustment controls directly in the tracker card and remove the modal markup
- simplify the credits update logic now that the inline pill is the only display target
- update styling and tests to reflect the inline credits UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb89b9aeec832ebf86e9faccddc536