### PR TITLE
Default experience tracker to add

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2096,6 +2096,7 @@ function serialize(){
   function getChecked(sel, root){ const el = qs(sel, root); return el ? el.checked : false; }
   qsa('input,select,textarea,progress').forEach(el=>{
     const id = el.id; if (!id) return;
+    if (id === 'xp-mode') return;
     if (el.type==='checkbox') data[id] = !!el.checked; else data[id] = el.value;
   });
   data.powers = qsa("[data-kind='power']").map(card => ({
@@ -2156,8 +2157,8 @@ function deserialize(data){
      el.dispatchEvent(new Event('change',{bubbles:true}));
    }
  });
- Object.entries(data||{}).forEach(([k,v])=>{
-   if(perkSelects.includes(k) || k==='saveProfs' || k==='skillProfs') return;
+  Object.entries(data||{}).forEach(([k,v])=>{
+   if(perkSelects.includes(k) || k==='saveProfs' || k==='skillProfs' || k==='xp-mode') return;
    const el=$(k);
    if (!el) return;
    if (el.type==='checkbox') el.checked=!!v; else el.value=v;
@@ -2182,6 +2183,8 @@ function deserialize(data){
   campaignLog.length=0; (data && data.campaignLog ? data.campaignLog : []).forEach(e=>campaignLog.push(e));
   localStorage.setItem('campaign-log', JSON.stringify(campaignLog));
   renderCampaignLog();
+  const xpModeEl = $('xp-mode');
+  if (xpModeEl) xpModeEl.value = 'add';
   if (elXP) {
     const xp = Math.max(0, num(elXP.value));
     currentTierIdx = getTierIndex(xp);


### PR DESCRIPTION
## Summary
- reset the Experience tracker select to Add XP whenever a character is loaded
- omit the tracker mode field from serialized save data so it no longer persists in saved characters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb8ae8a0bc832e87069a28437f9911