### PR TITLE
Align gear card buttons vertically

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,16 +332,14 @@
   <fieldset data-tab="gear" class="card">
     <h2 class="card-title">Gear</h2>
     <div class="grid grid-2">
-      <div class="card">
-        <div class="inline" style="justify-content:space-between">
-          <h3 style="margin:0">Weapons</h3><button id="add-weapon" class="btn-sm" style="max-width:140px">Add Weapon</button>
-        </div>
+      <div class="card gear-card">
+        <h3 class="gear-card-title">Weapons</h3>
+        <button id="add-weapon" class="btn-sm gear-card-action" style="max-width:140px">Add Weapon</button>
         <div id="weapons" class="grid grid-1"></div>
       </div>
-      <div class="card">
-        <div class="inline" style="justify-content:space-between">
-          <h3 style="margin:0">Armor &amp; Protection</h3><button id="add-armor" class="btn-sm" style="max-width:160px">Add Armor</button>
-        </div>
+      <div class="card gear-card">
+        <h3 class="gear-card-title">Armor &amp; Protection</h3>
+        <button id="add-armor" class="btn-sm gear-card-action" style="max-width:160px">Add Armor</button>
         <div id="armors" class="grid grid-1"></div>
       </div>
       <div class="card" style="grid-column:1/-1">

--- a/styles/main.css
+++ b/styles/main.css
@@ -582,6 +582,8 @@ progress::-moz-progress-bar{
 .sp-field #long-rest{width:100%;margin-top:8px;}
 .sp-field .cap-box{margin-top:8px;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:8px;display:flex;flex-direction:column;gap:10px;transition:box-shadow .3s ease-in-out;background:color-mix(in srgb,var(--surface) 5%,transparent);background-color:color-mix(in srgb,var(--surface) 5%,transparent);-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);margin-left:auto;margin-right:auto;width:100%;max-width:var(--content-width);font-size:1.1rem}
+.gear-card .gear-card-title{margin:0}
+.gear-card .gear-card-action{align-self:flex-start}
 .card[draggable]{cursor:grab}
 .card:focus-within{box-shadow:0 0 0 2px var(--accent),var(--shadow)}
 .card.dragging{opacity:.5}


### PR DESCRIPTION
## Summary
- stack the Weapons and Armor card buttons beneath their section titles to match the desired layout
- add scoped styles for the gear cards so the titles and buttons align consistently

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbdb9c71f8832eb4e25a2b9aca9761