### PR TITLE
Replace down animation with flowing blood overlay

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -311,31 +311,65 @@ progress::-moz-progress-bar{
 #down-animation{
   position:fixed;
   inset:0;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  font-size:10rem;
-  color:var(--accent);
-  text-shadow:0 0 1rem currentColor;
   pointer-events:none;
+  overflow:hidden;
   opacity:0;
   z-index:3000;
   will-change:transform,opacity;
+  background:radial-gradient(circle at 50% -20%,rgba(120,0,0,.35) 0,transparent 60%);
+}
+#down-animation::before,
+#down-animation::after{
+  content:"";
+  position:absolute;
+  left:0;
+  width:100%;
+  background-repeat:no-repeat;
+  transform:translateY(-120%);
 }
 #down-animation::before{
-  content:"";width:1em;height:1em;
+  top:-10%;
+  height:160%;
+  background:linear-gradient(180deg,rgba(120,0,0,.95) 0%,rgba(90,0,0,.92) 35%,rgba(45,0,0,.85) 100%);
+  clip-path:polygon(0 0,100% 0,100% 65%,92% 75%,85% 68%,72% 82%,62% 68%,50% 84%,40% 66%,28% 82%,18% 68%,8% 78%,0 62%);
+  box-shadow:0 20px 30px rgba(0,0,0,.45);
+}
+#down-animation::after{
+  top:-18%;
+  height:180%;
   background:
-    linear-gradient(currentColor,currentColor) 50% 20%/15% 60% no-repeat,
-    radial-gradient(circle,currentColor 60%,transparent 61%) 50% 85%/15% 15% no-repeat;
+    radial-gradient(40% 35% at 15% 20%,rgba(200,0,0,.95) 0%,rgba(200,0,0,.6) 65%,transparent 70%),
+    radial-gradient(30% 35% at 50% 8%,rgba(160,0,0,.9) 0%,rgba(160,0,0,.55) 70%,transparent 75%),
+    radial-gradient(35% 40% at 82% 18%,rgba(185,0,0,.92) 0%,rgba(185,0,0,.6) 70%,transparent 78%),
+    linear-gradient(180deg,rgba(140,0,0,.9) 0%,rgba(90,0,0,.85) 60%,rgba(55,0,0,.95) 100%);
+  background-size:28% 38%,22% 40%,24% 38%,100% 100%;
+  background-position:12% -10%,47% -18%,82% -12%,50% 0%;
+  filter:drop-shadow(0 10px 16px rgba(0,0,0,.5));
 }
 #down-animation.show{
-  animation:downFlash 1.5s ease-in-out forwards;
+  animation:bloodCurtainFade 2s ease-in-out forwards;
 }
-@keyframes downFlash{
-  0%{transform:translateY(-100px) scale(0);opacity:0;}
-  40%{transform:translateY(0) scale(1.3);opacity:1;}
-  70%{transform:translateY(10px) scale(1);opacity:0.8;}
-  100%{transform:translateY(40px) scale(0.5) rotate(360deg);opacity:0;}
+#down-animation.show::before{
+  animation:bloodCurtainDrop 2s cubic-bezier(.3,.02,.22,.99) forwards;
+}
+#down-animation.show::after{
+  animation:bloodDripFall 2s cubic-bezier(.3,.02,.22,.99) forwards;
+}
+@keyframes bloodCurtainFade{
+  0%{opacity:0;}
+  10%{opacity:.95;}
+  75%{opacity:.85;}
+  100%{opacity:0;}
+}
+@keyframes bloodCurtainDrop{
+  0%{transform:translateY(-120%);}
+  55%{transform:translateY(0%);}
+  100%{transform:translateY(120%);}
+}
+@keyframes bloodDripFall{
+  0%{transform:translateY(-130%);opacity:1;}
+  60%{transform:translateY(5%);opacity:1;}
+  100%{transform:translateY(130%);opacity:0;}
 }
 #death-animation{
   position:fixed;


### PR DESCRIPTION
## Summary
- restyle the downed player animation as a full-screen blood curtain that flows down the viewport
- animate layered gradients and drips to replace the previous icon-based effect

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbde8b3fe8832eba15615cabd557e7