### PR TITLE
Fix SOMF player toggle offline fallback

### DIFF
--- a/__tests__/dm_enable_shards_push_state.test.js
+++ b/__tests__/dm_enable_shards_push_state.test.js
@@ -55,3 +55,31 @@ test('DM enabling shards pushes state to active browsers', async () => {
   expect(playerCard.hidden).toBe(false);
 });
 
+test('DM toggle reveals shards without realtime database', async () => {
+  delete window._somf_db;
+  localStorage.clear();
+
+  document.body.innerHTML = `
+    <section id="somf-min" hidden></section>
+    <div id="somf-min-modal" hidden></div>
+    <div id="somfDM-toasts"></div>
+    <input id="somfDM-playerCard" type="checkbox">
+    <span id="somfDM-playerCard-state"></span>
+  `;
+
+  await import(`../shard-of-many-fates.js?offline=${Date.now()}`);
+
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  await new Promise(r => setTimeout(r, 0));
+
+  const playerCard = document.getElementById('somf-min');
+  expect(playerCard.hidden).toBe(true);
+
+  const toggle = document.getElementById('somfDM-playerCard');
+  toggle.checked = true;
+  toggle.dispatchEvent(new Event('change'));
+  await new Promise(r => setTimeout(r, 0));
+
+  expect(playerCard.hidden).toBe(false);
+});
+


### PR DESCRIPTION
## Summary
- allow the Shards of Many Fates player view to persist and react to the reveal toggle using local storage events when Firebase is unavailable
- guard the DM reveal toggle and listeners so they gracefully fall back to local storage updates without a realtime database
- add a regression test ensuring the player card appears when the DM toggle is used without a realtime database

## Testing
- npm test -- dm_enable_shards_push_state
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbdcde6574832ea8883d40ca221d9a