### PR TITLE
Replace death animation with animated skull artwork

### DIFF
--- a/images/death-animation.svg
+++ b/images/death-animation.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Fallen hero emblem</title>
+  <desc id="desc">A stylised crimson skull marking a player defeat.</desc>
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="45%" r="65%">
+      <stop offset="0%" stop-color="#ff6b6b"/>
+      <stop offset="55%" stop-color="#d03030"/>
+      <stop offset="100%" stop-color="#660d0d"/>
+    </radialGradient>
+    <linearGradient id="bone" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fff3f3"/>
+      <stop offset="100%" stop-color="#f0caca"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(80 80)">
+    <circle r="72" fill="url(#bg)"/>
+    <circle r="48" fill="#1b0808" opacity="0.18"/>
+    <g fill="url(#bone)" stroke="#8a3a3a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+      <rect x="-54" y="30" width="108" height="12" rx="6" transform="rotate(30)"/>
+      <rect x="-54" y="30" width="108" height="12" rx="6" transform="rotate(-30)"/>
+      <circle cx="-43" cy="66" r="8"/>
+      <circle cx="43" cy="66" r="8"/>
+      <circle cx="-39" cy="-30" r="8"/>
+      <circle cx="39" cy="-30" r="8"/>
+    </g>
+    <g>
+      <path d="M-34 -44c0-17.1 13.8-30.9 30.9-30.9h6.2c17.1 0 30.9 13.8 30.9 30.9v20.3c0 7.5-3.6 14.5-9.6 18.9l-6.2 4.6v9.7c0 9.1 -7.4 16.6 -16.6 16.6h-2.9c-9.1 0 -16.6-7.4 -16.6-16.6v-9.7l-6.2-4.6c-6-4.4-9.6-11.4-9.6-18.9z" fill="#fff5f5" stroke="#380d0d" stroke-width="4" stroke-linejoin="round"/>
+      <ellipse cx="-12" cy="-16" rx="10" ry="12" fill="#380d0d"/>
+      <ellipse cx="12" cy="-16" rx="10" ry="12" fill="#380d0d"/>
+      <rect x="-12" y="2" width="24" height="18" rx="5" fill="#ffdede" stroke="#380d0d" stroke-width="3"/>
+      <line x1="-6" y1="2" x2="-6" y2="18" stroke="#380d0d" stroke-width="2"/>
+      <line x1="0" y1="2" x2="0" y2="18" stroke="#380d0d" stroke-width="2"/>
+      <line x1="6" y1="2" x2="6" y2="18" stroke="#380d0d" stroke-width="2"/>
+    </g>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -996,7 +996,9 @@
 <audio id="somfDM-ping" preload="auto"></audio>
 
 <div id="down-animation" aria-hidden="true" hidden></div>
-<div id="death-animation" aria-hidden="true" hidden></div>
+<div id="death-animation" aria-hidden="true" hidden>
+  <img src="images/death-animation.svg" alt="" decoding="async" loading="lazy" />
+</div>
 <div id="damage-animation" aria-hidden="true" hidden></div>
 <div id="heal-animation" aria-hidden="true" hidden></div>
 <div id="save-animation" aria-hidden="true" hidden></div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -377,29 +377,39 @@ progress::-moz-progress-bar{
   display:flex;
   align-items:center;
   justify-content:center;
-  font-size:10rem;
-  color:var(--text);
-  text-shadow:0 0 1rem currentColor;
   pointer-events:none;
   opacity:0;
   z-index:3000;
+  will-change:opacity;
+}
+#death-animation img{
+  display:block;
+  width:min(45vmin, 320px);
+  max-width:80%;
+  height:auto;
+  opacity:0;
+  transform:scale(0.6) rotate(-12deg);
+  filter:drop-shadow(0 0 1.5rem rgba(136,0,0,0.55));
   will-change:transform,opacity;
 }
-#death-animation::before{
-  content:"";width:1em;height:1em;
-  background:
-    linear-gradient(45deg,transparent 40%,currentColor 40% 60%,transparent 60%),
-    linear-gradient(-45deg,transparent 40%,currentColor 40% 60%,transparent 60%);
-  background-size:100% 100%;
-}
 #death-animation.show{
-  animation:deathFade 2s ease-in-out forwards;
+  animation:deathVeil 2.4s ease-in-out forwards;
 }
-@keyframes deathFade{
-  0%{transform:scale(0) rotate(-180deg);opacity:0;}
-  30%{transform:scale(1.3) rotate(0);opacity:1;color:var(--error);}
-  70%{transform:scale(1) rotate(0);opacity:1;}
-  100%{transform:scale(0.5) rotate(180deg);opacity:0;}
+#death-animation.show img{
+  animation:deathPulse 2.4s ease-in-out forwards;
+}
+@keyframes deathVeil{
+  0%{opacity:0;}
+  18%{opacity:1;}
+  60%{opacity:.95;}
+  100%{opacity:0;}
+}
+@keyframes deathPulse{
+  0%{opacity:0;transform:scale(0.5) rotate(-18deg);}
+  20%{opacity:1;transform:scale(1.15) rotate(3deg);}
+  55%{opacity:1;transform:scale(1) rotate(0);}
+  80%{opacity:.9;transform:scale(0.95) rotate(-2deg);}
+  100%{opacity:0;transform:scale(0.85) rotate(-8deg);}
 }
 #damage-animation{
   position:fixed;


### PR DESCRIPTION
## Summary
- render the death animation with a dedicated SVG image instead of the previous emoji placeholder
- add a new animated overlay effect that pulses the artwork when death saves are failed
- include the custom skull SVG asset for use by the animation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe00937e8832e8ce2dc40dbf3b271