### PR TITLE
Improve faction reputation layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,7 +459,7 @@
         </div>
         <input id="credits" type="hidden" value="0"/>
       </div>
-      <div class="card">
+      <div class="card card-wide">
         <label>Faction Reputation</label>
         <div class="faction-rep">
           <div class="faction-rep__card">

--- a/styles/main.css
+++ b/styles/main.css
@@ -287,7 +287,11 @@ progress::-moz-progress-bar{
   letter-spacing:.04em;
 }
 .card.card-wide{max-width:none;width:100%;}
-.faction-rep{display:grid;gap:12px;width:100%;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));}
+.grid>.card.card-wide{grid-column:1/-1;}
+.faction-rep{display:grid;gap:12px;width:100%;grid-template-columns:1fr;grid-auto-flow:row;}
+@media(min-width:600px){
+  .faction-rep{grid-template-columns:repeat(2,minmax(0,1fr));grid-auto-flow:column;}
+}
 .faction-rep__card{display:flex;flex-direction:column;gap:10px;padding:12px;border-radius:var(--radius);background:color-mix(in srgb,var(--surface) 8%,transparent);border:1px solid color-mix(in srgb,var(--line) 50%,transparent);box-shadow:0 3px 8px rgba(0,0,0,.15);}
 .faction-rep__header{display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;}
 .faction-rep__perk{display:flex;flex-direction:column;gap:6px;padding:10px;border-radius:calc(var(--radius) - 2px);background:color-mix(in srgb,var(--surface-2) 35%,transparent);border:1px solid color-mix(in srgb,var(--line) 60%,transparent);}


### PR DESCRIPTION
## Summary
- allow the Faction Reputation card to span the full width of the story layout
- adjust the faction reputation grid to present a two-column, column-flow layout on wider screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe590c1fc832ebe1f30e08c4f5861