### PR TITLE
Fix SOMF DM toggle default and reveal behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -932,7 +932,7 @@
       <h3>DM • Shards <span id="somfDM-cardCount"></span></h3>
       <div class="somf-dm__hdr-controls">
         <div class="somf-dm__toggles">
-          <label class="somf-switch"><span id="somfDM-playerCard-state">On</span><input id="somfDM-playerCard" type="checkbox" checked><span>Reveal Shards</span></label>
+          <label class="somf-switch"><span id="somfDM-playerCard-state">Off</span><input id="somfDM-playerCard" type="checkbox"><span>Reveal Shards</span></label>
         </div>
         <div class="somf-dm__actions">
           <button id="somfDM-reset" class="somf-btn">Reset</button>

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -999,7 +999,7 @@ function initSomf(){
     const t=document.createElement('div');
     t.style.cssText='background:#0b1119;color:#e6f1ff;border:1px solid #1b2532;border-radius:8px;padding:10px 12px;min-width:260px;box-shadow:0 8px 24px #0008';
     t.innerHTML = msg;
-    D.toasts.appendChild(t);
+    if (D.toasts) D.toasts.appendChild(t);
     try{ D.ping.currentTime=0; D.ping.play(); }catch{}
     setTimeout(()=> t.remove(), ttl);
     if ('Notification' in window && Notification.permission==='granted'){
@@ -1020,6 +1020,11 @@ function initSomf(){
   D.playerCardToggle?.addEventListener('change', async ()=>{
     const hidden = !D.playerCardToggle.checked;
     if(D.playerCardState) D.playerCardState.textContent = D.playerCardToggle.checked ? 'On' : 'Off';
+    try {
+      await applyHiddenState(hidden);
+    } catch (err) {
+      console.error('SOMF hidden state apply failed', err);
+    }
     if(hasRealtime()){
       try {
         await db().ref(path.hidden(CID())).set(hidden);


### PR DESCRIPTION
## Summary
- set the DM shard reveal toggle to start in the Off position so the UI matches the default hidden state
- apply the selected toggle state immediately so the player shard card appears as soon as the DM enables it
- guard toast rendering against missing containers to avoid runtime errors during the reveal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc4ee800c4832eacf27d581165aa9a