### PR TITLE
Fix TSoMF firebase integration

### DIFF
--- a/scripts/somf-firebase.js
+++ b/scripts/somf-firebase.js
@@ -1,12 +1,12 @@
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
-import { getDatabase } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js';
+import firebase from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js';
+import 'https://www.gstatic.com/firebasejs/9.22.2/firebase-database-compat.js';
 
 const firebaseConfig = {
   databaseURL: 'https://ccccg-7d6b6-default-rtdb.firebaseio.com'
 };
 
-const app = initializeApp(firebaseConfig);
-const db = getDatabase(app);
+const app = firebase.apps?.length ? firebase.app() : firebase.initializeApp(firebaseConfig);
+const db = firebase.database(app);
 
 // The main runtime defines a global helper (SOMF_MIN.setFirebase) during its
 // own initialization. This file loads before that script, so the helper may not


### PR DESCRIPTION
## Summary
- switch the TSoMF Firebase bootstrap to the compat build so the DM tools get a database instance with the expected `ref`/`ServerValue` interface
- guard against duplicate initialization by reusing an existing Firebase app before wiring it into the runtime helpers

## Testing
- npm test -- somf
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf51109ba4832e92eae0d9bc0e5677