### PR TITLE
Show shard art in TSoMF player modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -837,27 +837,14 @@
 </div>
 
 <div id="somf-min-modal" class="somf-modal" hidden>
-  <div class="somf-modal__backdrop"></div>
-  <div class="somf-modal__card">
+  <div class="somf-modal__backdrop" data-somf-dismiss></div>
+  <div class="somf-modal__card somf-modal__card--image">
     <button id="somf-min-close" class="somf-modal__x" aria-label="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
-    <header class="somf-modal__hdr">
-      <strong>Shard</strong>
-    </header>
-    <div class="somf-modal__body">
-      <h4 id="somf-min-name" class="somf-subttl">—</h4>
-      <p id="somf-min-visual" class="somf-muted">—</p>
-      <ul id="somf-min-effect" class="somf-list"></ul>
-      <div id="somf-min-progress" class="somf-progress">Shard <span id="somf-min-idx">0</span>/<span id="somf-min-total">0</span></div>
-    </div>
-    <footer class="somf-modal__ftr">
-      <label class="somf-checkbox"><input id="somf-min-resolved" type="checkbox"> <span>Mark resolved</span></label>
-      <div class="somf-flex-spacer"></div>
-      <button id="somf-min-next" class="somf-btn somf-primary" disabled>Next</button>
-    </footer>
+    <img id="somf-min-image" class="somf-modal__art" alt="Shard artwork" loading="lazy">
   </div>
 </div>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -925,6 +925,9 @@ select[required]:valid{
 .somf-modal { position:fixed; inset:0; z-index:9999; display:grid; place-items:center }
 .somf-modal__backdrop { position:absolute; inset:0; background:rgba(0,0,0,.5) }
 .somf-modal__card { position:relative; background:var(--surface); border:1px solid var(--line); color:var(--text); border-radius:var(--radius); width:min(640px, 96vw); max-height:88vh; display:flex; flex-direction:column; box-shadow:var(--shadow) }
+.somf-modal__card--image{background:transparent;border:none;box-shadow:none;padding:0;display:block;width:auto;max-width:min(90vw,720px);max-height:90vh}
+.somf-modal__card--image .somf-modal__x{color:#fff;text-shadow:0 2px 6px rgba(0,0,0,.6)}
+.somf-modal__art{display:block;width:100%;height:auto;max-width:min(90vw,720px);max-height:90vh;border-radius:var(--radius);box-shadow:var(--shadow)}
 .somf-modal__hdr, .somf-modal__ftr { display:flex; align-items:center; gap:8px; padding:10px 12px; border-bottom:1px solid var(--line) }
 .somf-modal__ftr { border-top:1px solid var(--line); border-bottom:none }
 .somf-modal__body { padding:12px; overflow:auto }


### PR DESCRIPTION
## Summary
- replace the player shard modal with a simplified card that only renders artwork
- map shard IDs to the corresponding art files and feed those URLs to the player queue
- update modal styling and interaction so the image can be dismissed with the close button or backdrop tap

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfd34528c0832ebe6a9bfac68d9b08