### PR TITLE
Add currency symbol to credits total pill

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,6 +447,7 @@
       <div class="card">
         <label for="credits">Credits</label>
         <div class="inline">
+          <span class="credits-currency" aria-hidden="true">₡</span>
           <span id="credits-total-pill" class="pill">0</span>
         </div>
         <div class="inline">

--- a/styles/main.css
+++ b/styles/main.css
@@ -306,6 +306,13 @@ progress::-moz-progress-bar{
   font-size:1rem;
   letter-spacing:.04em;
 }
+
+.credits-currency{
+  flex:0 0 auto;
+  font-size:1rem;
+  font-weight:600;
+  letter-spacing:.04em;
+}
 .card.card-wide{max-width:none;width:100%;}
 .grid>.card.card-wide{grid-column:1/-1;}
 .faction-rep{display:grid;gap:12px;width:100%;grid-template-columns:1fr;grid-auto-flow:row;}


### PR DESCRIPTION
## Summary
- show the Costa Rican colón symbol next to the credits total pill so the currency is clear
- style the new currency marker to match the pill typography and layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfd7e9602c832e8df3ae54de8df572