### PR TITLE
Add shard artwork links to TSoMF notifications

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1299,6 +1299,9 @@ function queueDmNotification(message, meta = {}) {
       ts: typeof meta.ts === 'number' || typeof meta.ts === 'string' ? meta.ts : Date.now(),
       char: meta.char || 'System',
     };
+    if (typeof meta.html === 'string' && meta.html) {
+      record.html = meta.html;
+    }
     pending.push(record);
     const MAX_PENDING = 20;
     if (pending.length > MAX_PENDING) {


### PR DESCRIPTION
## Summary
- add sanitized shard artwork links to player TSoMF draw notifications and expose a click handler to reopen the art modal
- allow DM notifications to persist and render optional HTML so shard draws share the same artwork links
- propagate shard artwork metadata through queued notifications for consistency when DM tools are offline

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfd79a37d0832eaffd2500133f7cca