### PR TITLE
Fix gear catalog tier ordering

### DIFF
--- a/__tests__/catalog_sort.test.js
+++ b/__tests__/catalog_sort.test.js
@@ -1,0 +1,50 @@
+import { jest } from '@jest/globals';
+
+describe('gear catalog sorting', () => {
+  test('orders tiers from highest (T0) to lowest (T5)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ text: async () => '' });
+
+    const realGet = document.getElementById.bind(document);
+    document.getElementById = (id) => realGet(id) || {
+      innerHTML: '',
+      value: '',
+      style: { setProperty: () => {}, getPropertyValue: () => '' },
+      classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+      setAttribute: () => {},
+      getAttribute: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      appendChild: () => {},
+      contains: () => false,
+      add: () => {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      focus: () => {},
+      click: () => {},
+      textContent: '',
+      disabled: false,
+      checked: false,
+      hidden: false
+    };
+
+    const { sortCatalogRows } = await import('../scripts/main.js');
+
+    const rows = [
+      { name: 'Gamma', tier: 'T3', type: 'Item' },
+      { name: 'Alpha', tier: 'T1', type: 'Item' },
+      { name: 'Omega', tier: 'T5', type: 'Item' },
+      { name: 'Sigma', tier: 'T0', type: 'Item' },
+      { name: 'No Tier', tier: '', type: 'Item' }
+    ];
+
+    const sorted = sortCatalogRows(rows);
+
+    expect(sorted.map(entry => entry.name)).toEqual([
+      'Sigma',
+      'Alpha',
+      'Gamma',
+      'Omega',
+      'No Tier'
+    ]);
+  });
+});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2334,7 +2334,7 @@ function sortCatalogRows(rows){
     const aHasTier = Number.isFinite(rankA);
     const bHasTier = Number.isFinite(rankB);
     if (aHasTier && bHasTier && rankA !== rankB) {
-      return rankB - rankA;
+      return rankA - rankB;
     }
     if (aHasTier !== bHasTier) {
       return aHasTier ? -1 : 1;
@@ -2344,6 +2344,8 @@ function sortCatalogRows(rows){
     return (a.type || '').localeCompare(b.type || '', 'en', { sensitivity: 'base' });
   });
 }
+
+export { tierRank, sortCatalogRows };
 
 function setCatalogFilters(filters = {}){
   if (styleSel && Object.prototype.hasOwnProperty.call(filters, 'style')) {


### PR DESCRIPTION
## Summary
- update the gear catalog sort so higher tiers (T0) appear before lower tiers (T5)
- export the tier helpers and add a regression test covering the expected order

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfda7ec7a8832e87992fc37d72078c