### PR TITLE
Improve custom item creation workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -824,6 +824,28 @@
 </div>
 </div>
 
+<div class="overlay hidden" id="modal-custom-item" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Create Custom Item</h3>
+    <p>Select the type of custom item to add.</p>
+    <div class="custom-type-grid">
+      <button class="btn-sm" type="button" data-custom-type="weapon">Weapon</button>
+      <button class="btn-sm" type="button" data-custom-type="armor">Armor</button>
+      <button class="btn-sm" type="button" data-custom-type="shield">Shield</button>
+      <button class="btn-sm" type="button" data-custom-type="utility">Utility</button>
+      <button class="btn-sm" type="button" data-custom-type="item">Item</button>
+    </div>
+    <div class="actions">
+      <button class="btn-sm" type="button" data-close>Cancel</button>
+    </div>
+  </div>
+</div>
+
 <!-- RULES -->
 <div class="overlay hidden" id="modal-rules" aria-hidden="true">
   <div class="modal modal-rules" role="dialog" aria-modal="true" aria-label="Rules Help" tabindex="-1">

--- a/styles/main.css
+++ b/styles/main.css
@@ -652,6 +652,8 @@ progress::-moz-progress-bar{
 }
 .sp-grid{display:grid;width:100%;grid-template-columns:repeat(3,1fr);gap:8px;}
 .sp-grid .btn-sm{width:100%;}
+.custom-type-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:10px;margin:12px 0;}
+.custom-type-grid .btn-sm{width:100%;}
 
 .sp-field #sp-temp{flex:0 0 60px;max-width:60px;}
 .sp-field #long-rest{width:100%;margin-top:8px;}


### PR DESCRIPTION
## Summary
- replace the prompt-based custom item flow with a modal picker and blank cards for each custom type
- persist user-defined items in the catalog while preventing empty cards when no master list selection is made
- reuse pending manual cards when catalog items are chosen and clean up unused cards when the catalog closes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfdd5721f8832e86e8820349482380