### PR TITLE
Handle catalog prices with text annotations

### DIFF
--- a/__tests__/price_parsing.test.js
+++ b/__tests__/price_parsing.test.js
@@ -1,0 +1,27 @@
+import { extractPriceValue } from '../scripts/catalog-utils.js';
+
+describe('extractPriceValue', () => {
+  test('returns numeric value for plain numbers', () => {
+    expect(extractPriceValue('1200')).toBe(1200);
+  });
+
+  test('handles currency symbols and separators', () => {
+    expect(extractPriceValue('₡1,200')).toBe(1200);
+    expect(extractPriceValue('1,200 Cr')).toBe(1200);
+  });
+
+  test('extracts the largest numeric value from mixed text', () => {
+    expect(extractPriceValue('Pack of 3 for 1,500 credits')).toBe(1500);
+    expect(extractPriceValue('Cr 3,500 (x3 bundle)')).toBe(3500);
+  });
+
+  test('supports decimal prices', () => {
+    expect(extractPriceValue('Cost: 42.5 Cr')).toBe(42.5);
+  });
+
+  test('returns null when no positive price is present', () => {
+    expect(extractPriceValue('Free item')).toBeNull();
+    expect(extractPriceValue('0')).toBeNull();
+    expect(extractPriceValue('')).toBeNull();
+  });
+});

--- a/scripts/catalog-utils.js
+++ b/scripts/catalog-utils.js
@@ -1,0 +1,23 @@
+function extractPriceValue(source) {
+  if (source == null) return null;
+  if (typeof source === 'number' && Number.isFinite(source) && source > 0) {
+    return source;
+  }
+  const text = String(source).trim();
+  if (!text) return null;
+  const matches = text.match(/\d[\d,.]*(?:\.\d+)?/g);
+  if (!matches) return null;
+  let best = null;
+  for (const rawMatch of matches) {
+    const normalized = rawMatch.replace(/,/g, '');
+    if (!normalized) continue;
+    const numeric = Number(normalized);
+    if (!Number.isFinite(numeric) || numeric <= 0) continue;
+    if (best === null || numeric > best) {
+      best = numeric;
+    }
+  }
+  return best;
+}
+
+export { extractPriceValue };

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -16,6 +16,7 @@ import {
 import { show, hide } from './modal.js';
 import { cacheCloudSaves, subscribeCloudSaves } from './storage.js';
 import { hasPin, setPin, verifyPin as verifyStoredPin, clearPin, syncPin } from './pin.js';
+import { extractPriceValue } from './catalog-utils.js';
 // Global CC object for cross-module state
 window.CC = window.CC || {};
 CC.partials = CC.partials || {};
@@ -2354,11 +2355,7 @@ function normalizeCatalogRow(row){
   if (!name) return null;
   const tier = (row.Tier || '').trim();
   const priceSource = (row.PriceCr || '').trim();
-  let price = null;
-  if (priceSource && /^[0-9.,\s]+$/.test(priceSource)) {
-    const numeric = Number(priceSource.replace(/[^0-9.]/g, ''));
-    if (Number.isFinite(numeric)) price = numeric;
-  }
+  const price = extractPriceValue(priceSource);
   const perk = (row.Perk || '').trim();
   const description = (row.Description || '').trim();
   const use = (row.Use || '').trim();
@@ -2415,10 +2412,7 @@ function getEntryPriceValue(entry){
   if (Number.isFinite(entry.price) && entry.price > 0) return entry.price;
   const raw = (entry.priceText || entry.priceRaw || '').trim();
   if (!raw) return null;
-  const normalized = raw.replace(/[,]/g, '');
-  const match = normalized.match(/(\d+(?:\.\d+)?)/);
-  if (!match) return null;
-  const numeric = Number(match[1]);
+  const numeric = extractPriceValue(raw);
   return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
 }
 
@@ -2751,7 +2745,7 @@ function sortCatalogRows(rows){
   });
 }
 
-export { tierRank, sortCatalogRows };
+export { tierRank, sortCatalogRows, extractPriceValue };
 
 function setCatalogFilters(filters = {}){
   if (styleSel && Object.prototype.hasOwnProperty.call(filters, 'style')) {


### PR DESCRIPTION
## Summary
- add a reusable `extractPriceValue` helper that finds the numeric price inside a PriceCr cell even when extra text surrounds it
- use the helper when normalizing catalog rows so price fields populate correctly
- cover the price parser with unit tests for currency symbols, bundles, decimals and empty/zero values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfe855384c832e9032dc16749412b4