### PR TITLE
Enable DM incoming shard navigation

### DIFF
--- a/__tests__/somf_dm_incoming_focus.test.js
+++ b/__tests__/somf_dm_incoming_focus.test.js
@@ -1,0 +1,92 @@
+import { jest } from '@jest/globals';
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.useRealTimers();
+  localStorage.clear();
+  sessionStorage.clear();
+  document.body.innerHTML = '';
+});
+
+const setupDom = () => {
+  document.body.innerHTML = `
+    <section id="somf-min"></section>
+    <div id="somf-min-modal" hidden></div>
+    <div id="somfDM-toasts"></div>
+    <input id="somfDM-playerCard" type="checkbox">
+    <span id="somfDM-playerCard-state"></span>
+    <div class="overlay hidden" id="modal-somf-dm" aria-hidden="true">
+      <section>
+        <button id="somfDM-close"></button>
+        <div id="somfDM-cardCount"></div>
+        <button id="somfDM-reset"></button>
+        <nav>
+          <button data-tab="cards" class="somf-dm-tabbtn"></button>
+          <button data-tab="resolve" class="somf-dm-tabbtn"></button>
+          <button data-tab="npcs" class="somf-dm-tabbtn"></button>
+          <button data-tab="items" class="somf-dm-tabbtn"></button>
+        </nav>
+        <section id="somfDM-tab-cards" class="somf-dm__tab"></section>
+        <section id="somfDM-tab-resolve" class="somf-dm__tab">
+          <ol id="somfDM-incoming"></ol>
+          <div id="somfDM-noticeView"></div>
+          <div class="somf-dm__actions">
+            <button id="somfDM-markResolved"></button>
+            <button id="somfDM-spawnNPC"></button>
+          </div>
+          <ol id="somfDM-resolveOptions"></ol>
+        </section>
+        <section id="somfDM-tab-npcs" class="somf-dm__tab">
+          <ul id="somfDM-npcList"></ul>
+        </section>
+        <section id="somfDM-tab-items" class="somf-dm__tab">
+          <ul id="somfDM-itemList"></ul>
+        </section>
+      </section>
+    </div>
+    <div id="somfDM-npcModal" class="hidden" aria-hidden="true">
+      <section id="somfDM-npcModalCard"></section>
+    </div>
+    <ol id="somfDM-notifications"></ol>
+    <audio id="somfDM-ping"></audio>
+  `;
+  if (!HTMLElement.prototype.scrollIntoView) {
+    HTMLElement.prototype.scrollIntoView = jest.fn();
+  }
+};
+
+test('clicking an incoming shard name focuses its card', async () => {
+  const notice = [{
+    key: 'focus-test',
+    ids: ['ECHO'],
+    names: ['The Echo'],
+    ts: Date.now(),
+  }];
+  localStorage.setItem('somf_notices__ccampaign-001', JSON.stringify(notice));
+
+  setupDom();
+
+  await import('../shard-of-many-fates.js');
+
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  const incomingList = document.getElementById('somfDM-incoming');
+  expect(incomingList).toBeTruthy();
+  const nameButton = incomingList.querySelector('button.somf-dm__link');
+  expect(nameButton).toBeTruthy();
+  expect(nameButton.textContent).toBe('The Echo');
+
+  nameButton.click();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  const cardsTabBtn = document.querySelector('[data-tab="cards"]');
+  const cardsTab = document.getElementById('somfDM-tab-cards');
+  expect(cardsTabBtn?.classList.contains('active')).toBe(true);
+  expect(cardsTab?.classList.contains('active')).toBe(true);
+
+  const card = document.getElementById('somfDM-card-ECHO');
+  expect(card).toBeTruthy();
+  expect(card.classList.contains('somf-dm__card--highlight')).toBe(true);
+});
+

--- a/styles/main.css
+++ b/styles/main.css
@@ -992,8 +992,14 @@ select[required]:valid{
 .somf-dm__list li{border-top:1px solid #1b2532;padding:8px 10px;cursor:pointer}
 .somf-dm__list li:first-child{border-top:none}
 .somf-dm__list li.active{background:#0b2a3a}
+.somf-dm__noticeNames{opacity:.8}
+.somf-dm__link{color:#8fc7ff;background:none;border:none;padding:0;font:inherit;cursor:pointer;text-decoration:underline}
+.somf-dm__link:hover{color:#cfe7ff}
+.somf-dm__link:focus-visible{outline:2px solid #2b9dff;outline-offset:2px}
 .somf-dm__card{border:1px solid #1b2532;border-radius:8px;background:#0b1119;padding:12px;min-height:160px}
 .somf-dm__subcard{border:1px dashed #223044;border-radius:8px;background:#0c0f13;padding:10px;margin-top:8px}
+@keyframes somf-dm-card-highlight{0%{box-shadow:0 0 0 0 rgba(43,157,255,.6)}50%{box-shadow:0 0 0 6px rgba(43,157,255,.25)}100%{box-shadow:0 0 0 0 rgba(43,157,255,0)}}
+#somfDM-tab-cards .somf-dm__card--highlight{border-color:#2b9dff!important;animation:somf-dm-card-highlight 2s ease-out}
 .somf-seeds{display:grid;gap:8px}
 .somf-seed{border:1px solid #1b2532;border-radius:8px;background:#0c1017;padding:8px}
 .somf-seed h6{margin:0 0 4px 0}


### PR DESCRIPTION
## Summary
- make shard names in the DM incoming draws list interactive and focus the matching card in the Shards List
- add styling and highlight treatment for focused shard cards
- cover the new navigation flow with a regression test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d005c0663c832e8db00faaf9d65cab