### PR TITLE
Revamp header navigation with pill-style design

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,67 @@
 
 
 <header>
-  <div class="top">
-    <span class="tabs-title"><img src="images/LOGO.PNG" alt="Catalyst Core logo" class="logo"/>Catalyst Core</span>
-    <div class="dropdown">
-      <button id="btn-menu" class="icon" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button">
+  <nav class="pill-nav top" aria-label="Primary">
+    <button class="pill-logo-button" type="button" aria-label="Toggle theme" data-no-star-border>
+      <span class="pill-logo" aria-hidden="true">
+        <img src="images/LOGO.PNG" alt="Catalyst Core logo" class="logo"/>
+      </span>
+    </button>
+    <span class="pill-brand" aria-hidden="true">Catalyst Core</span>
+    <div class="pill-nav-items tabs" role="tablist" aria-label="Primary">
+      <button class="tab active" data-go="combat" aria-label="Combat" title="Combat" role="tab" aria-current="page" type="button" data-no-star-border>
+        <span class="hover-circle" aria-hidden="true"></span>
+        <span class="pill-content">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <polyline stroke-linecap="round" stroke-linejoin="round" points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/>
+            <line stroke-linecap="round" stroke-linejoin="round" x1="13" y1="19" x2="19" y2="13"/>
+            <line stroke-linecap="round" stroke-linejoin="round" x1="16" y1="16" x2="20" y2="20"/>
+            <line stroke-linecap="round" stroke-linejoin="round" x1="19" y1="21" x2="21" y2="19"/>
+          </svg>
+          <span class="pill-label-text">Combat</span>
+        </span>
+      </button>
+      <button class="tab" data-go="abilities" aria-label="Abilities" title="Abilities" role="tab" type="button" data-no-star-border>
+        <span class="hover-circle" aria-hidden="true"></span>
+        <span class="pill-content">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9.8132 15.9038L9 18.75L8.1868 15.9038C7.75968 14.4089 6.59112 13.2403 5.09619 12.8132L2.25 12L5.09619 11.1868C6.59113 10.7597 7.75968 9.59112 8.1868 8.09619L9 5.25L9.8132 8.09619C10.2403 9.59113 11.4089 10.7597 12.9038 11.1868L15.75 12L12.9038 12.8132C11.4089 13.2403 10.2403 14.4089 9.8132 15.9038Z"/>
+            <path stroke-linecap="round" stroke-linejoin="round" d="M18.2589 8.71454L18 9.75L17.7411 8.71454C17.4388 7.50533 16.4947 6.56117 15.2855 6.25887L14.25 6L15.2855 5.74113C16.4947 5.43883 17.4388 4.49467 17.7411 3.28546L18 2.25L18.2589 3.28546C18.5612 4.49467 19.5053 5.43883 20.7145 5.74113L21.75 6L20.7145 6.25887C19.5053 6.56117 18.5612 7.50533 18.2589 8.71454Z"/>
+            <path stroke-linecap="round" stroke-linejoin="round" d="M16.8942 20.5673L16.5 21.75L16.1058 20.5673C15.8818 19.8954 15.3546 19.3682 14.6827 19.1442L13.5 18.75L14.6827 18.3558C15.3546 18.1318 15.8818 17.6046 16.1058 16.9327L16.5 15.75L16.8942 16.9327C17.1182 17.6046 17.6454 18.1318 18.3173 18.3558L19.5 18.75L18.3173 19.1442C17.6454 19.3682 17.1182 19.8954 16.8942 20.5673Z"/>
+          </svg>
+          <span class="pill-label-text">Abilities</span>
+        </span>
+      </button>
+      <button class="tab" data-go="powers" aria-label="Powers" title="Powers" role="tab" type="button" data-no-star-border>
+        <span class="hover-circle" aria-hidden="true"></span>
+        <span class="pill-content">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5L14.25 2.25L12 10.5H20.25L9.75 21.75L12 13.5H3.75Z"/>
+          </svg>
+          <span class="pill-label-text">Powers</span>
+        </span>
+      </button>
+      <button class="tab" data-go="gear" aria-label="Gear" title="Gear" role="tab" type="button" data-no-star-border>
+        <span class="hover-circle" aria-hidden="true"></span>
+        <span class="pill-content">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M20.38 3.46 16 2a4 4 0 0 1-8 0L3.62 3.46a2 2 0 0 0-1.34 2.23l.58 3.47a1 1 0 0 0 .99.84H6v10c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V10h2.15a1 1 0 0 0 .99-.84l.58-3.47a2 2 0 0 0-1.34-2.23z"/>
+          </svg>
+          <span class="pill-label-text">Gear</span>
+        </span>
+      </button>
+      <button class="tab" data-go="story" aria-label="Story" title="Story" role="tab" type="button" data-no-star-border>
+        <span class="hover-circle" aria-hidden="true"></span>
+        <span class="pill-content">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
+          </svg>
+          <span class="pill-label-text">Story</span>
+        </span>
+      </button>
+    </div>
+    <div class="dropdown pill-nav-menu">
+      <button id="btn-menu" class="pill-menu-button" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button" data-no-star-border>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15m-15 5.25h15m-15 5.25h15"/>
         </svg>
@@ -43,38 +100,6 @@
         <button id="btn-fun" class="btn-sm">Fun Tip</button>
       </div>
     </div>
-  </div>
-  <nav class="tabs" role="tablist" aria-label="Primary">
-    <button class="tab active" data-go="combat" aria-label="Combat" title="Combat" role="tab" aria-current="page" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <polyline stroke-linecap="round" stroke-linejoin="round" points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/>
-        <line stroke-linecap="round" stroke-linejoin="round" x1="13" y1="19" x2="19" y2="13"/>
-        <line stroke-linecap="round" stroke-linejoin="round" x1="16" y1="16" x2="20" y2="20"/>
-        <line stroke-linecap="round" stroke-linejoin="round" x1="19" y1="21" x2="21" y2="19"/>
-      </svg>
-    </button>
-    <button class="tab" data-go="abilities" aria-label="Abilities" title="Abilities" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9.8132 15.9038L9 18.75L8.1868 15.9038C7.75968 14.4089 6.59112 13.2403 5.09619 12.8132L2.25 12L5.09619 11.1868C6.59113 10.7597 7.75968 9.59112 8.1868 8.09619L9 5.25L9.8132 8.09619C10.2403 9.59113 11.4089 10.7597 12.9038 11.1868L15.75 12L12.9038 12.8132C11.4089 13.2403 10.2403 14.4089 9.8132 15.9038Z"/>
-        <path stroke-linecap="round" stroke-linejoin="round" d="M18.2589 8.71454L18 9.75L17.7411 8.71454C17.4388 7.50533 16.4947 6.56117 15.2855 6.25887L14.25 6L15.2855 5.74113C16.4947 5.43883 17.4388 4.49467 17.7411 3.28546L18 2.25L18.2589 3.28546C18.5612 4.49467 19.5053 5.43883 20.7145 5.74113L21.75 6L20.7145 6.25887C19.5053 6.56117 18.5612 7.50533 18.2589 8.71454Z"/>
-        <path stroke-linecap="round" stroke-linejoin="round" d="M16.8942 20.5673L16.5 21.75L16.1058 20.5673C15.8818 19.8954 15.3546 19.3682 14.6827 19.1442L13.5 18.75L14.6827 18.3558C15.3546 18.1318 15.8818 17.6046 16.1058 16.9327L16.5 15.75L16.8942 16.9327C17.1182 17.6046 17.6454 18.1318 18.3173 18.3558L19.5 18.75L18.3173 19.1442C17.6454 19.3682 17.1182 19.8954 16.8942 20.5673Z"/>
-      </svg>
-    </button>
-    <button class="tab" data-go="powers" aria-label="Powers" title="Powers" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5L14.25 2.25L12 10.5H20.25L9.75 21.75L12 13.5H3.75Z"/>
-      </svg>
-    </button>
-    <button class="tab" data-go="gear" aria-label="Gear" title="Gear" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M20.38 3.46 16 2a4 4 0 0 1-8 0L3.62 3.46a2 2 0 0 0-1.34 2.23l.58 3.47a1 1 0 0 0 .99.84H6v10c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V10h2.15a1 1 0 0 0 .99-.84l.58-3.47a2 2 0 0 0-1.34-2.23z"/>
-      </svg>
-    </button>
-    <button class="tab" data-go="story" aria-label="Story" title="Story" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
-      </svg>
-    </button>
   </nav>
 </header>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -462,12 +462,16 @@ if (btnMenu && menuActions) {
 
 /* ========= header ========= */
 const headerEl = qs('header');
+const logoButton = qs('.pill-logo-button');
 const logoEl = qs('.logo');
-if (logoEl) {
-  logoEl.addEventListener('click', e => {
-    e.stopPropagation();
-    toggleTheme();
-  });
+const onLogoClick = e => {
+  e.stopPropagation();
+  toggleTheme();
+};
+if (logoButton) {
+  logoButton.addEventListener('click', onLogoClick);
+} else if (logoEl) {
+  logoEl.addEventListener('click', onLogoClick);
 }
 
 /* ========= tabs ========= */

--- a/scripts/star-border.js
+++ b/scripts/star-border.js
@@ -10,6 +10,7 @@ function createGlow(className) {
 
 function wrapButton(button) {
   if (!(button instanceof HTMLButtonElement)) return;
+  if (button.hasAttribute('data-no-star-border')) return;
   if (button.querySelector(CONTENT_SELECTOR)) {
     button.dataset[STAR_BORDER_FLAG] = 'true';
     button.classList.add('star-border');

--- a/styles/main.css
+++ b/styles/main.css
@@ -19,71 +19,61 @@ h1,h2,h3,h4{font-family:inherit;line-height:1.25;margin:0 0 .5em}
 h1{font-size:2rem;font-weight:700;color:var(--accent)}
 h2{font-size:1.5rem;font-weight:600;color:var(--accent)}
 h3{font-size:1.25rem;font-weight:600}
-header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(4px * 1.15 + env(safe-area-inset-top)) calc(20px + env(safe-area-inset-right)) calc(4px * 1.15) calc(20px + env(safe-area-inset-left));-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;flex-direction:column;gap:calc(6px * 1.15)}
-header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(calc(-10px * 1.15))}
+header{position:sticky;top:0;z-index:20;padding:calc(8px * 1.15 + env(safe-area-inset-top)) calc(20px + env(safe-area-inset-right)) calc(8px * 1.15) calc(20px + env(safe-area-inset-left));background:var(--surface);box-shadow:var(--shadow);-webkit-backdrop-filter:blur(14px);backdrop-filter:blur(14px);display:flex;justify-content:center}
+header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(-12px)}
 .actions{display:flex;gap:calc(6px * 1.15);flex-wrap:wrap}
-.dropdown{position:relative;display:flex;align-items:center;justify-self:center;grid-column:5;margin-left:0}
-.menu{position:absolute;top:calc(100% + 4px);right:0;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50;opacity:0;transform:translateY(-10px);visibility:hidden;transition:opacity .3s ease,transform .3s ease;pointer-events:none}
-.menu.show{opacity:1;transform:translateY(0);visibility:visible;pointer-events:auto}
-.menu button{
-  background:transparent;
-  color:var(--text);
-  border:none;
-  padding:0;
-  text-align:left;
-  font-weight:400;
-  min-height:auto;
-  white-space:nowrap;
-  width:100%;
-  --star-border-radius:var(--radius);
-  --star-border-inner-bg:var(--surface-2);
-  --star-border-inner-border:1px solid var(--accent);
-  --star-border-text-color:var(--text);
-  --star-border-color:var(--accent);
-  --star-border-content-padding-y:8px;
-  --star-border-content-padding-x:12px;
-}
-.menu button .star-border__content{
-  justify-content:flex-start;
-  font-weight:400;
-  min-height:auto;
-}
-.menu button:hover .star-border__content{
-  background:var(--accent);
-  color:var(--text-on-accent);
-  filter:none;
-}
+.dropdown{position:relative;display:flex;align-items:center}
+.pill-nav{--pill-nav-height:48px;--pill-nav-gap:clamp(.35rem,1.5vw,.75rem);--pill-nav-base:var(--text);--pill-nav-pill-bg:var(--surface-2);--pill-nav-hover-bg:var(--accent);--pill-nav-text:var(--text);--pill-nav-hover-text:var(--text-on-accent);--pill-nav-ease:cubic-bezier(.4,0,.2,1);width:100%;max-width:960px;display:flex;align-items:center;gap:clamp(.6rem,2vw,1.6rem);padding:.45rem clamp(.75rem,2.5vw,1.75rem);border-radius:9999px;background:var(--surface-2);background:color-mix(in srgb,var(--surface) 65%,transparent);border:1px solid var(--line);border:1px solid color-mix(in srgb,var(--accent) 18%,transparent);box-shadow:0 18px 36px rgba(0,0,0,.28);flex-wrap:wrap}
+.theme-light .pill-nav{background:color-mix(in srgb,var(--surface) 80%,rgba(255,255,255,.9));border-color:color-mix(in srgb,var(--accent) 20%,transparent);box-shadow:0 18px 36px rgba(15,23,42,.18)}
+.theme-high .pill-nav{background:color-mix(in srgb,var(--surface) 80%,transparent);border-color:var(--text);box-shadow:none}
+.pill-logo-button{border:none;padding:0;margin:0;background:transparent;cursor:pointer;display:flex;align-items:center;justify-content:center;width:var(--pill-nav-height);height:var(--pill-nav-height)}
+.pill-logo{display:inline-flex;align-items:center;justify-content:center;width:100%;height:100%;border-radius:9999px;background:var(--pill-nav-base);box-shadow:0 10px 24px rgba(0,0,0,.35);overflow:hidden}
+.theme-light .pill-logo{box-shadow:0 12px 28px rgba(15,23,42,.22)}
+.pill-logo img{width:70%;height:70%;object-fit:contain;display:block}
+.pill-brand{font-size:clamp(1.2rem,3vw,1.9rem);font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--text);flex:0 0 auto}
+.pill-nav-items{flex:1 1 320px;display:flex;align-items:center;justify-content:center;gap:var(--pill-nav-gap);min-width:0}
+.pill-nav .tab{position:relative;border:none;background:transparent;padding:0;display:flex;align-items:center;justify-content:center;height:var(--pill-nav-height);border-radius:9999px;cursor:pointer;color:var(--pill-nav-text);transition:color .35s var(--pill-nav-ease)}
+.pill-nav .tab:focus-visible{outline:2px solid var(--accent);outline-offset:4px}
+.pill-nav .pill-content{position:relative;z-index:2;display:inline-flex;align-items:center;gap:.55rem;padding:0 clamp(.9rem,2vw,1.3rem);height:100%;border-radius:9999px;background:var(--pill-nav-pill-bg);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);color:inherit;transition:transform .35s var(--pill-nav-ease),color .35s var(--pill-nav-ease),background .35s var(--pill-nav-ease)}
+.pill-nav .hover-circle{position:absolute;inset:0;border-radius:9999px;background:var(--pill-nav-hover-bg);transform:scale(.2);opacity:0;transition:transform .35s var(--pill-nav-ease),opacity .35s var(--pill-nav-ease);z-index:1}
+.pill-nav .pill-label-text{font-size:.85rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;white-space:nowrap}
+.pill-nav .tab svg{width:1.25rem;height:1.25rem;flex-shrink:0;stroke-width:1.6}
+.pill-nav .tab:hover .hover-circle,
+.pill-nav .tab:focus-visible .hover-circle,
+.pill-nav .tab.active .hover-circle{transform:scale(1.05);opacity:1}
+.pill-nav .tab:hover .pill-content,
+.pill-nav .tab:focus-visible .pill-content,
+.pill-nav .tab.active .pill-content{color:var(--pill-nav-hover-text);background:var(--pill-nav-hover-bg);background:color-mix(in srgb,var(--pill-nav-hover-bg) 18%,transparent);transform:translateY(-1px)}
+.pill-nav .tab.active{color:var(--pill-nav-hover-text)}
+.pill-nav .tab.active::after{content:"";position:absolute;bottom:-6px;left:50%;transform:translateX(-50%);width:12px;height:12px;border-radius:50%;background:var(--pill-nav-hover-bg)}
+.pill-nav-menu{flex:0 0 auto;position:relative;display:flex;align-items:center;justify-content:center}
+.pill-menu-button{width:var(--pill-nav-height);height:var(--pill-nav-height);border-radius:9999px;border:none;display:flex;align-items:center;justify-content:center;background:var(--pill-nav-base);color:var(--surface);box-shadow:0 10px 24px rgba(0,0,0,.3);cursor:pointer}
+.theme-light .pill-menu-button{color:var(--surface);box-shadow:0 12px 28px rgba(15,23,42,.18)}
+.pill-menu-button svg{width:1.35rem;height:1.35rem;transition:transform .3s ease}
+.pill-menu-button:hover,
+.pill-menu-button:focus-visible{background:var(--pill-nav-hover-bg);color:var(--pill-nav-hover-text)}
+#btn-menu.open svg{transform:rotate(90deg)}
+.menu{position:absolute;top:calc(100% + 10px);right:0;display:flex;flex-direction:column;gap:6px;background:var(--surface-2);background:color-mix(in srgb,var(--surface) 90%,transparent);border-radius:24px;border:1px solid var(--accent);border:1px solid color-mix(in srgb,var(--accent) 30%,transparent);box-shadow:0 18px 40px rgba(0,0,0,.35);padding:12px;min-width:200px;z-index:50;opacity:0;visibility:hidden;transform:translateY(-12px);transition:opacity .3s ease,transform .3s ease,visibility .3s ease;pointer-events:none}
+.menu.show{opacity:1;visibility:visible;transform:translateY(0);pointer-events:auto}
+.menu button{background:transparent;color:var(--text);border:none;padding:0;text-align:left;font-weight:500;min-height:auto;width:100%;white-space:nowrap}
+.menu button .star-border__content{justify-content:flex-start;font-weight:500;min-height:auto;background:transparent;border:none;padding:8px 12px}
+.menu button:hover .star-border__content{background:var(--pill-nav-hover-bg);color:var(--pill-nav-hover-text);filter:none}
 .menu .btn-sm{justify-content:flex-start}
+.tabs{display:flex;align-items:center;justify-content:center;gap:var(--pill-nav-gap);flex:1;transition:opacity .4s ease,transform .4s ease}
+@media(max-width:900px){
+  .pill-nav{justify-content:center}
+  .pill-logo-button{order:-2}
+  .pill-brand{flex-basis:100%;text-align:center;order:-1}
+  .pill-nav-items{flex-basis:100%;flex-wrap:wrap;row-gap:.45rem}
+  .pill-nav-menu{order:2}
+}
 @media(max-width:600px){
+  .pill-nav{padding:.35rem clamp(.6rem,5vw,1.1rem)}
+  .pill-nav .pill-content{padding:0 .9rem}
+  .pill-nav .pill-label-text{font-size:.75rem;letter-spacing:.08em}
+  .pill-nav .tab svg{width:1.15rem;height:1.15rem}
   .actions{justify-content:center}
 }
-.icon,.tab{
-  --star-border-radius:var(--radius);
-  --star-border-inner-bg:var(--surface-2);
-  --star-border-inner-border:1px solid var(--accent);
-  --star-border-text-color:var(--accent);
-  --star-border-color:var(--accent);
-  --star-border-content-padding-y:calc(2px * 1.15);
-  --star-border-content-padding-x:calc(2px * 1.15);
-  height:calc(23px * 1.15);
-  min-height:calc(27px * 1.15);
-  width:calc(23px * 1.15 * 1.8);
-  touch-action:manipulation;
-}
-.icon .star-border__content,
-.tab .star-border__content{
-  width:100%;
-  height:100%;
-}
-.icon .star-border__content svg,
-.tab .star-border__content svg{width:calc(23px * 1.15);height:calc(23px * 1.15)}
-.modal .x .star-border__content svg{width:20px;height:20px}
-.icon svg{transition:transform .3s ease}
-#btn-menu.open svg{transform:rotate(90deg)}
-.icon:hover .star-border__content,
-.tab:hover .star-border__content{background:var(--accent);color:var(--text-on-accent);filter:none}
-.icon:active .star-border__content{transform:translateY(1px)}
-.modal .x:focus-visible,a:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 a{color:var(--accent);text-decoration:none}
 a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 .skip-link{position:absolute;left:-999px;top:auto;width:1px;height:1px;overflow:hidden;}
@@ -91,36 +81,6 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 [data-tip]{position:relative;cursor:help}
 [data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
 .breadcrumb,.breadcrumbs{display:none}
-.top{display:grid;grid-template-columns:repeat(5,1fr);align-items:center;gap:calc(6px * 1.15);position:relative}
-.tabs{display:grid;grid-template-columns:repeat(5,1fr);align-items:center;gap:calc(4px * 1.15);width:100%;transition:opacity .4s ease,transform .4s ease}
-.tabs-title{
-  padding:0 8px;
-  font-size:clamp(1.5rem,4vw,2.25rem);
-  white-space:nowrap;
-  color:var(--accent);
-  font-weight:700;
-  text-align:center;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  gap:8px;
-  grid-column:1/5;
-  position:static;
-  transform:none;
-}
-
-.tabs .tab{justify-self:center}
-
-.tabs-title .logo{
-  height:43px;
-  width:43px;
-  object-fit:contain;
-  cursor:pointer;
-}
-.theme-light .tabs-title .logo{
-  filter:invert(1);
-}
-.tab.active{background:var(--accent);color:var(--text-on-accent)}
 main{width:100%;max-width:var(--content-width);margin:16px auto;padding:0 calc(20px + env(safe-area-inset-right)) calc(4px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left))}
 fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:10px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translateX(10px);cursor:default;transition:opacity .3s ease,transform .3s ease;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);background-color:color-mix(in srgb,var(--surface) 5%,transparent)}
 main>:last-child{margin-bottom:0}


### PR DESCRIPTION
## Summary
- replace the header markup with a pill-style navigation that combines the logo, tabs, and action menu
- restyle the header and dropdown using new PillNav-inspired CSS, including responsive behavior and hover animations
- update supporting scripts so the theme toggle works on the new logo button and star-border skips the navigation buttons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d12a345b24832ebe99ad0276fbd06d