### PR TITLE
Restyle header with pill navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,58 +24,76 @@
 
 
 <header>
-  <div class="top">
-    <span class="tabs-title"><img src="images/LOGO.PNG" alt="Catalyst Core logo" class="logo"/>Catalyst Core</span>
-    <div class="dropdown">
-      <button id="btn-menu" class="icon" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15m-15 5.25h15m-15 5.25h15"/>
-        </svg>
+  <div class="pill-nav-container">
+    <nav class="pill-nav custom-nav" aria-label="Primary">
+      <button type="button" class="pill-logo" aria-label="Toggle theme">
+        <img src="images/LOGO.PNG" alt="Catalyst Core logo" class="logo"/>
       </button>
-      <div id="menu-actions" class="menu" hidden>
-        <button id="btn-load" class="btn-sm">Load / Save</button>
-        <button id="btn-view-mode" class="btn-sm" type="button" aria-pressed="false" title="Switch to View Mode">View Mode</button>
-        <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
-        <button id="btn-log" class="btn-sm">Action Log</button>
-        <button id="btn-campaign" class="btn-sm">Campaign Log</button>
-        <button id="btn-rules" class="btn-sm">Rules</button>
-        <button id="btn-help" class="btn-sm">Help</button>
-        <button id="btn-fun" class="btn-sm">Fun Tip</button>
+      <span class="brand-title">Catalyst Core</span>
+      <div class="pill-nav-items" id="nav-tabs">
+        <div class="pill-tablist" role="tablist">
+          <button class="pill tab active" data-go="combat" role="tab" aria-label="Combat" aria-current="page" type="button">
+            <span class="hover-circle" aria-hidden="true"></span>
+            <span class="label-stack">
+              <span class="pill-label">Combat</span>
+              <span class="pill-label-hover" aria-hidden="true">Combat</span>
+            </span>
+          </button>
+          <button class="pill tab" data-go="abilities" role="tab" aria-label="Abilities" type="button">
+            <span class="hover-circle" aria-hidden="true"></span>
+            <span class="label-stack">
+              <span class="pill-label">Abilities</span>
+              <span class="pill-label-hover" aria-hidden="true">Abilities</span>
+            </span>
+          </button>
+          <button class="pill tab" data-go="powers" role="tab" aria-label="Powers" type="button">
+            <span class="hover-circle" aria-hidden="true"></span>
+            <span class="label-stack">
+              <span class="pill-label">Powers</span>
+              <span class="pill-label-hover" aria-hidden="true">Powers</span>
+            </span>
+          </button>
+          <button class="pill tab" data-go="gear" role="tab" aria-label="Gear" type="button">
+            <span class="hover-circle" aria-hidden="true"></span>
+            <span class="label-stack">
+              <span class="pill-label">Gear</span>
+              <span class="pill-label-hover" aria-hidden="true">Gear</span>
+            </span>
+          </button>
+          <button class="pill tab" data-go="story" role="tab" aria-label="Story" type="button">
+            <span class="hover-circle" aria-hidden="true"></span>
+            <span class="label-stack">
+              <span class="pill-label">Story</span>
+              <span class="pill-label-hover" aria-hidden="true">Story</span>
+            </span>
+          </button>
+        </div>
       </div>
-    </div>
+      <div class="dropdown pill-menu-container">
+        <button id="btn-menu" class="pill pill-menu" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button">
+          <span class="hover-circle" aria-hidden="true"></span>
+          <span class="label-stack">
+            <span class="pill-label">Menu</span>
+            <span class="pill-label-hover" aria-hidden="true">Menu</span>
+          </span>
+        </button>
+        <div id="menu-actions" class="menu" hidden>
+          <button id="btn-load" class="btn-sm">Load / Save</button>
+          <button id="btn-view-mode" class="btn-sm" type="button" aria-pressed="false" title="Switch to View Mode">View Mode</button>
+          <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
+          <button id="btn-log" class="btn-sm">Action Log</button>
+          <button id="btn-campaign" class="btn-sm">Campaign Log</button>
+          <button id="btn-rules" class="btn-sm">Rules</button>
+          <button id="btn-help" class="btn-sm">Help</button>
+          <button id="btn-fun" class="btn-sm">Fun Tip</button>
+        </div>
+      </div>
+      <button class="mobile-menu-button" type="button" aria-label="Toggle navigation" aria-expanded="false">
+        <span class="hamburger-line"></span>
+        <span class="hamburger-line"></span>
+      </button>
+    </nav>
   </div>
-  <nav class="tabs" role="tablist" aria-label="Primary">
-    <button class="tab active" data-go="combat" aria-label="Combat" title="Combat" role="tab" aria-current="page" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <polyline stroke-linecap="round" stroke-linejoin="round" points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/>
-        <line stroke-linecap="round" stroke-linejoin="round" x1="13" y1="19" x2="19" y2="13"/>
-        <line stroke-linecap="round" stroke-linejoin="round" x1="16" y1="16" x2="20" y2="20"/>
-        <line stroke-linecap="round" stroke-linejoin="round" x1="19" y1="21" x2="21" y2="19"/>
-      </svg>
-    </button>
-    <button class="tab" data-go="abilities" aria-label="Abilities" title="Abilities" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9.8132 15.9038L9 18.75L8.1868 15.9038C7.75968 14.4089 6.59112 13.2403 5.09619 12.8132L2.25 12L5.09619 11.1868C6.59113 10.7597 7.75968 9.59112 8.1868 8.09619L9 5.25L9.8132 8.09619C10.2403 9.59113 11.4089 10.7597 12.9038 11.1868L15.75 12L12.9038 12.8132C11.4089 13.2403 10.2403 14.4089 9.8132 15.9038Z"/>
-        <path stroke-linecap="round" stroke-linejoin="round" d="M18.2589 8.71454L18 9.75L17.7411 8.71454C17.4388 7.50533 16.4947 6.56117 15.2855 6.25887L14.25 6L15.2855 5.74113C16.4947 5.43883 17.4388 4.49467 17.7411 3.28546L18 2.25L18.2589 3.28546C18.5612 4.49467 19.5053 5.43883 20.7145 5.74113L21.75 6L20.7145 6.25887C19.5053 6.56117 18.5612 7.50533 18.2589 8.71454Z"/>
-        <path stroke-linecap="round" stroke-linejoin="round" d="M16.8942 20.5673L16.5 21.75L16.1058 20.5673C15.8818 19.8954 15.3546 19.3682 14.6827 19.1442L13.5 18.75L14.6827 18.3558C15.3546 18.1318 15.8818 17.6046 16.1058 16.9327L16.5 15.75L16.8942 16.9327C17.1182 17.6046 17.6454 18.1318 18.3173 18.3558L19.5 18.75L18.3173 19.1442C17.6454 19.3682 17.1182 19.8954 16.8942 20.5673Z"/>
-      </svg>
-    </button>
-    <button class="tab" data-go="powers" aria-label="Powers" title="Powers" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5L14.25 2.25L12 10.5H20.25L9.75 21.75L12 13.5H3.75Z"/>
-      </svg>
-    </button>
-    <button class="tab" data-go="gear" aria-label="Gear" title="Gear" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M20.38 3.46 16 2a4 4 0 0 1-8 0L3.62 3.46a2 2 0 0 0-1.34 2.23l.58 3.47a1 1 0 0 0 .99.84H6v10c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V10h2.15a1 1 0 0 0 .99-.84l.58-3.47a2 2 0 0 0-1.34-2.23z"/>
-      </svg>
-    </button>
-    <button class="tab" data-go="story" aria-label="Story" title="Story" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
-      </svg>
-    </button>
-  </nav>
 </header>
 
 <main id="main">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -433,6 +433,10 @@ bindClassificationTheme('classification');
 
 const btnMenu = $('btn-menu');
 const menuActions = $('menu-actions');
+const pillNav = qs('.pill-nav');
+const pillNavItems = qs('.pill-nav-items');
+const mobileMenuButton = qs('.mobile-menu-button');
+let closeMobileMenu = () => {};
 if (btnMenu && menuActions) {
   const hideMenu = () => {
     if (!menuActions.hidden) {
@@ -460,14 +464,53 @@ if (btnMenu && menuActions) {
   });
 }
 
+if (pillNav && mobileMenuButton) {
+  const setMobileNavState = open => {
+    pillNav.classList.toggle('is-open', open);
+    mobileMenuButton.setAttribute('aria-expanded', open ? 'true' : 'false');
+    if (pillNavItems) {
+      const hidden = !open && window.innerWidth <= 768;
+      pillNavItems.setAttribute('aria-hidden', hidden ? 'true' : 'false');
+    }
+  };
+
+  closeMobileMenu = () => setMobileNavState(false);
+
+  mobileMenuButton.addEventListener('click', e => {
+    e.stopPropagation();
+    const expanded = mobileMenuButton.getAttribute('aria-expanded') === 'true';
+    setMobileNavState(!expanded);
+  });
+
+  document.addEventListener('click', e => {
+    if (!pillNav.contains(e.target)) closeMobileMenu();
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') closeMobileMenu();
+  });
+
+  window.addEventListener('resize', () => setMobileNavState(false), { passive: true });
+
+  setMobileNavState(false);
+}
+
 /* ========= header ========= */
 const headerEl = qs('header');
-const logoEl = qs('.logo');
-if (logoEl) {
-  logoEl.addEventListener('click', e => {
+const logoButton = qs('.pill-logo');
+if (logoButton) {
+  logoButton.addEventListener('click', e => {
     e.stopPropagation();
     toggleTheme();
   });
+} else {
+  const logoEl = qs('.logo');
+  if (logoEl) {
+    logoEl.addEventListener('click', e => {
+      e.stopPropagation();
+      toggleTheme();
+    });
+  }
 }
 
 /* ========= tabs ========= */
@@ -488,6 +531,7 @@ function setTab(name){
 }
 
 const switchTab = name => {
+  closeMobileMenu();
   if (headerEl && window.scrollY > 0) {
     headerEl.classList.add('hide-tabs');
     const showTabs = () => {

--- a/styles/main.css
+++ b/styles/main.css
@@ -19,27 +19,40 @@ h1,h2,h3,h4{font-family:inherit;line-height:1.25;margin:0 0 .5em}
 h1{font-size:2rem;font-weight:700;color:var(--accent)}
 h2{font-size:1.5rem;font-weight:600;color:var(--accent)}
 h3{font-size:1.25rem;font-weight:600}
-header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding:calc(4px * 1.15 + env(safe-area-inset-top)) calc(20px + env(safe-area-inset-right)) calc(4px * 1.15) calc(20px + env(safe-area-inset-left));-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;flex-direction:column;gap:calc(6px * 1.15)}
-header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(calc(-10px * 1.15))}
-.actions{display:flex;gap:calc(6px * 1.15);flex-wrap:wrap}
-.dropdown{position:relative;display:flex;align-items:center;justify-self:center;grid-column:5;margin-left:0}
-.menu{position:absolute;top:calc(100% + 4px);right:0;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50;opacity:0;transform:translateY(-10px);visibility:hidden;transition:opacity .3s ease,transform .3s ease;pointer-events:none}
+header{position:sticky;top:0;z-index:30;background:color-mix(in srgb,var(--surface) 82%,transparent);box-shadow:var(--shadow);padding:calc(8px * 1.15 + env(safe-area-inset-top)) calc(20px + env(safe-area-inset-right)) calc(8px * 1.15) calc(20px + env(safe-area-inset-left));-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);display:flex;justify-content:center;transition:var(--transition)}
+header.hide-tabs .pill-nav-items,header.hide-tabs .pill-menu-container,header.hide-tabs .mobile-menu-button{opacity:0;pointer-events:none;transform:translateY(-12px)}
+.pill-nav-container{width:100%;max-width:calc(var(--content-width) + 200px)}
+.pill-nav{--nav-h:48px;--base:var(--accent);--pill-bg:color-mix(in srgb,var(--surface) 92%,transparent);--hover-text:var(--text-on-accent);--pill-text:var(--text);width:100%;display:flex;align-items:center;gap:12px;padding:10px 16px;background:var(--base);background:color-mix(in srgb,var(--accent) 86%,var(--surface) 14%);border-radius:9999px;box-shadow:var(--shadow);flex-wrap:wrap;position:relative}
+.pill-logo{width:var(--nav-h);height:var(--nav-h);border-radius:50%;background:var(--pill-bg);border:none;padding:6px;display:inline-flex;align-items:center;justify-content:center;cursor:pointer;overflow:hidden;box-shadow:0 8px 22px rgba(0,0,0,.2)}
+.pill-logo img{width:100%;height:100%;object-fit:contain;display:block}
+.brand-title{font-size:clamp(1.3rem,3vw,2rem);font-weight:700;color:var(--hover-text);letter-spacing:.12em;text-transform:uppercase;margin:0 10px 0 8px;white-space:nowrap;display:flex;align-items:center;flex:0 0 auto}
+.pill-nav-items{flex:1;display:flex;justify-content:center;transition:opacity .3s ease,transform .3s ease}
+.pill-tablist{display:flex;align-items:center;justify-content:center;gap:8px;flex-wrap:wrap;width:100%}
+.pill{display:inline-flex;align-items:center;justify-content:center;height:var(--nav-h);padding:0 22px;border-radius:9999px;background:var(--pill-bg);color:var(--pill-text);border:1px solid color-mix(in srgb,var(--accent) 35%,transparent);font-weight:600;font-size:.875rem;letter-spacing:.16em;text-transform:uppercase;white-space:nowrap;cursor:pointer;position:relative;overflow:hidden;transition:transform .3s ease,box-shadow .3s ease,color .3s ease;touch-action:manipulation}
+.pill:active{transform:translateY(1px)}
+.pill .hover-circle{position:absolute;left:50%;top:50%;width:0;height:0;border-radius:50%;transform:translate(-50%,-50%);background:var(--accent);opacity:0;transition:width .35s ease,height .35s ease,opacity .35s ease}
+.pill .label-stack{position:relative;display:inline-flex;align-items:center;justify-content:center;gap:6px;z-index:1}
+.pill .pill-label,.pill .pill-label-hover{display:inline-flex;align-items:center;justify-content:center;line-height:1;transition:transform .35s ease,opacity .35s ease}
+.pill .pill-label-hover{position:absolute;inset:0;color:var(--hover-text);opacity:0;transform:translateY(12px)}
+.pill:hover,.pill:focus-visible{transform:translateY(-1px);box-shadow:0 12px 26px rgba(0,0,0,.25)}
+.pill:hover .hover-circle,.pill:focus-visible .hover-circle,.pill.active .hover-circle,.pill.is-active .hover-circle,#btn-menu.open .hover-circle{width:220%;height:220%;opacity:1}
+.pill:hover .pill-label,.pill:focus-visible .pill-label,.pill.active .pill-label,.pill.is-active .pill-label,#btn-menu.open .pill-label{opacity:0;transform:translateY(-12px)}
+.pill:hover .pill-label-hover,.pill:focus-visible .pill-label-hover,.pill.active .pill-label-hover,.pill.is-active .pill-label-hover,#btn-menu.open .pill-label-hover{opacity:1;transform:translateY(0)}
+.pill:focus-visible{outline:2px solid var(--hover-text);outline-offset:3px}
+.pill.tab.active{color:var(--hover-text)}
+.pill-menu-container{position:relative;display:flex;align-items:center;transition:opacity .3s ease,transform .3s ease}
+.pill-menu{min-width:120px}
+.dropdown{position:relative;display:flex;align-items:center;justify-content:center;width:auto}
+.menu{position:absolute;top:calc(100% + 10px);right:0;display:flex;flex-direction:column;background:color-mix(in srgb,var(--surface) 90%,transparent);border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);border-radius:24px;box-shadow:var(--shadow);z-index:60;opacity:0;transform:translateY(-10px);visibility:hidden;transition:opacity .3s ease,transform .3s ease;min-width:200px;max-width:min(260px,calc(100vw - 32px));backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);pointer-events:none;padding:8px}
 .menu.show{opacity:1;transform:translateY(0);visibility:visible;pointer-events:auto}
-.menu button{background:transparent;color:var(--text);border:none;padding:8px 12px;text-align:left;font-weight:400;min-height:auto;white-space:nowrap}
+.menu button{background:transparent;color:var(--text);border:none;padding:10px 14px;text-align:left;font-weight:500;min-height:auto;white-space:nowrap;border-radius:16px}
 .menu button:hover{background:var(--accent);color:var(--text-on-accent)}
 .menu .btn-sm{justify-content:flex-start}
-@media(max-width:600px){
-  .actions{justify-content:center}
-}
-.icon,.tab{padding:calc(2px * 1.15);height:calc(23px * 1.15);min-height:calc(27px * 1.15);border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition);cursor:pointer;touch-action:manipulation}
-.icon{width:calc(23px * 1.15 * 1.8)}
-.tab{width:calc(23px * 1.15 * 1.8)}
-.icon svg,.tab svg{width:calc(23px * 1.15);height:calc(23px * 1.15)}
+.mobile-menu-button{width:var(--nav-h);height:var(--nav-h);border-radius:50%;background:var(--pill-bg);border:none;display:none;flex-direction:column;align-items:center;justify-content:center;gap:6px;cursor:pointer;margin-left:auto;box-shadow:0 8px 22px rgba(0,0,0,.2);transition:opacity .3s ease,transform .3s ease,box-shadow .3s ease}
+.hamburger-line{width:18px;height:2px;background:var(--accent);border-radius:1px;transition:transform .3s ease,opacity .3s ease}
 .modal .x svg{width:20px;height:20px}
-.icon svg{transition:transform .3s ease}
-#btn-menu.open svg{transform:rotate(90deg)}
-.icon:hover,.tab:hover{background:var(--accent);color:var(--text-on-accent);transform:translateY(-1px)}
-.icon:active{transform:translateY(1px)}
+.pill-nav.is-open .hamburger-line:first-child{transform:translateY(5px) rotate(45deg)}
+.pill-nav.is-open .hamburger-line:last-child{transform:translateY(-5px) rotate(-45deg)}
 .modal .x:focus-visible,a:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 a{color:var(--accent);text-decoration:none}
 a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
@@ -48,36 +61,24 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 [data-tip]{position:relative;cursor:help}
 [data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
 .breadcrumb,.breadcrumbs{display:none}
-.top{display:grid;grid-template-columns:repeat(5,1fr);align-items:center;gap:calc(6px * 1.15);position:relative}
-.tabs{display:grid;grid-template-columns:repeat(5,1fr);align-items:center;gap:calc(4px * 1.15);width:100%;transition:opacity .4s ease,transform .4s ease}
-.tabs-title{
-  padding:0 8px;
-  font-size:clamp(1.5rem,4vw,2.25rem);
-  white-space:nowrap;
-  color:var(--accent);
-  font-weight:700;
-  text-align:center;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  gap:8px;
-  grid-column:1/5;
-  position:static;
-  transform:none;
+@media(max-width:768px){
+  header{padding:calc(6px * 1.15 + env(safe-area-inset-top)) calc(16px + env(safe-area-inset-right)) calc(10px) calc(16px + env(safe-area-inset-left))}
+  .pill-nav{gap:10px}
+  .brand-title{order:2;width:100%;justify-content:center;margin:6px 0 0;flex:0 0 100%}
+  .pill-nav-items{order:3;width:100%;display:none;opacity:1;transform:none}
+  .pill-nav.is-open .pill-nav-items{display:flex}
+  .pill-tablist{flex-direction:column;align-items:stretch;gap:10px}
+  .pill{width:100%}
+  .pill-menu-container{order:4;width:100%;display:none;opacity:1;transform:none}
+  .pill-nav.is-open .pill-menu-container{display:flex;justify-content:center}
+  .pill-menu{width:100%}
+  .mobile-menu-button{display:flex}
+  .menu{right:auto;left:0;min-width:0;width:100%}
 }
-
-.tabs .tab{justify-self:center}
-
-.tabs-title .logo{
-  height:43px;
-  width:43px;
-  object-fit:contain;
-  cursor:pointer;
+@media(max-width:600px){
+  .actions{justify-content:center}
 }
-.theme-light .tabs-title .logo{
-  filter:invert(1);
-}
-.tab.active{background:var(--accent);color:var(--text-on-accent)}
+.actions{display:flex;gap:calc(6px * 1.15);flex-wrap:wrap}
 main{width:100%;max-width:var(--content-width);margin:16px auto;padding:0 calc(20px + env(safe-area-inset-right)) calc(4px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left))}
 fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:10px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translateX(10px);cursor:default;transition:opacity .3s ease,transform .3s ease;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);background-color:color-mix(in srgb,var(--surface) 5%,transparent)}
 main>:last-child{margin-bottom:0}


### PR DESCRIPTION
## Summary
- replace the header markup with a pill navigation layout that includes the logo, brand title, tab buttons, and dropdown actions
- add pill navigation styling for desktop and mobile, including hover animations, menu popover, and responsive behavior
- update the main script to manage the new navigation structure, mobile menu toggle, and preserve theme switching via the logo

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d12d33c9f4832eb85a58f987a9e6cc