### PR TITLE
Add The Government faction to reputation tracker

### DIFF
--- a/__tests__/faction_rep.test.js
+++ b/__tests__/faction_rep.test.js
@@ -116,6 +116,47 @@ describe('faction reputation tracker', () => {
     expect(handlePerkEffects).toHaveBeenCalled();
   });
 
+  test('government faction uses custom tiers and perks', () => {
+    document.body.innerHTML = `
+      <div>
+        <progress id="government-rep-bar" max="100" value="0"></progress>
+        <span id="government-rep-tier"></span>
+        <p id="government-rep-perk"></p>
+        <button id="government-rep-gain"></button>
+        <button id="government-rep-lose"></button>
+        <input type="hidden" id="government-rep" value="295" />
+      </div>
+    `;
+    const pushHistory = jest.fn();
+    const handlePerkEffects = jest.fn();
+    window.logAction = jest.fn();
+
+    setupFactionRepTracker(handlePerkEffects, pushHistory);
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const repInput = document.getElementById('government-rep');
+    const bar = document.getElementById('government-rep-bar');
+    expect(repInput.value).toBe('295');
+    expect(bar.max).toBe(599);
+    expect(bar.getAttribute('max')).toBe('599');
+    expect(bar.value).toBe(295);
+    const tier = document.getElementById('government-rep-tier');
+    expect(tier.textContent).toBe('Neutral');
+    const perk = document.getElementById('government-rep-perk');
+    expect(perk.textContent).toContain('Baseline funding');
+    expect(handlePerkEffects).toHaveBeenCalled();
+
+    handlePerkEffects.mockClear();
+    document.getElementById('government-rep-gain').click();
+
+    expect(repInput.value).toBe('300');
+    expect(bar.value).toBe(300);
+    expect(tier.textContent).toBe('Supported');
+    expect(window.logAction).toHaveBeenCalledWith('The Government Reputation: Neutral -> Supported');
+    expect(handlePerkEffects).toHaveBeenCalled();
+    expect(pushHistory).toHaveBeenCalled();
+  });
+
   test('migrates legacy public opinion values to the new scale', () => {
     const snapshot = {
       'public-rep': '-3',

--- a/index.html
+++ b/index.html
@@ -530,6 +530,22 @@
           </div>
           <div class="faction-rep__card">
             <div class="faction-rep__header">
+              <span class="pill pill-sm">The Government</span>
+              <span id="government-rep-tier" class="pill pill-sm">Neutral</span>
+            </div>
+            <progress id="government-rep-bar" max="100" value="0"></progress>
+            <div class="inline">
+              <button id="government-rep-gain" class="btn-sm">Gain</button>
+              <button id="government-rep-lose" class="btn-sm">Lose</button>
+            </div>
+            <input type="hidden" id="government-rep" value="200"/>
+            <div class="faction-rep__perk">
+              <span class="faction-rep__perk-label">Current Perk</span>
+              <p id="government-rep-perk" class="perk"></p>
+            </div>
+          </div>
+          <div class="faction-rep__card">
+            <div class="faction-rep__header">
               <span class="pill pill-sm">Public Opinion</span>
               <span id="public-rep-tier" class="pill pill-sm">Neutral</span>
             </div>


### PR DESCRIPTION
## Summary
- add The Government faction with bespoke reputation tier descriptions
- allow faction configs to provide custom tier progressions and render the new tracker card
- cover the new faction logic with a unit test

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d27c7c324c832ebec07a5317619389