### PR TITLE
Ensure launch intro covers viewport and keep modals interactive

### DIFF
--- a/scripts/modal.js
+++ b/scripts/modal.js
@@ -1,5 +1,15 @@
 import { $, qsa } from './helpers.js';
 
+function getInertTargets() {
+  const targets = new Set();
+  qsa('body > :not(.overlay):not([data-launch-shell])').forEach(el => targets.add(el));
+  const shell = document.querySelector('[data-launch-shell]');
+  if (shell) {
+    qsa(':scope > :not(.overlay)', shell).forEach(el => targets.add(el));
+  }
+  return Array.from(targets);
+}
+
 let lastFocus = null;
 let openModals = 0;
 
@@ -57,10 +67,10 @@ export function show(id) {
   const el = $(id);
   if (!el || !el.classList.contains('hidden')) return;
   lastFocus = document.activeElement;
-    if (openModals === 0) {
-      document.body.classList.add('modal-open');
-      qsa('body > :not(.overlay)').forEach(e => e.setAttribute('inert', ''));
-    }
+  if (openModals === 0) {
+    document.body.classList.add('modal-open');
+    getInertTargets().forEach(e => e.setAttribute('inert', ''));
+  }
   openModals++;
   el.style.display = 'flex';
   el.classList.remove('hidden');
@@ -89,8 +99,8 @@ export function hide(id) {
     lastFocus.focus();
   }
   openModals = Math.max(0, openModals - 1);
-    if (openModals === 0) {
-      document.body.classList.remove('modal-open');
-      qsa('body > :not(.overlay)').forEach(e => e.removeAttribute('inert'));
-    }
+  if (openModals === 0) {
+    document.body.classList.remove('modal-open');
+    getInertTargets().forEach(e => e.removeAttribute('inert'));
+  }
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -18,7 +18,7 @@ body{min-height:100%;margin:0;background:transparent;color:var(--text);font-fami
 body.launching{overflow:hidden;height:100vh;height:100dvh}
 .app-shell{opacity:1;transition:opacity .6s ease}
 body.launching .app-shell{opacity:0}
-#launch-animation{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:0;background:var(--bg-color,#0e1117);z-index:2000;opacity:0;pointer-events:none;transition:opacity .6s ease,visibility .6s ease;visibility:hidden;min-height:100vh;min-height:100dvh}
+#launch-animation{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:0;background:var(--bg-color,#0e1117);z-index:2000;opacity:0;pointer-events:none;transition:opacity .6s ease,visibility .6s ease;visibility:hidden;width:100vw;height:100vh;height:100dvh;min-height:100vh;min-height:100dvh}
 body.launching #launch-animation{opacity:1;visibility:visible}
 #launch-animation img{width:100%;height:100%;max-width:none;max-height:none;display:block;object-fit:cover}
 ::selection{background:var(--accent);color:var(--text-on-accent)}
@@ -752,7 +752,8 @@ progress::-moz-progress-bar{
 .modal:focus{outline:none}
 .overlay.hidden .modal{transform:scale(.95);opacity:0}
 body.modal-open{overflow:hidden}
-body.modal-open> :not(.overlay){pointer-events:none;user-select:none}
+body.modal-open> :not(.overlay):not([data-launch-shell]){pointer-events:none;user-select:none}
+body.modal-open [data-launch-shell]> :not(.overlay){pointer-events:none;user-select:none}
 .modal h3{margin:0 0 4px;color:var(--accent);font-size:.9rem;line-height:1.2;font-weight:600}
 .modal .x{position:sticky;top:8px;margin-left:auto;margin-right:8px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition);z-index:2}
 .modal .x:hover{color:var(--accent)}


### PR DESCRIPTION
## Summary
- ensure the launch animation element explicitly fills the viewport for a full-screen intro
- scope modal inert and pointer-event locking to non-overlay content so touch interactions remain available

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d864b4b8ac832e96b72594704d250b