### PR TITLE
Fix launch animation background color

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -15,10 +15,10 @@ html{-webkit-text-size-adjust:100%;-moz-text-size-adjust:100%;text-size-adjust:1
 body,h1,h2,h3,h4,p,figure,blockquote,dl,dd{margin:0}
 html{height:100%;background:var(--bg);transition:var(--transition);scroll-behavior:smooth;-webkit-tap-highlight-color:transparent}
 body{min-height:100%;margin:0;background:transparent;color:var(--text);font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased;overflow-x:hidden;line-height:1.6;font-size:clamp(.95rem,2.2vw,1rem);transition:var(--transition);opacity:1;padding:0}
-body.launching{overflow:hidden;height:100vh;height:100dvh}
+body.launching{overflow:hidden;height:100vh;height:100dvh;background:#000}
 .app-shell{opacity:1;transition:opacity .6s ease}
 body.launching .app-shell{opacity:0}
-#launch-animation{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:0;background:var(--bg-color,#0e1117);z-index:2000;opacity:0;pointer-events:none;transition:opacity .6s ease,visibility .6s ease;visibility:hidden;width:100vw;height:100vh;height:100dvh;min-height:100vh;min-height:100dvh}
+#launch-animation{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:0;background:#000;z-index:2000;opacity:0;pointer-events:none;transition:opacity .6s ease,visibility .6s ease;visibility:hidden;width:100vw;height:100vh;height:100dvh;min-height:100vh;min-height:100dvh}
 body.launching #launch-animation{opacity:1;visibility:visible}
 #launch-animation img{width:100%;height:100%;max-width:none;max-height:none;display:block;object-fit:cover}
 ::selection{background:var(--accent);color:var(--text-on-accent)}


### PR DESCRIPTION
## Summary
- set the launch animation background to solid black so the GIF fills the screen
- apply the same black background to the launching body state to avoid a visible bar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d872183804832e8490418fb16aa8c7