### PR TITLE
Ensure DM notifications respect DM login state

### DIFF
--- a/__tests__/dm_notifications_dm.test.js
+++ b/__tests__/dm_notifications_dm.test.js
@@ -1,4 +1,8 @@
 import { jest } from '@jest/globals';
+import { DM_PIN } from '../scripts/dm-pin.js';
+
+const DM_NOTIFICATIONS_KEY = 'dm-notifications-log';
+const PENDING_DM_NOTIFICATIONS_KEY = 'cc:pending-dm-notifications';
 
 function setupDom() {
   document.body.innerHTML = `
@@ -15,37 +19,97 @@ function setupDom() {
   `;
 }
 
+async function initDmModule({ loggedIn = false, storedNotifications = null } = {}) {
+  jest.resetModules();
+  localStorage.clear();
+  sessionStorage.clear();
+  if (storedNotifications) {
+    sessionStorage.setItem(DM_NOTIFICATIONS_KEY, JSON.stringify(storedNotifications));
+  }
+  if (!window.matchMedia) {
+    window.matchMedia = () => ({ matches: false, addListener: () => {}, removeListener: () => {} });
+  }
+
+  const listCharacters = jest.fn(async () => []);
+  const currentCharacter = jest.fn(() => null);
+  const setCurrentCharacter = jest.fn();
+  const loadCharacter = jest.fn(async () => ({}));
+  const show = jest.fn();
+  const hide = jest.fn();
+  jest.unstable_mockModule('../scripts/modal.js', () => ({
+    show,
+    hide,
+  }));
+  jest.unstable_mockModule('../scripts/characters.js', () => ({
+    listCharacters,
+    currentCharacter,
+    setCurrentCharacter,
+    loadCharacter,
+  }));
+
+  setupDom();
+  global.toast = jest.fn();
+  global.dismissToast = jest.fn();
+
+  await import('../scripts/dm.js');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+
+  if (loggedIn) {
+    await completeLogin();
+  }
+}
+
+async function completeLogin() {
+  const loginPromise = window.dmRequireLogin();
+  const pinInput = document.getElementById('dm-login-pin');
+  pinInput.value = DM_PIN;
+  const submit = document.getElementById('dm-login-submit');
+  submit.dispatchEvent(new Event('click'));
+  await loginPromise;
+}
+
 describe('dmNotify labels actions as DM when logged in', () => {
   beforeEach(async () => {
-    jest.resetModules();
-    localStorage.clear();
-    sessionStorage.clear();
-    if (!window.matchMedia) {
-      window.matchMedia = () => ({ matches: false, addListener: () => {}, removeListener: () => {} });
-    }
-
-    const listCharacters = jest.fn(async () => []);
-    const currentCharacter = jest.fn(() => null);
-    const setCurrentCharacter = jest.fn();
-    const loadCharacter = jest.fn(async () => ({}));
-    jest.unstable_mockModule('../scripts/characters.js', () => ({
-      listCharacters,
-      currentCharacter,
-      setCurrentCharacter,
-      loadCharacter,
-    }));
-
-    setupDom();
-
-    await import('../scripts/dm.js');
-    document.dispatchEvent(new Event('DOMContentLoaded'));
-    sessionStorage.setItem('dmLoggedIn', '1');
+    await initDmModule({ loggedIn: true });
   });
 
   test('uses DM tag', () => {
     window.dmNotify('testing');
     const list = document.getElementById('dm-notifications-list');
     expect(list.textContent).toContain('DM: testing');
+  });
+});
+
+describe('DM notifications visibility', () => {
+  test('does not render notifications when logged out', async () => {
+    await initDmModule();
+    const list = document.getElementById('dm-notifications-list');
+    window.dmNotify('testing visibility');
+    expect(list.textContent).toBe('');
+    const raw = sessionStorage.getItem(PENDING_DM_NOTIFICATIONS_KEY);
+    const pending = raw ? JSON.parse(raw) : [];
+    expect(pending).toHaveLength(1);
+  });
+
+  test('renders stored and pending notifications after login', async () => {
+    const stored = [{ ts: '2025-01-01 00:00', char: 'System', detail: 'Stored entry' }];
+    await initDmModule({ storedNotifications: stored });
+    const list = document.getElementById('dm-notifications-list');
+    expect(list.textContent).toBe('');
+
+    window.dmNotify('Queued while logged out');
+    let pending = JSON.parse(sessionStorage.getItem(PENDING_DM_NOTIFICATIONS_KEY));
+    expect(pending).toHaveLength(1);
+
+    await completeLogin();
+
+    pending = JSON.parse(sessionStorage.getItem(PENDING_DM_NOTIFICATIONS_KEY) || '[]');
+    expect(pending).toHaveLength(0);
+    expect(list.textContent).toContain('System: Stored entry');
+    expect(list.textContent).toContain('Queued while logged out');
+
+    const dmBtn = document.getElementById('dm-login');
+    expect(dmBtn.style.opacity).toBe('1');
   });
 });
 


### PR DESCRIPTION
## Summary
- hide DM notifications and queue them when the DM is not logged in, only rendering once authenticated
- refresh button visibility and notification display when login status changes
- expand dm notification tests to cover hidden state, queued delivery, and login helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9723777c4832ebd96353a3e032feb