### PR TITLE
Restrict DM tools visibility to authorized device

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ configure the database:
 
 The application communicates with the database using its public REST API.
 
+## DM tools access
+
+The DM tools are protected by a shared PIN defined in `scripts/dm-pin.js`. You
+can further restrict access so the tools only appear on a single device by
+setting `DM_DEVICE_FINGERPRINT` in the same file. To generate the fingerprint
+string, open the site on the allowed device and run
+`window.computeDmDeviceFingerprint()` in the browser console. Copy the returned
+value into `DM_DEVICE_FINGERPRINT`. The DM tools menu will be hidden on devices
+whose fingerprint does not match.
+

--- a/scripts/dm-pin.js
+++ b/scripts/dm-pin.js
@@ -1,2 +1,9 @@
 // Shared DM PIN used for authentication and character protection
 export const DM_PIN = '123123';
+
+// Optional device fingerprint used to hide DM tools on unauthorized devices.
+// Leave this empty to allow any device with the DM PIN to see the tools.
+// To restrict the tools to a single device, compute the fingerprint using
+// `window.computeDmDeviceFingerprint()` in the browser console and copy the
+// resulting string here.
+export const DM_DEVICE_FINGERPRINT = '';


### PR DESCRIPTION
## Summary
- add an optional device fingerprint check before rendering the DM tools
- expose a helper to compute the fingerprint and document how to configure it
- remove DM UI elements when the current device is not authorized

## Testing
- npm test -- --runTestsByPath __tests__/dm_login.test.js
- npm test -- --runTestsByPath __tests__/dm_character_tool.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9782eb848832e957dfcad92d8a24e