### PR TITLE
Enhance launch animation, tab navigation, and fun tip display

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 <noscript>This app requires JavaScript to run properly.</noscript>
 
 <div id="launch-animation" role="presentation" aria-hidden="true">
-  <img src="images/IMG_4848.gif" alt="" loading="eager" decoding="async"/>
+  <video src="images/b02fb7b3-095b-4e40-9e4e-20fb5ee3b4b9.mp4" autoplay muted loop playsinline preload="auto"></video>
 </div>
 
 <div class="app-shell" data-launch-shell>
@@ -81,6 +81,13 @@
       </svg>
     </button>
   </nav>
+  <div class="news-ticker" role="status" aria-live="polite">
+    <div class="news-ticker__inner">
+      <div class="news-ticker__track" data-fun-ticker-track>
+        <span class="news-ticker__text" data-fun-ticker-text>Loading fun tips…</span>
+      </div>
+    </div>
+  </div>
 </header>
 
 <main id="main">

--- a/styles/main.css
+++ b/styles/main.css
@@ -20,7 +20,7 @@ body.launching{overflow:hidden;height:100vh;height:100dvh;background:#000}
 body.launching .app-shell{opacity:0}
 #launch-animation{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:0;background:#000;z-index:2000;opacity:0;pointer-events:none;transition:opacity .6s ease,visibility .6s ease;visibility:hidden;width:100vw;height:100vh;height:100dvh;min-height:100vh;min-height:100dvh}
 body.launching #launch-animation{opacity:1;visibility:visible}
-#launch-animation img{width:100%;height:100%;max-width:none;max-height:none;display:block;object-fit:cover}
+#launch-animation video{width:100%;height:100%;max-width:none;max-height:none;display:block;object-fit:cover}
 ::selection{background:var(--accent);color:var(--text-on-accent)}
 h1,h2,h3,h4{font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;line-height:1.25;margin:0 0 .5em}
 h1{font-size:clamp(1.75rem,4.6vw,2rem);font-weight:700;color:var(--accent)}
@@ -153,6 +153,11 @@ label[data-animate-title]{
   filter:invert(1);
 }
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
+.news-ticker{position:relative;overflow:hidden;background:color-mix(in srgb,var(--surface) 70%,transparent);border:1px solid color-mix(in srgb,var(--accent) 80%,transparent);border-radius:calc(var(--radius) - 4px);box-shadow:var(--shadow);min-height:36px}
+.news-ticker__inner{display:flex;align-items:center;width:100%;height:100%}
+.news-ticker__track{display:inline-flex;align-items:center;gap:12px;padding:6px 18px;white-space:nowrap;animation:ticker-scroll 5s linear infinite}
+.news-ticker__text{font-weight:600;letter-spacing:.04em;text-transform:uppercase;font-size:.75rem;color:var(--accent)}
+@keyframes ticker-scroll{from{transform:translate3d(100%,0,0)}to{transform:translate3d(-100%,0,0)}}
 main{width:100%;max-width:var(--content-width);margin:16px auto;padding:0 calc(20px + env(safe-area-inset-right)) calc(4px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left))}
 fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:10px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translateX(10px);cursor:default;transition:opacity .3s ease,transform .3s ease;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);background-color:color-mix(in srgb,var(--surface) 5%,transparent)}
 main>:last-child{margin-bottom:0}
@@ -176,6 +181,15 @@ footer p{
   margin-left:auto;
   margin-right:auto;
 }
+.tab-swipe-indicator{--swipe-offset:28px;position:fixed;top:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;padding:16px;border-radius:var(--radius);background:color-mix(in srgb,var(--surface) 85%,transparent);border:1px solid color-mix(in srgb,var(--accent) 70%,transparent);box-shadow:var(--shadow);pointer-events:none;opacity:0;transform:translate3d(0,-50%,0);transition:opacity .2s ease,transform .2s ease;z-index:40}
+.tab-swipe-indicator.show{opacity:.95}
+.tab-swipe-indicator[data-direction="left"]{left:16px}
+.tab-swipe-indicator[data-direction="right"]{right:16px}
+.tab-swipe-indicator[data-direction="left"].show{transform:translate3d(calc(-1 * var(--swipe-offset)), -50%, 0)}
+.tab-swipe-indicator[data-direction="right"].show{transform:translate3d(var(--swipe-offset), -50%, 0)}
+.tab-swipe-icon{display:flex;align-items:center;justify-content:center}
+.tab-swipe-icon svg{width:42px;height:42px}
+.tab-swipe-label{font-size:.75rem;letter-spacing:.08em;text-transform:uppercase;color:var(--text);text-align:center}
 .grid{display:grid;gap:12px}
 .grid-1{grid-template-columns:1fr}
 .grid-2{grid-template-columns:1fr}


### PR DESCRIPTION
## Summary
- replace the launch GIF with a muted, looping full-screen MP4 intro video
- add a sticky fun-tip news ticker beneath the header that rotates messages every three scroll cycles
- enable swipe gestures between tabs with directional icon indicators for the destination tab

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d985dd0d50832e8551f4c8c3f6514e