### PR TITLE
Update news ticker layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,8 +81,9 @@
       </svg>
     </button>
   </nav>
-  <div class="news-ticker" role="status" aria-live="polite">
+  <div class="news-ticker" role="status" aria-live="polite" aria-labelledby="news-ticker-label">
     <div class="news-ticker__inner">
+      <span class="news-ticker__label" id="news-ticker-label">O.M.N.I Tip</span>
       <div class="news-ticker__track" data-fun-ticker-track>
         <span class="news-ticker__text" data-fun-ticker-text>Loading fun tips…</span>
       </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -153,11 +153,12 @@ label[data-animate-title]{
   filter:invert(1);
 }
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
-.news-ticker{position:relative;overflow:hidden;background:color-mix(in srgb,var(--surface) 70%,transparent);border:1px solid color-mix(in srgb,var(--accent) 80%,transparent);border-radius:calc(var(--radius) - 4px);box-shadow:var(--shadow);min-height:36px}
-.news-ticker__inner{display:flex;align-items:center;width:100%;height:100%}
-.news-ticker__track{display:inline-flex;align-items:center;gap:12px;padding:6px 18px;white-space:nowrap;animation:ticker-scroll 5s linear infinite}
+.news-ticker{position:relative;overflow:hidden;background:color-mix(in srgb,var(--surface) 70%,transparent);border:1px solid color-mix(in srgb,var(--accent) 80%,transparent);border-radius:calc(var(--radius) - 4px);box-shadow:var(--shadow);min-height:36px;width:100vw;margin-inline:calc(50% - 50vw)}
+.news-ticker__inner{display:flex;align-items:center;width:100%;height:100%;gap:12px;padding-block:6px;padding-inline:18px;padding-inline:calc(18px + env(safe-area-inset-left)) calc(18px + env(safe-area-inset-right))}
+.news-ticker__label{display:inline-flex;align-items:center;justify-content:center;padding:4px 12px;border-radius:999px;background:var(--accent);color:var(--text-on-accent);font-weight:700;letter-spacing:.08em;text-transform:uppercase;font-size:.75rem;white-space:nowrap}
+.news-ticker__track{--ticker-gap:clamp(64px,20vw,280px);display:inline-flex;align-items:center;gap:12px;white-space:nowrap;animation:ticker-scroll var(--ticker-duration,12s) linear infinite;will-change:transform;flex:1 0 auto;min-width:100%}
 .news-ticker__text{font-weight:600;letter-spacing:.04em;text-transform:uppercase;font-size:.75rem;color:var(--accent)}
-@keyframes ticker-scroll{from{transform:translate3d(100%,0,0)}to{transform:translate3d(-100%,0,0)}}
+@keyframes ticker-scroll{from{transform:translate3d(100%,0,0)}to{transform:translate3d(calc(-100% - var(--ticker-gap)),0,0)}}
 main{width:100%;max-width:var(--content-width);margin:16px auto;padding:0 calc(20px + env(safe-area-inset-right)) calc(4px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left))}
 fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:10px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translateX(10px);cursor:default;transition:opacity .3s ease,transform .3s ease;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);background-color:color-mix(in srgb,var(--surface) 5%,transparent)}
 main>:last-child{margin-bottom:0}


### PR DESCRIPTION
## Summary
- expand the news ticker to span the full viewport beneath the header and add an "O.M.N.I Tip" label
- tweak ticker animation spacing so the scroll does not restart until the current message fully exits the screen

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d98fcbe520832ea427c5cbd78e03ef