### PR TITLE
Style news ticker with pennant overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,10 @@
   </nav>
   <div class="news-ticker" role="status" aria-live="polite" aria-labelledby="news-ticker-label">
     <div class="news-ticker__inner">
-      <span class="news-ticker__label" id="news-ticker-label">O.M.N.I Tip</span>
+      <span class="news-ticker__label" id="news-ticker-label">
+        <span class="news-ticker__label-line">O.M.N.I</span>
+        <span class="news-ticker__label-line">TIP</span>
+      </span>
       <div class="news-ticker__track" data-fun-ticker-track>
         <span class="news-ticker__text" data-fun-ticker-text>Loading fun tips…</span>
       </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -153,11 +153,95 @@ label[data-animate-title]{
   filter:invert(1);
 }
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
-.news-ticker{position:relative;overflow:hidden;background:color-mix(in srgb,var(--surface) 70%,transparent);border:1px solid color-mix(in srgb,var(--accent) 80%,transparent);border-radius:calc(var(--radius) - 4px);box-shadow:var(--shadow);min-height:36px;width:100vw;margin-inline:calc(50% - 50vw)}
-.news-ticker__inner{display:flex;align-items:center;width:100%;height:100%;gap:12px;padding-block:6px;padding-inline:18px;padding-inline:calc(18px + env(safe-area-inset-left)) calc(18px + env(safe-area-inset-right))}
-.news-ticker__label{display:inline-flex;align-items:center;justify-content:center;padding:4px 12px;border-radius:999px;background:var(--accent);color:var(--text-on-accent);font-weight:700;letter-spacing:.08em;text-transform:uppercase;font-size:.75rem;white-space:nowrap}
-.news-ticker__track{--ticker-gap:clamp(64px,20vw,280px);display:inline-flex;align-items:center;gap:12px;white-space:nowrap;animation:ticker-scroll var(--ticker-duration,12s) linear infinite;will-change:transform;flex:1 0 auto;min-width:100%}
-.news-ticker__text{font-weight:600;letter-spacing:.04em;text-transform:uppercase;font-size:.75rem;color:var(--accent)}
+.news-ticker{
+  --pennant-width:clamp(96px,20vw,180px);
+  position:relative;
+  overflow:hidden;
+  background:color-mix(in srgb,var(--surface) 92%, transparent);
+  border-top:2px solid var(--accent);
+  border-bottom:2px solid var(--accent);
+  border-left:2px solid var(--accent);
+  width:100vw;
+  margin-inline:calc(50% - 50vw);
+  min-height:48px;
+}
+.news-ticker::after{
+  content:"";
+  position:absolute;
+  inset:0 0 0 auto;
+  width:var(--pennant-width);
+  background:var(--accent);
+  clip-path:polygon(24% 0,100% 0,100% 100%,24% 100%,0 50%);
+  z-index:2;
+  pointer-events:none;
+}
+.news-ticker::before{
+  content:"\2190";
+  position:absolute;
+  right:clamp(32px,8vw,60px);
+  top:50%;
+  transform:translate3d(0,-50%,0);
+  color:var(--text-on-accent);
+  font-size:1.35rem;
+  font-weight:700;
+  letter-spacing:.08em;
+  z-index:3;
+  pointer-events:none;
+}
+.news-ticker__inner{
+  position:relative;
+  display:flex;
+  align-items:stretch;
+  gap:18px;
+  width:100%;
+  height:100%;
+  padding-block:6px;
+  padding-left:calc(18px + env(safe-area-inset-left));
+  padding-right:calc(var(--pennant-width) + 24px + env(safe-area-inset-right));
+}
+.news-ticker__label{
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:center;
+  gap:2px;
+  padding-inline:12px;
+  border-right:2px solid var(--accent);
+  color:var(--accent);
+  font-weight:700;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+  font-size:.7rem;
+  line-height:1;
+  min-width:82px;
+  flex:0 0 auto;
+}
+.news-ticker__label-line{
+  display:block;
+}
+.news-ticker__label-line:last-child{
+  letter-spacing:.24em;
+}
+.news-ticker__track{
+  --ticker-gap:clamp(64px,20vw,280px);
+  display:inline-flex;
+  align-items:center;
+  gap:18px;
+  white-space:nowrap;
+  animation:ticker-scroll var(--ticker-duration,12s) linear infinite;
+  will-change:transform;
+  flex:1 1 auto;
+  min-width:100%;
+  position:relative;
+  z-index:1;
+}
+.news-ticker__text{
+  font-weight:600;
+  letter-spacing:.1em;
+  text-transform:uppercase;
+  font-size:.78rem;
+  color:var(--accent);
+}
 @keyframes ticker-scroll{from{transform:translate3d(100%,0,0)}to{transform:translate3d(calc(-100% - var(--ticker-gap)),0,0)}}
 main{width:100%;max-width:var(--content-width);margin:16px auto;padding:0 calc(20px + env(safe-area-inset-right)) calc(4px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left))}
 fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:10px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translateX(10px);cursor:default;transition:opacity .3s ease,transform .3s ease;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);background-color:color-mix(in srgb,var(--surface) 5%,transparent)}


### PR DESCRIPTION
## Summary
- restyle the news ticker to add a pennant endcap that the scrolling text slides behind
- update the ticker label markup to stack O.M.N.I and TIP vertically within the bordered mast

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d995971bbc832e937018d4169a8b7c