### PR TITLE
Replace ticker pennant text with logo

### DIFF
--- a/images/omni-pennant-logo.svg
+++ b/images/omni-pennant-logo.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-hidden="true">
+  <defs>
+    <linearGradient id="omniGradient" x1="20" y1="10" x2="140" y2="140" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f7f8fb"/>
+      <stop offset="1" stop-color="#cdd4dc"/>
+    </linearGradient>
+    <linearGradient id="wingGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#e4e8ef"/>
+      <stop offset="1" stop-color="#b7c1cc"/>
+    </linearGradient>
+  </defs>
+  <circle cx="80" cy="80" r="74" fill="url(#omniGradient)" stroke="#7f8a98" stroke-width="4"/>
+  <circle cx="80" cy="80" r="58" fill="#0f1a24"/>
+  <circle cx="80" cy="80" r="50" fill="#111c26" stroke="#c1cad4" stroke-width="4"/>
+  <path d="M80 42c11 0 20 9 20 20v6H60v-6c0-11 9-20 20-20Z" fill="#d7dde4"/>
+  <path d="M80 38c-13.255 0-24 10.745-24 24v8h48v-8c0-13.255-10.745-24-24-24Zm16 28H64v-4c0-8.837 7.163-16 16-16s16 7.163 16 16v4Z" fill="#2b353f"/>
+  <g fill="url(#wingGradient)" stroke="#6f7c8a" stroke-width="2" stroke-linejoin="round">
+    <path d="M26 84h48l-10 18H20l6-18Z"/>
+    <path d="M38 66h32l-8 18H30l8-18Z"/>
+    <path d="M48 52h20l-6 14H42l6-14Z"/>
+    <path d="M134 84h-48l10 18h44l-6-18Z"/>
+    <path d="M122 66H90l8 18h32l-8-18Z"/>
+    <path d="M112 52H92l6 14h20l-6-14Z"/>
+  </g>
+  <path d="M80 62c-8.837 0-16 7.163-16 16v24h32V78c0-8.837-7.163-16-16-16Z" fill="#0f1a24" stroke="#c1cad4" stroke-width="4"/>
+  <path d="M68 118h24l-12 16-12-16Z" fill="#c1cad4" stroke="#2b353f" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M80 112c13.807 0 25-11.193 25-25H55c0 13.807 11.193 25 25 25Z" fill="#d7dde4" stroke="#2b353f" stroke-width="2"/>
+  <text x="80" y="88" text-anchor="middle" font-family="'CFTechnoMania Slanted','Inter',sans-serif" font-size="20" fill="#111c26" letter-spacing="10">OMNI</text>
+  <text x="80" y="128" text-anchor="middle" font-family="'Inter',sans-serif" font-size="7" fill="#1a242e" letter-spacing="3">BALANCE IN DESIGN</text>
+  <text x="80" y="40" text-anchor="middle" font-family="'Inter',sans-serif" font-size="7" fill="#1a242e" letter-spacing="2">POWER WITH PERMISSION</text>
+  <path d="M80 18a62 62 0 1 1 0 124 62 62 0 0 1 0-124Zm0 6a56 56 0 1 0 0 112 56 56 0 0 0 0-112Z" fill="#b4bdc7"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -84,8 +84,10 @@
   <div class="news-ticker" role="status" aria-live="polite" aria-labelledby="news-ticker-label">
     <div class="news-ticker__inner">
       <span class="news-ticker__label" id="news-ticker-label">
-        <span class="news-ticker__logo">O.M.N.I</span>
-        <span class="news-ticker__logo-sub">Tip</span>
+        <span class="news-ticker__logo" aria-hidden="true">
+          <img src="images/omni-pennant-logo.svg" alt="" role="presentation"/>
+        </span>
+        <span class="sr-only">O.M.N.I tip ticker</span>
       </span>
       <div class="news-ticker__track" data-fun-ticker-track>
         <span class="news-ticker__text" data-fun-ticker-text>Loading fun tips…</span>

--- a/styles/main.css
+++ b/styles/main.css
@@ -154,8 +154,8 @@ label[data-animate-title]{
 }
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 .news-ticker{
-  --pennant-width:clamp(148px,28vw,236px);
-  --pennant-point:clamp(34px,8vw,56px);
+  --pennant-width:clamp(168px,32vw,260px);
+  --pennant-point:clamp(36px,8.6vw,60px);
   --pennant-gap:clamp(18px,4.4vw,32px);
   --pennant-overlap:calc(var(--pennant-point) + var(--pennant-gap));
   position:relative;
@@ -174,7 +174,7 @@ label[data-animate-title]{
   position:absolute;
   inset:0 auto 0 0;
   width:calc(var(--pennant-width) + var(--pennant-overlap));
-  background:linear-gradient(90deg,color-mix(in srgb,var(--surface) 96%, transparent) 0%,color-mix(in srgb,var(--surface) 88%, transparent) 48%,transparent 78%);
+  background:linear-gradient(90deg,color-mix(in srgb,var(--surface) 96%, transparent) 0%,color-mix(in srgb,var(--surface) 82%, transparent) 42%,transparent 75%);
   pointer-events:none;
   z-index:1;
 }
@@ -190,10 +190,8 @@ label[data-animate-title]{
 .news-ticker__label{
   position:relative;
   display:flex;
-  flex-direction:column;
   justify-content:center;
   align-items:center;
-  gap:2px;
   min-width:var(--pennant-width);
   padding-block:clamp(8px,2.4vw,14px);
   padding-left:calc(clamp(18px,4.8vw,32px) + env(safe-area-inset-left));
@@ -216,15 +214,16 @@ label[data-animate-title]{
   opacity:.24;
 }
 .news-ticker__logo{
-  font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;
-  font-size:clamp(.92rem,3.2vw,1.45rem);
-  letter-spacing:.38em;
-  line-height:1;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:clamp(76px,15vw,118px);
 }
-.news-ticker__logo-sub{
-  font-size:clamp(.58rem,1.8vw,.78rem);
-  letter-spacing:.54em;
-  line-height:1;
+
+.news-ticker__logo img{
+  display:block;
+  width:100%;
+  height:auto;
 }
 .news-ticker__track{
   --ticker-gap:clamp(64px,20vw,280px);
@@ -236,10 +235,10 @@ label[data-animate-title]{
   white-space:nowrap;
   animation:ticker-scroll var(--ticker-duration,12s) linear infinite;
   will-change:transform;
-  margin-left:calc(-1 * (var(--pennant-overlap) - clamp(14px,3.8vw,24px)));
-  padding-left:calc(var(--pennant-overlap) + clamp(8px,2.2vw,14px));
+  margin-left:calc(-1 * (var(--pennant-overlap) - clamp(12px,3.4vw,22px)));
+  padding-left:calc(var(--pennant-overlap) + clamp(14px,3.6vw,24px));
   min-width:100%;
-  z-index:2;
+  z-index:0;
 }
 .news-ticker__text{
   font-weight:600;


### PR DESCRIPTION
## Summary
- swap the ticker pennant text for an inline O.M.N.I logo image so only the emblem shows inside the pennant
- adjust ticker logo styling to center and scale the artwork while keeping the track text layered behind
- add a reusable vector version of the O.M.N.I emblem for the ticker

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a4a391cc832e9cd849b281252110