### PR TITLE
Adjust news ticker pennant and logo sizing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -154,9 +154,9 @@ label[data-animate-title]{
 }
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 .news-ticker{
-  --pennant-width:clamp(160px,30vw,240px);
-  --pennant-point:clamp(26px,6.4vw,44px);
-  --pennant-gap:clamp(14px,3.6vw,26px);
+  --pennant-width:clamp(120px,24vw,180px);
+  --pennant-point:clamp(22px,5vw,36px);
+  --pennant-gap:clamp(12px,3vw,20px);
   --pennant-overlap:calc(var(--pennant-point) + var(--pennant-gap));
   position:relative;
   overflow:hidden;
@@ -220,7 +220,7 @@ label[data-animate-title]{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  width:clamp(60px,12vw,90px);
+  width:clamp(72px,14vw,110px);
   height:calc(100% - 8px);
   color:var(--text-on-accent);
   flex:0 0 auto;


### PR DESCRIPTION
## Summary
- reduce the news ticker pennant width and point variables so the banner appears slimmer
- enlarge the news ticker logo width clamp so the graphic fills the pennant more comfortably

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9c32113e4832ebca8e45e61b2dbf1