### PR TITLE
Adjust news ticker pennant and launch animation layout

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -18,9 +18,9 @@ body{min-height:100%;margin:0;background:transparent;color:var(--text);font-fami
 body.launching{overflow:hidden;height:100vh;height:100dvh;background:#000}
 .app-shell{opacity:1;transition:opacity .6s ease}
 body.launching .app-shell{opacity:0}
-#launch-animation{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:constant(safe-area-inset-top) constant(safe-area-inset-right) constant(safe-area-inset-bottom) constant(safe-area-inset-left);padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);background:#000;z-index:2000;opacity:0;pointer-events:none;transition:opacity .6s ease,visibility .6s ease;visibility:hidden;width:100vw;height:100vh;height:100dvh;min-height:100vh;min-height:100dvh;box-sizing:border-box}
+#launch-animation{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:0;background:#000;z-index:2000;opacity:0;pointer-events:none;transition:opacity .6s ease,visibility .6s ease;visibility:hidden;width:100vw;height:100vh;height:100dvh;min-height:100vh;min-height:100dvh;box-sizing:border-box}
 body.launching #launch-animation{opacity:1;visibility:visible}
-#launch-animation video{width:100%;height:100%;max-width:none;max-height:none;display:block;object-fit:cover}
+#launch-animation video{width:calc(100% + constant(safe-area-inset-left) + constant(safe-area-inset-right));height:calc(100% + constant(safe-area-inset-top) + constant(safe-area-inset-bottom));margin-left:calc(-1 * constant(safe-area-inset-left));margin-right:calc(-1 * constant(safe-area-inset-right));margin-top:calc(-1 * constant(safe-area-inset-top));margin-bottom:calc(-1 * constant(safe-area-inset-bottom));width:calc(100% + env(safe-area-inset-left) + env(safe-area-inset-right));height:calc(100% + env(safe-area-inset-top) + env(safe-area-inset-bottom));margin-left:calc(-1 * env(safe-area-inset-left));margin-right:calc(-1 * env(safe-area-inset-right));margin-top:calc(-1 * env(safe-area-inset-top));margin-bottom:calc(-1 * env(safe-area-inset-bottom));max-width:none;max-height:none;display:block;object-fit:cover}
 ::selection{background:var(--accent);color:var(--text-on-accent)}
 h1,h2,h3,h4{font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;line-height:1.25;margin:0 0 .5em}
 h1{font-size:clamp(1.75rem,4.6vw,2rem);font-weight:700;color:var(--accent)}
@@ -154,9 +154,9 @@ label[data-animate-title]{
 }
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 .news-ticker{
-  --pennant-width:clamp(120px,24vw,180px);
-  --pennant-point:clamp(22px,5vw,36px);
-  --pennant-gap:clamp(12px,3vw,20px);
+  --pennant-width:clamp(100px,20vw,150px);
+  --pennant-point:clamp(18px,4vw,30px);
+  --pennant-gap:clamp(10px,2.6vw,18px);
   --pennant-overlap:calc(var(--pennant-point) + var(--pennant-gap));
   position:relative;
   overflow:hidden;
@@ -197,7 +197,7 @@ label[data-animate-title]{
   min-width:var(--pennant-width);
   height:100%;
   padding-block:0;
-  padding-left:calc(clamp(18px,4.8vw,32px) + env(safe-area-inset-left));
+  padding-left:calc(clamp(14px,3.8vw,24px) + env(safe-area-inset-left));
   padding-right:calc(var(--pennant-overlap) + clamp(10px,2.8vw,16px));
   background:var(--accent);
   color:var(--text-on-accent);
@@ -220,8 +220,8 @@ label[data-animate-title]{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  width:clamp(72px,14vw,110px);
-  height:calc(100% - 8px);
+  width:clamp(82px,17vw,120px);
+  height:calc(100% - 6px);
   color:var(--text-on-accent);
   flex:0 0 auto;
 }


### PR DESCRIPTION
## Summary
- narrow the news ticker pennant and enlarge the embedded logo so the proportions feel balanced
- ensure the launch animation video covers the full viewport by removing padding and compensating for safe-area insets

## Testing
- Not run (non-code changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d9c7ef02fc832e82b6bf2cf0a63076