### PR TITLE
Restore ticker height while enlarging ticker logo

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -220,8 +220,9 @@ label[data-animate-title]{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  width:clamp(82px,17vw,120px);
-  height:calc(100% - 6px);
+  width:clamp(164px,34vw,260px);
+  height:100%;
+  margin-block:-2px;
   color:var(--text-on-accent);
   flex:0 0 auto;
 }
@@ -232,8 +233,8 @@ label[data-animate-title]{
   width:100%;
   height:100%;
   background:currentColor;
-  mask:url('../images/6a78d5b9-619a-4670-a141-271387532fdb.svg') center/contain no-repeat;
-  -webkit-mask:url('../images/6a78d5b9-619a-4670-a141-271387532fdb.svg') center/contain no-repeat;
+  mask:url('../images/6a78d5b9-619a-4670-a141-271387532fdb.svg') center/180% 180% no-repeat;
+  -webkit-mask:url('../images/6a78d5b9-619a-4670-a141-271387532fdb.svg') center/180% 180% no-repeat;
 }
 .news-ticker__track{
   --ticker-gap:clamp(64px,20vw,280px);


### PR DESCRIPTION
## Summary
- return the news ticker container to its 45px height requirement
- expand the ticker logo footprint and mask scaling so the emblem reads larger without altering layout height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ca584e78832ea601ca5570f1b19e