### PR TITLE
Ensure footer DM logo remains visible when logged out

### DIFF
--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -278,10 +278,17 @@ function initDMLogin(){
       renderStoredNotifications();
     }
     if (dmBtn){
-      dmBtn.style.opacity = loggedIn ? '1' : '0';
-      dmBtn.style.left = loggedIn ? '18px' : '50%';
-      dmBtn.style.bottom = loggedIn ? '18px' : '0';
-      dmBtn.style.transform = loggedIn ? 'none' : 'translateX(-50%)';
+      if (loggedIn) {
+        dmBtn.style.opacity = '1';
+        dmBtn.style.left = '18px';
+        dmBtn.style.bottom = '18px';
+        dmBtn.style.transform = 'none';
+      } else {
+        dmBtn.style.removeProperty('opacity');
+        dmBtn.style.removeProperty('left');
+        dmBtn.style.removeProperty('bottom');
+        dmBtn.style.removeProperty('transform');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- keep the DM footer login button visible when logged out so the new logo can display
- clear inline positioning styles when logged out while retaining the logged-in layout adjustments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da2bce2b48832ea06d729fb7be93c0