### PR TITLE
Fix launch animation skipping

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -198,7 +198,20 @@ const LAUNCH_MAX_WAIT = 12000;
         if(fallbackTimer) window.clearTimeout(fallbackTimer);
         window.setTimeout(finish, 120);
       }, { once: true });
-      ['error','abort','emptied'].forEach(evt => vid.addEventListener(evt, finish, { once: true }));
+      ['error','abort'].forEach(evt => vid.addEventListener(evt, finish, { once: true }));
+      let allowEmptiedFinish = false;
+      const markEmptiedEligible = () => {
+        allowEmptiedFinish = true;
+      };
+      const handleEmptied = () => {
+        if(!allowEmptiedFinish){
+          return;
+        }
+        vid.removeEventListener('emptied', handleEmptied);
+        finish();
+      };
+      vid.addEventListener('loadeddata', markEmptiedEligible, { once: true });
+      vid.addEventListener('emptied', handleEmptied);
       const handleUserGesture = () => {
         attemptPlayback();
       };


### PR DESCRIPTION
## Summary
- gate the launch animation fallback on the video having loaded data before treating `emptied` as a fatal error
- ensure subsequent `emptied` events still complete cleanup once playback has begun

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da3647e728832eb8c28a2decbde09a