### PR TITLE
Add M24N broadcast ticker with rotating headlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,18 @@
       </div>
     </div>
   </div>
+  <div class="news-ticker news-ticker--m24n" role="status" aria-live="polite" aria-labelledby="m24n-ticker-label">
+    <div class="news-ticker__inner">
+      <span class="news-ticker__label news-ticker__label--m24n" id="m24n-ticker-label">
+        <span class="news-ticker__logo news-ticker__logo--m24n" aria-hidden="true">M24N</span>
+        <span class="news-ticker__badge news-ticker__badge--live" aria-hidden="true">LIVE</span>
+        <span class="sr-only">M24N breaking news ticker</span>
+      </span>
+      <div class="news-ticker__track news-ticker__track--m24n" data-m24n-ticker-track>
+        <span class="news-ticker__text news-ticker__text--m24n" data-m24n-ticker-text>Loading M24N feed…</span>
+      </div>
+    </div>
+  </div>
 </header>
 
 <main id="main">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -998,6 +998,145 @@ if(tickerTrack && tickerText){
   });
 }
 
+const m24nTrack = qs('[data-m24n-ticker-track]');
+const m24nText = qs('[data-m24n-ticker-text]');
+if(m24nTrack && m24nText){
+  const HEADLINE_DURATION = 20000;
+  const BUFFER_DURATION = 3000;
+  const ROTATION_WINDOW = 10 * 60 * 1000;
+  const HEADLINES_PER_ROTATION = Math.max(1, Math.floor(ROTATION_WINDOW / (HEADLINE_DURATION + BUFFER_DURATION)));
+  let headlines = [];
+  let rotationItems = [];
+  let rotationIndex = 0;
+  let rotationStart = 0;
+  let animationTimer = null;
+  let bufferTimer = null;
+
+  function clearTimers(){
+    if(animationTimer){
+      clearTimeout(animationTimer);
+      animationTimer = null;
+    }
+    if(bufferTimer){
+      clearTimeout(bufferTimer);
+      bufferTimer = null;
+    }
+  }
+
+  function resetTrack(){
+    m24nTrack.classList.remove('is-animating');
+    m24nTrack.style.transform = 'translate3d(100%,0,0)';
+  }
+
+  function shuffle(arr){
+    for(let i = arr.length - 1; i > 0; i--){
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  function buildRotation(){
+    rotationStart = Date.now();
+    rotationIndex = 0;
+    if(!headlines.length){
+      rotationItems = [];
+      return;
+    }
+    const pool = shuffle([...headlines]);
+    const selectionSize = Math.min(pool.length, HEADLINES_PER_ROTATION);
+    rotationItems = pool.slice(0, selectionSize);
+  }
+
+  async function loadHeadlines(){
+    try{
+      const res = await fetch('News.txt', { cache: 'no-store' });
+      if(!res || !res.ok){
+        throw new Error(`Failed to fetch headlines (${res ? res.status : 'no response'})`);
+      }
+      const rawText = await res.text();
+      const sets = [];
+      const lines = rawText.split(/\r?\n/);
+      let current = [];
+      const pushCurrent = () => {
+        if(!current.length) return;
+        const combined = current.join(' ')
+          .replace(/\s*\|\s*/g, ' | ')
+          .replace(/\s{2,}/g, ' ')
+          .trim();
+        if(combined) sets.push(combined);
+        current = [];
+      };
+      for(const line of lines){
+        const trimmed = line.trim();
+        if(!trimmed) continue;
+        const startMatch = trimmed.match(/^(\d+)\.\s*(.*)$/);
+        if(startMatch){
+          pushCurrent();
+          current.push(startMatch[2]);
+        }else if(current.length){
+          current.push(trimmed);
+        }
+      }
+      pushCurrent();
+      headlines = sets.slice(0, 100);
+      if(!headlines.length){
+        throw new Error('No M24N headlines available');
+      }
+      buildRotation();
+    }catch(err){
+      console.error('Failed to load M24N ticker', err);
+      m24nText.textContent = 'M24N feed temporarily offline.';
+    }
+  }
+
+  function scheduleNextHeadline(){
+    clearTimers();
+    if(!headlines.length){
+      return;
+    }
+    if(!rotationItems.length){
+      buildRotation();
+    }
+    if(!rotationItems.length){
+      return;
+    }
+    if(Date.now() - rotationStart >= ROTATION_WINDOW){
+      buildRotation();
+    }
+    if(!rotationItems.length){
+      return;
+    }
+    const headline = rotationItems[rotationIndex] || rotationItems[0];
+    rotationIndex = (rotationIndex + 1) % rotationItems.length;
+    m24nText.textContent = headline;
+    resetTrack();
+    requestAnimationFrame(() => {
+      void m24nTrack.offsetWidth;
+      m24nTrack.classList.add('is-animating');
+      animationTimer = window.setTimeout(() => {
+        resetTrack();
+        bufferTimer = window.setTimeout(scheduleNextHeadline, BUFFER_DURATION);
+      }, HEADLINE_DURATION);
+    });
+  }
+
+  loadHeadlines().then(() => {
+    if(rotationItems.length){
+      scheduleNextHeadline();
+    }
+  });
+
+  document.addEventListener('visibilitychange', () => {
+    if(document.visibilityState === 'hidden'){
+      clearTimers();
+      resetTrack();
+    }else if(headlines.length && !animationTimer && !bufferTimer){
+      bufferTimer = window.setTimeout(scheduleNextHeadline, BUFFER_DURATION);
+    }
+  });
+}
+
 /* ========= ability grid + autos ========= */
 const ABILS = ['str','dex','con','int','wis','cha'];
 const abilGrid = $('abil-grid');

--- a/styles/main.css
+++ b/styles/main.css
@@ -271,6 +271,79 @@ label[data-animate-title]{
   font-size:.78rem;
   color:var(--accent);
 }
+.news-ticker--m24n{
+  --m24n-primary:#1f2a44;
+  --m24n-highlight:#e84561;
+  --m24n-text:#f4f6ff;
+  margin-top:6px;
+  background:linear-gradient(90deg,rgba(17,21,32,.9) 0%,rgba(24,31,48,.88) 62%,rgba(13,17,25,.92) 100%);
+  border-color:color-mix(in srgb,var(--accent) 60%, transparent);
+  box-shadow:0 14px 34px rgba(12,16,28,.48);
+}
+.news-ticker--m24n::before{
+  background:linear-gradient(90deg,rgba(46,62,101,.92) 0%,rgba(26,34,54,.7) 55%,transparent 92%);
+}
+.news-ticker__label--m24n{
+  background:linear-gradient(135deg,var(--m24n-primary) 0%,#111726 100%);
+  color:var(--m24n-text);
+  text-shadow:0 2px 10px rgba(0,0,0,.38);
+}
+.news-ticker__label--m24n::after{
+  background:linear-gradient(120deg,rgba(255,255,255,.12) 0%,rgba(255,255,255,0) 65%);
+  opacity:.34;
+}
+.news-ticker__logo--m24n{
+  position:relative;
+  width:auto;
+  min-width:unset;
+  height:calc(100% - 8px);
+  padding:0 clamp(18px,4vw,26px);
+  margin-block:auto;
+  border-radius:4px;
+  background:linear-gradient(135deg,#f7f8ff 0%,#dce3ff 52%,#fefeff 100%);
+  color:#131c30;
+  font-weight:800;
+  font-size:clamp(1.05rem,3.6vw,1.45rem);
+  letter-spacing:.38em;
+  line-height:1;
+  text-transform:uppercase;
+  box-shadow:0 4px 16px rgba(10,14,24,.35);
+}
+.news-ticker__logo--m24n::before{content:none}
+.news-ticker__badge{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-height:22px;
+  padding:0 clamp(10px,2.6vw,16px);
+  margin-left:clamp(10px,2.8vw,18px);
+  border-radius:999px;
+  font-weight:700;
+  font-size:.68rem;
+  letter-spacing:.28em;
+  text-transform:uppercase;
+  box-shadow:0 2px 12px rgba(0,0,0,.35);
+}
+.news-ticker__badge--live{
+  background:linear-gradient(135deg,var(--m24n-highlight) 0%,#b4163d 100%);
+  color:#fff;
+  text-shadow:0 1px 4px rgba(0,0,0,.4);
+}
+.news-ticker__track--m24n{
+  --ticker-duration:20s;
+  animation:none;
+  transform:translate3d(100%,0,0);
+  gap:clamp(44px,10vw,72px);
+}
+.news-ticker__track--m24n.is-animating{
+  animation:ticker-scroll var(--ticker-duration) linear forwards;
+}
+.news-ticker__text--m24n{
+  color:var(--m24n-text);
+  font-size:.8rem;
+  letter-spacing:.12em;
+  text-shadow:0 1px 6px rgba(0,0,0,.35);
+}
 @keyframes ticker-scroll{from{transform:translate3d(100%,0,0)}to{transform:translate3d(calc(-100% - var(--ticker-gap)),0,0)}}
 main{
   flex:1 0 auto;


### PR DESCRIPTION
## Summary
- add an M24N-branded ticker beneath the fun tips feed with dedicated markup and styling
- parse News.txt headlines and cycle random 10-minute rotations with timed scroll animations

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68da3b049ebc832ea40d5aef405b1995