### PR TITLE
Prevent sticky header blur artifact on scroll

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -34,8 +34,13 @@ h1{font-size:clamp(1.75rem,4.6vw,2rem);font-weight:700;color:var(--accent)}
 h2{font-size:clamp(1.35rem,3.8vw,1.5rem);font-weight:600;color:var(--accent)}
 h3{font-size:clamp(1.1rem,3.2vw,1.25rem);font-weight:600}
 h4{font-size:clamp(1rem,2.8vw,1.1rem);font-weight:600}
-header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding-top:calc(4px * 1.15 + constant(safe-area-inset-top));padding-right:calc(20px + constant(safe-area-inset-right));padding-bottom:calc(4px * 1.15 + constant(safe-area-inset-bottom));padding-left:calc(20px + constant(safe-area-inset-left));padding-top:calc(4px * 1.15 + env(safe-area-inset-top));padding-right:calc(20px + env(safe-area-inset-right));padding-bottom:calc(4px * 1.15 + env(safe-area-inset-bottom));padding-left:calc(20px + env(safe-area-inset-left));-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;flex-direction:column;gap:calc(6px * 1.15)}
+header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding-top:calc(4px * 1.15 + constant(safe-area-inset-top));padding-right:calc(20px + constant(safe-area-inset-right));padding-bottom:calc(4px * 1.15 + constant(safe-area-inset-bottom));padding-left:calc(20px + constant(safe-area-inset-left));padding-top:calc(4px * 1.15 + env(safe-area-inset-top));padding-right:calc(20px + env(safe-area-inset-right));padding-bottom:calc(4px * 1.15 + env(safe-area-inset-bottom));padding-left:calc(20px + env(safe-area-inset-left));display:flex;flex-direction:column;gap:calc(6px * 1.15);isolation:isolate}
 header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(calc(-10px * 1.15))}
+header::before{content:none}
+@supports ((-webkit-backdrop-filter:blur(0)) or (backdrop-filter:blur(0))){
+  header{background:color-mix(in srgb,var(--surface) 92%, transparent)}
+  header::before{content:"";position:absolute;inset:0;background:color-mix(in srgb,var(--surface) 92%, transparent);-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);pointer-events:none;z-index:-1}
+}
 .actions{display:flex;gap:calc(6px * 1.15);flex-wrap:wrap}
 .dropdown{position:relative;display:flex;align-items:center;justify-self:center;grid-column:5;margin-left:0}
 .menu{position:absolute;top:calc(100% + 4px);right:0;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50;opacity:0;transform:translateY(-10px);visibility:hidden;transition:opacity .3s ease,transform .3s ease;pointer-events:none}


### PR DESCRIPTION
## Summary
- remove the backdrop-filter from the sticky header and apply it through a pseudo element to avoid the grey bar artifact while scrolling
- isolate the header stacking context so the news ticker blur stays contained to the header area

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da422c1c7c832eb9c399c35933e61d