### PR TITLE
Improve launch video timing and M24N ticker layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,8 @@
 </div>
 <script>
   (function(){
-    const FALLBACK_DELAY = 6000;
+    const DEFAULT_FALLBACK = 12000;
+    const MIN_VISIBLE = 1800;
     const body = document.body;
     const launchEl = document.getElementById('launch-animation');
     const video = launchEl ? launchEl.querySelector('video') : null;
@@ -35,10 +36,19 @@
       return;
     }
 
+    let fallbackTimer = null;
+    const clearFallback = () => {
+      if(fallbackTimer){
+        window.clearTimeout(fallbackTimer);
+        fallbackTimer = null;
+      }
+    };
+
     const hideLaunch = () => {
       if(!body.classList.contains('launching')){
         return;
       }
+      clearFallback();
       body.classList.remove('launching');
       launchEl.setAttribute('data-hidden', 'true');
       launchEl.addEventListener('transitionend', () => {
@@ -53,12 +63,14 @@
       }, 800);
     };
 
-    const scheduleFallback = () => {
-      window.setTimeout(() => {
+    const scheduleFallback = (delay = DEFAULT_FALLBACK) => {
+      clearFallback();
+      const timeout = Math.max(delay, MIN_VISIBLE);
+      fallbackTimer = window.setTimeout(() => {
         if(body.classList.contains('launching')){
           hideLaunch();
         }
-      }, FALLBACK_DELAY);
+      }, timeout);
     };
 
     if(video){
@@ -72,22 +84,42 @@
           video.muted = true;
         } catch (err) {}
       };
-      ensureAttributes();
-      ['error','abort','stalled','suspend'].forEach(evt => {
-        video.addEventListener(evt, hideLaunch, { once: true });
-      });
-      video.addEventListener('loadeddata', () => {
+      const attemptPlay = () => {
         ensureAttributes();
         if(typeof video.play === 'function'){
-          video.play().catch(() => {});
+          const playAttempt = video.play();
+          if(playAttempt && typeof playAttempt.catch === 'function'){
+            playAttempt.catch(() => {});
+          }
         }
-      }, { once: true });
+      };
+      const handleReady = () => {
+        attemptPlay();
+        const durationMs = Number.isFinite(video.duration) && video.duration > 0
+          ? (video.duration * 1000) + 500
+          : DEFAULT_FALLBACK;
+        scheduleFallback(durationMs);
+      };
+      ensureAttributes();
+      video.addEventListener('ended', hideLaunch, { once: true });
+      ['error','abort','stalled','suspend'].forEach(evt => {
+        video.addEventListener(evt, () => scheduleFallback(MIN_VISIBLE), { once: true });
+      });
+      video.addEventListener('loadeddata', ensureAttributes, { once: true });
+      if(video.readyState >= 1){
+        handleReady();
+      } else {
+        video.addEventListener('loadedmetadata', handleReady, { once: true });
+        scheduleFallback(DEFAULT_FALLBACK);
+      }
     }
 
-    if(document.readyState === 'complete'){
-      scheduleFallback();
-    } else {
-      window.addEventListener('load', scheduleFallback, { once: true });
+    if(!video){
+      if(document.readyState === 'complete'){
+        scheduleFallback();
+      } else {
+        window.addEventListener('load', () => scheduleFallback(), { once: true });
+      }
     }
   })();
 </script>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -229,7 +229,8 @@ const LAUNCH_MAX_WAIT = 12000;
     }
     cleanupUserGestures();
     const durationMs = Number.isFinite(video.duration) && video.duration > 0 ? (video.duration * 1000) + 500 : LAUNCH_MAX_WAIT;
-    scheduleFallback(Math.min(durationMs, LAUNCH_MAX_WAIT));
+    const fallbackDelay = Math.max(durationMs, LAUNCH_MAX_WAIT);
+    scheduleFallback(fallbackDelay);
   };
 
   const handlePause = () => {

--- a/styles/main.css
+++ b/styles/main.css
@@ -297,7 +297,11 @@ label[data-animate-title]{
   clip-path:none;
   border-radius:8px 0 0 8px;
   padding-right:var(--m24n-line-width);
-  gap:clamp(12px,3vw,18px);
+  gap:clamp(10px,2.6vw,16px);
+  flex:0 1 auto;
+  min-width:var(--pennant-width);
+  flex-wrap:nowrap;
+  max-width:100%;
   overflow:hidden;
 }
 .news-ticker__label--m24n::before{
@@ -325,8 +329,13 @@ label[data-animate-title]{
 }
 .news-ticker__logo--m24n{
   position:relative;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
   width:auto;
   min-width:unset;
+  min-width:0;
+  max-width:100%;
   height:calc(100% - 8px);
   padding:0 clamp(18px,4vw,26px);
   margin-block:auto;
@@ -354,6 +363,8 @@ label[data-animate-title]{
   letter-spacing:.28em;
   text-transform:uppercase;
   box-shadow:0 2px 12px rgba(0,0,0,.35);
+  flex:0 0 auto;
+  white-space:nowrap;
 }
 .news-ticker__badge--live{
   background:linear-gradient(135deg,var(--m24n-highlight) 0%,#b4163d 100%);
@@ -384,19 +395,20 @@ label[data-animate-title]{
     --m24n-line-gap:clamp(8px,2.6vw,12px);
   }
   .news-ticker__label--m24n{
+    gap:clamp(6px,2vw,12px);
     padding-left:calc(clamp(10px,3vw,18px) + env(safe-area-inset-left));
-    padding-right:var(--m24n-line-width);
+    padding-right:calc(var(--m24n-line-width) + clamp(6px,2vw,12px));
   }
   .news-ticker__logo--m24n{
     padding:0 clamp(14px,3vw,20px);
-    font-size:clamp(.88rem,3.8vw,1.1rem);
-    letter-spacing:.26em;
+    font-size:clamp(.88rem,3.4vw,1.08rem);
+    letter-spacing:.24em;
   }
   .news-ticker--m24n .news-ticker__badge{
     margin-left:clamp(6px,2vw,12px);
     padding:0 clamp(8px,2vw,12px);
-    font-size:.62rem;
-    letter-spacing:.2em;
+    font-size:.6rem;
+    letter-spacing:.18em;
   }
   .news-ticker__track--m24n{
     gap:clamp(26px,7vw,42px);
@@ -405,6 +417,26 @@ label[data-animate-title]{
   .news-ticker__text--m24n{
     font-size:.72rem;
     letter-spacing:.1em;
+  }
+}
+
+@media(max-width:400px){
+  .news-ticker--m24n{
+    --m24n-line-gap:clamp(6px,1.8vw,10px);
+  }
+  .news-ticker__label--m24n{
+    gap:clamp(4px,1.8vw,8px);
+    padding-right:calc(var(--m24n-line-width) + clamp(4px,1.6vw,8px));
+  }
+  .news-ticker__logo--m24n{
+    padding:0 clamp(12px,3.6vw,18px);
+    font-size:clamp(.82rem,3.2vw,.98rem);
+    letter-spacing:.18em;
+  }
+  .news-ticker--m24n .news-ticker__badge{
+    padding:0 clamp(6px,1.8vw,10px);
+    font-size:.56rem;
+    letter-spacing:.14em;
   }
 }
 @keyframes ticker-scroll{from{transform:translate3d(100%,0,0)}to{transform:translate3d(calc(-100% - var(--ticker-gap)),0,0)}}


### PR DESCRIPTION
## Summary
- ensure the launch splash video enforces muted inline playback and only dismisses after it finishes or a guarded fallback
- tweak the M24N ticker logo and badge sizing, spacing, and responsive rules to prevent overlaps on narrow viewports

## Testing
- Manual verification in Playwright (360x780 viewport)


------
https://chatgpt.com/codex/tasks/task_e_68da48b691ac832eae8bf1c986e0d1dd