### PR TITLE
Adjust launch animation scaling for wide displays

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -29,6 +29,7 @@ body.launching .app-shell{opacity:0}
 body.launching #launch-animation{opacity:1;visibility:visible}
 #launch-animation[data-hidden="true"]{opacity:0;visibility:hidden;pointer-events:none}
 #launch-animation video{width:calc(100% + constant(safe-area-inset-left) + constant(safe-area-inset-right));height:calc(100% + constant(safe-area-inset-top) + constant(safe-area-inset-bottom));margin-left:calc(-1 * constant(safe-area-inset-left));margin-right:calc(-1 * constant(safe-area-inset-right));margin-top:calc(-1 * constant(safe-area-inset-top));margin-bottom:calc(-1 * constant(safe-area-inset-bottom));width:calc(100% + env(safe-area-inset-left) + env(safe-area-inset-right));height:calc(100% + env(safe-area-inset-top) + env(safe-area-inset-bottom));margin-left:calc(-1 * env(safe-area-inset-left));margin-right:calc(-1 * env(safe-area-inset-right));margin-top:calc(-1 * env(safe-area-inset-top));margin-bottom:calc(-1 * env(safe-area-inset-bottom));max-width:none;max-height:none;display:block;object-fit:cover}
+@media (min-width:1200px){#launch-animation video{object-fit:contain;max-width:100vw;max-height:100vh}}
 ::selection{background:var(--accent);color:var(--text-on-accent)}
 h1,h2,h3,h4{font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;line-height:1.25;margin:0 0 .5em}
 h1{font-size:clamp(1.75rem,4.6vw,2rem);font-weight:700;color:var(--accent)}


### PR DESCRIPTION
## Summary
- prevent the launch animation from being cropped on large viewports by switching the video to `object-fit: contain`
- cap the video dimensions to the viewport so the entire animation stays visible on wide displays

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da4e5349d8832e900a599b7e1149e0