### PR TITLE
Improve M24N ticker visuals and scrolling behavior

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1004,10 +1004,15 @@ if(m24nTrack && m24nText){
 
   function updateHeadlineDuration(){
     const trackStyles = window.getComputedStyle(m24nTrack);
-    const gapValueRaw = trackStyles.getPropertyValue('--ticker-gap');
-    const gapValue = Number.parseFloat(gapValueRaw) || 0;
+    const gapValue = Number.parseFloat(
+      trackStyles.getPropertyValue('column-gap') ||
+      trackStyles.getPropertyValue('gap') ||
+      '0'
+    ) || 0;
     const trackWidth = m24nTrack.scrollWidth;
-    const travelDistance = (trackWidth * 2) + gapValue;
+    const viewportWidth = m24nTrack.parentElement?.clientWidth || m24nTrack.offsetWidth;
+    const travelDistance = trackWidth + viewportWidth + gapValue;
+    m24nTrack.style.setProperty('--ticker-distance', `${Math.round(travelDistance)}px`);
     const durationMs = Math.min(
       MAX_HEADLINE_DURATION,
       Math.max(MIN_HEADLINE_DURATION, (travelDistance / SCROLL_SPEED_PX_PER_SEC) * 1000)

--- a/styles/main.css
+++ b/styles/main.css
@@ -291,6 +291,9 @@ label[data-animate-title]{
   border-color:color-mix(in srgb,var(--accent) 60%, transparent);
   box-shadow:0 14px 34px rgba(12,16,28,.48);
 }
+.news-ticker--m24n .news-ticker__inner{
+  padding-left:0;
+}
 .news-ticker--m24n::before{content:none}
 .news-ticker__label--m24n{
   background:linear-gradient(135deg,var(--m24n-primary) 0%,#111726 100%);
@@ -299,14 +302,15 @@ label[data-animate-title]{
   clip-path:none;
   border-radius:8px 0 0 8px;
   padding-right:var(--m24n-line-width);
-  gap:clamp(10px,2.6vw,16px);
-  justify-content:flex-start;
+  gap:clamp(6px,2vw,12px);
+  justify-content:center;
   flex:0 0 auto;
   min-width:var(--pennant-width);
   flex-wrap:nowrap;
   max-width:100%;
   overflow:hidden;
-  padding-left:env(safe-area-inset-left);
+  padding-left:env(safe-area-inset-left, 0px);
+  text-align:center;
 }
 .news-ticker__label--m24n::before{
   content:"";
@@ -340,15 +344,15 @@ label[data-animate-title]{
   min-width:unset;
   min-width:0;
   max-width:100%;
-  height:calc(100% - 8px);
-  padding:0 clamp(12px,3vw,18px);
+  height:calc(100% - 10px);
+  padding:0 clamp(10px,2.4vw,14px);
   margin-block:auto;
   border-radius:4px;
   background:linear-gradient(135deg,#f7f8ff 0%,#dce3ff 52%,#fefeff 100%);
   color:#131c30;
   font-family:'Race Sport',sans-serif;
   font-weight:800;
-  font-size:clamp(.95rem,3.1vw,1.25rem);
+  font-size:clamp(.82rem,2.8vw,1.12rem);
   letter-spacing:3px;
   line-height:1;
   text-transform:uppercase;
@@ -380,14 +384,15 @@ label[data-animate-title]{
   text-shadow:0 1px 4px rgba(0,0,0,.4);
 }
 .news-ticker--m24n .news-ticker__badge{
-  margin-left:clamp(8px,2.4vw,14px);
-  padding:0 clamp(8px,2.2vw,14px);
-  min-height:20px;
-  font-size:.62rem;
-  letter-spacing:.18em;
+  margin-left:clamp(6px,2vw,10px);
+  padding:0 clamp(6px,2vw,10px);
+  min-height:18px;
+  font-size:.58rem;
+  letter-spacing:.16em;
 }
 .news-ticker__track--m24n{
   --ticker-duration:30s;
+  --ticker-distance:calc(100% + var(--ticker-gap));
   animation:none;
   transform:translate3d(100%,0,0);
   gap:clamp(44px,10vw,72px);
@@ -395,13 +400,17 @@ label[data-animate-title]{
   padding-left:calc(var(--m24n-line-width) + var(--m24n-line-gap));
 }
 .news-ticker__track--m24n.is-animating{
-  animation:ticker-scroll var(--ticker-duration) linear forwards;
+  animation:ticker-scroll-m24n var(--ticker-duration) linear forwards;
 }
 .news-ticker__text--m24n{
   color:var(--m24n-text);
   font-size:.8rem;
   letter-spacing:.12em;
   text-shadow:0 1px 6px rgba(0,0,0,.35);
+}
+@keyframes ticker-scroll-m24n{
+  from{transform:translate3d(100%,0,0)}
+  to{transform:translate3d(calc(-1 * var(--ticker-distance, 100%)),0,0)}
 }
 @media(max-width:540px){
   .news-ticker--m24n{
@@ -410,20 +419,20 @@ label[data-animate-title]{
     --m24n-line-gap:clamp(8px,2.6vw,12px);
   }
   .news-ticker__label--m24n{
-    gap:clamp(6px,2vw,12px);
-    padding-left:env(safe-area-inset-left);
+    gap:clamp(4px,1.8vw,10px);
+    padding-left:env(safe-area-inset-left, 0px);
     padding-right:calc(var(--m24n-line-width) + clamp(6px,2vw,12px));
   }
   .news-ticker__logo--m24n{
-    padding:0 clamp(10px,2.6vw,16px);
-    font-size:clamp(.82rem,3.1vw,.98rem);
+    padding:0 clamp(8px,2.4vw,12px);
+    font-size:clamp(.74rem,2.8vw,.94rem);
     letter-spacing:3px;
   }
   .news-ticker--m24n .news-ticker__badge{
-    margin-left:clamp(6px,2vw,10px);
-    padding:0 clamp(6px,2vw,10px);
-    min-height:18px;
-    font-size:.56rem;
+    margin-left:clamp(4px,1.8vw,8px);
+    padding:0 clamp(4px,1.8vw,8px);
+    min-height:16px;
+    font-size:.52rem;
     letter-spacing:.12em;
   }
   .news-ticker__track--m24n{
@@ -441,18 +450,18 @@ label[data-animate-title]{
     --m24n-line-gap:clamp(6px,1.8vw,10px);
   }
   .news-ticker__label--m24n{
-    gap:clamp(4px,1.8vw,8px);
+    gap:clamp(3px,1.4vw,6px);
     padding-right:calc(var(--m24n-line-width) + clamp(4px,1.6vw,8px));
   }
   .news-ticker__logo--m24n{
-    padding:0 clamp(10px,3vw,16px);
-    font-size:clamp(.78rem,3vw,.92rem);
+    padding:0 clamp(8px,2.6vw,12px);
+    font-size:clamp(.7rem,2.6vw,.88rem);
     letter-spacing:3px;
   }
   .news-ticker--m24n .news-ticker__badge{
-    padding:0 clamp(6px,1.8vw,10px);
-    font-size:.56rem;
-    letter-spacing:.14em;
+    padding:0 clamp(4px,1.6vw,8px);
+    font-size:.5rem;
+    letter-spacing:.12em;
   }
 }
 @keyframes ticker-scroll{from{transform:translate3d(100%,0,0)}to{transform:translate3d(calc(-100% - var(--ticker-gap)),0,0)}}


### PR DESCRIPTION
## Summary
- tighten the M24N ticker layout so the logo label sits flush left, centered, and scaled down with a smaller live badge
- update the M24N ticker animation to travel the full headline width for complete scrolls

## Testing
- npm test -- --runTestsByPath


------
https://chatgpt.com/codex/tasks/task_e_68da5f3c3ea4832e8e34875bf9c18a6c