### PR TITLE
Add floating DM tools toggle after DM login

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -10,6 +10,7 @@ describe('dm login', () => {
   test('DM login unlocks tools', async () => {
     document.body.innerHTML = `
         <button id="dm-login"></button>
+        <button id="dm-tools-toggle" hidden></button>
         <div id="dm-tools-menu" hidden></div>
         <button id="dm-tools-tsomf"></button>
         <button id="dm-tools-logout"></button>
@@ -51,13 +52,15 @@ describe('dm login', () => {
     expect(modal.getAttribute('aria-hidden')).toBe('true');
     const dmBtn = document.getElementById('dm-login');
     const menu = document.getElementById('dm-tools-menu');
-    expect(dmBtn.style.opacity).toBe('1');
-    expect(dmBtn.style.left).toBe('18px');
-    expect(dmBtn.style.bottom).toBe('18px');
-    expect(dmBtn.style.transform).toBe('none');
+    const toggle = document.getElementById('dm-tools-toggle');
+    expect(dmBtn.disabled).toBe(true);
+    expect(dmBtn.getAttribute('aria-disabled')).toBe('true');
+    expect(toggle.hidden).toBe(false);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
     expect(menu.hidden).toBe(true);
-    dmBtn.click();
+    toggle.click();
     expect(menu.hidden).toBe(false);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
     delete window.toast;
     delete window.dismissToast;
   });
@@ -65,6 +68,7 @@ describe('dm login', () => {
   test('login modal closes even if tools init fails', async () => {
     document.body.innerHTML = `
         <button id="dm-login"></button>
+        <button id="dm-tools-toggle" hidden></button>
         <div id="dm-tools-menu" hidden></div>
         <button id="dm-tools-tsomf"></button>
         <button id="dm-tools-logout"></button>
@@ -103,8 +107,11 @@ describe('dm login', () => {
     expect(modal.classList.contains('hidden')).toBe(true);
     const dmBtn = document.getElementById('dm-login');
     const menu = document.getElementById('dm-tools-menu');
+    const toggle = document.getElementById('dm-tools-toggle');
+    expect(dmBtn.disabled).toBe(true);
+    expect(toggle.hidden).toBe(false);
     expect(menu.hidden).toBe(true);
-    dmBtn.click();
+    toggle.click();
     expect(menu.hidden).toBe(false);
     delete window.toast;
     delete window.dismissToast;

--- a/index.html
+++ b/index.html
@@ -1042,6 +1042,7 @@
   <button id="dm-tools-characters" class="btn-sm">Characters</button>
   <button id="dm-tools-logout" class="btn-sm">Logout</button>
 </div>
+<button id="dm-tools-toggle" class="dm-tools-toggle" hidden aria-haspopup="true" aria-controls="dm-tools-menu">DM Tools</button>
 <div class="overlay hidden" id="dm-login-modal" aria-hidden="true">
   <section class="modal">
     <button id="dm-login-close" class="x" aria-label="Close">

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -120,6 +120,7 @@ function formatNotification(entry, { html = false } = {}) {
 
 function initDMLogin(){
   const dmBtn = document.getElementById('dm-login');
+  const dmToggleBtn = document.getElementById('dm-tools-toggle');
   const menu = document.getElementById('dm-tools-menu');
   const tsomfBtn = document.getElementById('dm-tools-tsomf');
   const notifyBtn = document.getElementById('dm-tools-notifications');
@@ -141,6 +142,7 @@ function initDMLogin(){
 
   if (!isAuthorizedDevice()) {
     dmBtn?.remove();
+    dmToggleBtn?.remove();
     menu?.remove();
     loginModal?.remove();
     notifyModal?.remove();
@@ -278,17 +280,19 @@ function initDMLogin(){
       renderStoredNotifications();
     }
     if (dmBtn){
+      dmBtn.disabled = loggedIn;
       if (loggedIn) {
-        dmBtn.style.opacity = '1';
-        dmBtn.style.left = '18px';
-        dmBtn.style.bottom = '18px';
-        dmBtn.style.transform = 'none';
+        dmBtn.classList.add('dm-login-btn--inactive');
+        dmBtn.setAttribute('aria-disabled', 'true');
       } else {
-        dmBtn.style.removeProperty('opacity');
-        dmBtn.style.removeProperty('left');
-        dmBtn.style.removeProperty('bottom');
-        dmBtn.style.removeProperty('transform');
+        dmBtn.classList.remove('dm-login-btn--inactive');
+        dmBtn.removeAttribute('aria-disabled');
       }
+    }
+    if (dmToggleBtn) {
+      dmToggleBtn.hidden = !loggedIn;
+      const expanded = loggedIn && menu && !menu.hidden;
+      dmToggleBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
     }
   }
 
@@ -377,7 +381,11 @@ function initDMLogin(){
   }
 
   function toggleMenu(){
-    if(menu) menu.hidden = !menu.hidden;
+    if(!menu) return;
+    menu.hidden = !menu.hidden;
+    if (dmToggleBtn) {
+      dmToggleBtn.setAttribute('aria-expanded', menu.hidden ? 'false' : 'true');
+    }
   }
 
   function openNotifications(){
@@ -534,22 +542,30 @@ function initDMLogin(){
     });
 
   if (dmBtn) dmBtn.addEventListener('click', () => {
-    if (isLoggedIn()) {
-      toggleMenu();
-    } else {
+    if (!isLoggedIn()) {
       requireLogin().catch(() => {});
     }
   });
 
+  if (dmToggleBtn) dmToggleBtn.addEventListener('click', () => {
+    if (!isLoggedIn()) {
+      requireLogin().catch(() => {});
+      return;
+    }
+    toggleMenu();
+  });
+
   document.addEventListener('click', e => {
-    if (menu && !menu.hidden && !menu.contains(e.target) && !dmBtn?.contains(e.target)) {
+    if (menu && !menu.hidden && !menu.contains(e.target) && !dmBtn?.contains(e.target) && !dmToggleBtn?.contains(e.target)) {
       menu.hidden = true;
+      if (dmToggleBtn) dmToggleBtn.setAttribute('aria-expanded', 'false');
     }
   });
 
   if (tsomfBtn) {
     tsomfBtn.addEventListener('click', () => {
       if (menu) menu.hidden = true;
+      if (dmToggleBtn) dmToggleBtn.setAttribute('aria-expanded', 'false');
       if (window.openSomfDM) window.openSomfDM();
     });
   }
@@ -557,6 +573,7 @@ function initDMLogin(){
   if (notifyBtn) {
     notifyBtn.addEventListener('click', () => {
       if (menu) menu.hidden = true;
+      if (dmToggleBtn) dmToggleBtn.setAttribute('aria-expanded', 'false');
       openNotifications();
     });
   }
@@ -564,6 +581,7 @@ function initDMLogin(){
     if (charBtn) {
       charBtn.addEventListener('click', () => {
         if (menu) menu.hidden = true;
+        if (dmToggleBtn) dmToggleBtn.setAttribute('aria-expanded', 'false');
         openCharacters();
       });
     }
@@ -579,6 +597,7 @@ function initDMLogin(){
   if (logoutBtn) {
     logoutBtn.addEventListener('click', () => {
       if (menu) menu.hidden = true;
+      if (dmToggleBtn) dmToggleBtn.setAttribute('aria-expanded', 'false');
       logout();
     });
   }

--- a/styles/main.css
+++ b/styles/main.css
@@ -1378,10 +1378,15 @@ select[required]:valid{
   cursor:pointer;
 }
 .dm-login-btn img{display:block;max-width:160px;width:100%;height:auto}
+.dm-login-btn:disabled,.dm-login-btn.dm-login-btn--inactive{cursor:default;opacity:.65}
+.dm-login-btn:disabled img,.dm-login-btn.dm-login-btn--inactive img{opacity:1}
 .dm-tools-menu{position:fixed;bottom:80px;left:18px;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:2000}
 .dm-tools-menu[hidden]{display:none}
 .dm-tools-menu button{background:transparent;color:var(--text);border:none;padding:8px 12px;text-align:left;min-width:160px}
 .dm-tools-menu button:hover{background:var(--accent);color:var(--text-on-accent)}
+.dm-tools-toggle{position:fixed;bottom:18px;left:18px;display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:10px 16px;border-radius:var(--radius);border:1px solid var(--accent);background:var(--accent);color:var(--text-on-accent);font-weight:600;box-shadow:var(--shadow);cursor:pointer;z-index:2100}
+.dm-tools-toggle:hover{background:var(--accent-2);border-color:var(--accent-2)}
+.dm-tools-toggle[hidden]{display:none}
 
 /* DM Tool (Shards of Many Fates) */
 .somf-dm{background:var(--surface);color:var(--text);border:1px solid var(--line);border-radius:var(--radius);padding:12px;margin:0;width:100%;max-width:800px;max-height:calc(var(--vh,1vh)*100 - 32px);overflow:auto;-webkit-overflow-scrolling:touch}


### PR DESCRIPTION
## Summary
- add a dedicated floating DM Tools toggle that appears after logging in and disable the footer login button
- wire the DM logic to drive the new toggle, keep aria-expanded in sync, and update the associated tests
- style the floating toggle for consistent positioning with the tools menu

## Testing
- npm test -- dm_login

------
https://chatgpt.com/codex/tasks/task_e_68da681b4fa4832e89d4b769916193e1