### PR TITLE
Update MN24 ticker branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,12 +204,12 @@
   <div class="news-ticker news-ticker--m24n" role="status" aria-live="polite" aria-labelledby="m24n-ticker-label">
     <div class="news-ticker__inner">
       <span class="news-ticker__label news-ticker__label--m24n" id="m24n-ticker-label">
-        <span class="news-ticker__logo news-ticker__logo--m24n" aria-hidden="true">M24N</span>
+        <span class="news-ticker__logo news-ticker__logo--m24n" aria-hidden="true">MN24/7:</span>
         <span class="news-ticker__badge news-ticker__badge--live" aria-hidden="true">LIVE</span>
-        <span class="sr-only">M24N breaking news ticker</span>
+        <span class="sr-only">MN24/7 breaking news ticker</span>
       </span>
       <div class="news-ticker__track news-ticker__track--m24n" data-m24n-ticker-track>
-        <span class="news-ticker__text news-ticker__text--m24n" data-m24n-ticker-text>Loading M24N feed…</span>
+        <span class="news-ticker__text news-ticker__text--m24n" data-m24n-ticker-text>Loading MN24/7 feed…</span>
       </div>
     </div>
   </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1093,12 +1093,12 @@ if(m24nTrack && m24nText){
       pushCurrent();
       headlines = sets.slice(0, 100);
       if(!headlines.length){
-        throw new Error('No M24N headlines available');
+        throw new Error('No MN24/7 headlines available');
       }
       buildRotation();
     }catch(err){
-      console.error('Failed to load M24N ticker', err);
-      m24nText.textContent = 'M24N feed temporarily offline.';
+      console.error('Failed to load MN24/7 ticker', err);
+      m24nText.textContent = 'MN24/7 feed temporarily offline.';
     }
   }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -355,8 +355,9 @@ label[data-animate-title]{
   color:#131c30;
   font-family:'Race Sport',sans-serif;
   font-weight:800;
+  font-style:italic;
   font-size:clamp(.82rem,2.8vw,1.12rem);
-  letter-spacing:3px;
+  letter-spacing:1px;
   line-height:1;
   text-transform:uppercase;
   flex-shrink:0;
@@ -429,7 +430,7 @@ label[data-animate-title]{
   .news-ticker__logo--m24n{
     padding:0 clamp(8px,2.4vw,12px);
     font-size:clamp(.74rem,2.8vw,.94rem);
-    letter-spacing:3px;
+    letter-spacing:1px;
   }
   .news-ticker--m24n .news-ticker__badge{
     margin-left:clamp(4px,1.8vw,8px);
@@ -459,7 +460,7 @@ label[data-animate-title]{
   .news-ticker__logo--m24n{
     padding:0 clamp(8px,2.6vw,12px);
     font-size:clamp(.7rem,2.6vw,.88rem);
-    letter-spacing:3px;
+    letter-spacing:1px;
   }
   .news-ticker--m24n .news-ticker__badge{
     padding:0 clamp(4px,1.6vw,8px);


### PR DESCRIPTION
## Summary
- rename the M24N ticker label to MN24/7 and adjust supporting copy
- tighten the ticker logo letter spacing and render it in italics for better readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da7608812c832e9f398a8d8aa8169f