### PR TITLE
Center combat cards and remove ticker border

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -293,6 +293,7 @@ label[data-animate-title]{
   background:linear-gradient(90deg,rgba(17,21,32,.9) 0%,rgba(24,31,48,.88) 62%,rgba(13,17,25,.92) 100%);
   border-color:color-mix(in srgb,var(--accent) 60%, transparent);
   box-shadow:0 14px 34px rgba(12,16,28,.48);
+  border-bottom:none;
 }
 .news-ticker--m24n .news-ticker__inner{
   padding-left:0;
@@ -477,6 +478,10 @@ main{
   padding:0 calc(20px + env(safe-area-inset-right)) calc(4px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left));
 }
 fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:10px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translate3d(18px,0,0);cursor:default;pointer-events:none;will-change:opacity,transform;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);background-color:color-mix(in srgb,var(--surface) 5%,transparent)}
+fieldset[data-tab="combat"].card{flex-direction:column;align-items:center}
+fieldset[data-tab="combat"].card>*{width:100%}
+fieldset[data-tab="combat"].card .grid{justify-items:center}
+fieldset[data-tab="combat"].card .grid>.card{width:100%}
 main>:last-child{margin-bottom:0}
 fieldset[data-tab].card.active{display:flex;opacity:1;transform:translate3d(0,0,0);pointer-events:auto;animation:tab-panel-enter .45s cubic-bezier(.33,1,.68,1);animation-fill-mode:forwards}
 @keyframes tab-panel-enter{from{opacity:0;transform:translate3d(18px,0,0)}to{opacity:1;transform:translate3d(0,0,0)}}


### PR DESCRIPTION
## Summary
- center the Combat tab layout so its cards align in the middle of the page
- remove the bottom border from the MN24/7 ticker so the header ends with the feed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da89d6d954832eaac1496d5e02d6e5