### PR TITLE
Remove footer button shadow

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1381,6 +1381,7 @@ select[required]:valid{
   border:none;
   padding:0;
   background:transparent;
+  box-shadow:none;
   cursor:pointer;
 }
 .dm-login-btn img{display:block;max-width:160px;width:100%;height:auto}


### PR DESCRIPTION
## Summary
- remove the inherited drop shadow from the DM footer button so it blends with the footer background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8fc2ebb4832e8a8e2d39336ce3f3