### PR TITLE
Fix header padding to remain compact during scroll

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -40,7 +40,7 @@ h1{font-size:clamp(1.75rem,4.6vw,2rem);font-weight:700;color:var(--accent)}
 h2{font-size:clamp(1.35rem,3.8vw,1.5rem);font-weight:600;color:var(--accent)}
 h3{font-size:clamp(1.1rem,3.2vw,1.25rem);font-weight:600}
 h4{font-size:clamp(1rem,2.8vw,1.1rem);font-weight:600}
-header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding-top:calc(4px * 1.15 + constant(safe-area-inset-top));padding-right:calc(20px + constant(safe-area-inset-right));padding-bottom:calc(4px * 1.15 + constant(safe-area-inset-bottom));padding-left:calc(20px + constant(safe-area-inset-left));padding-top:calc(4px * 1.15 + env(safe-area-inset-top));padding-right:calc(20px + env(safe-area-inset-right));padding-bottom:calc(4px * 1.15 + env(safe-area-inset-bottom));padding-left:calc(20px + env(safe-area-inset-left));display:flex;flex-direction:column;gap:calc(6px * 1.15);isolation:isolate}
+header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding-top:calc(4px * 1.15);padding-right:calc(20px + env(safe-area-inset-right, 0px));padding-bottom:calc(4px * 1.15);padding-left:calc(20px + env(safe-area-inset-left, 0px));display:flex;flex-direction:column;gap:calc(6px * 1.15);isolation:isolate}
 header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(calc(-10px * 1.15))}
 header::before{content:none}
 @supports ((-webkit-backdrop-filter:blur(0)) or (backdrop-filter:blur(0))){


### PR DESCRIPTION
## Summary
- remove the safe-area driven top/bottom padding from the sticky header so its size no longer changes while scrolling
- retain horizontal safe-area support using env fallbacks to avoid clipping on notched devices

## Testing
- not run (CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68da98d46bec832eaebfddf0e483a54f