### PR TITLE
Improve tab swipe animation smoothness

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -478,6 +478,7 @@ main{
   padding:0 calc(20px + env(safe-area-inset-right)) calc(4px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left));
 }
 fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:10px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translate3d(18px,0,0);cursor:default;pointer-events:none;will-change:opacity,transform;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);background-color:color-mix(in srgb,var(--surface) 5%,transparent)}
+fieldset[data-tab].card.animating{display:flex!important;pointer-events:none;animation:none!important}
 fieldset[data-tab="combat"].card{
   flex-direction:column;
   align-items:center;
@@ -523,7 +524,7 @@ footer p{
   margin-left:auto;
   margin-right:auto;
 }
-.tab-swipe-indicator{position:fixed;top:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;padding:16px;border-radius:var(--radius);background:color-mix(in srgb,var(--surface) 85%,transparent);border:1px solid color-mix(in srgb,var(--accent) 70%,transparent);box-shadow:var(--shadow);pointer-events:none;opacity:0;transform:translate3d(var(--swipe-translate,0px),-50%,0);transition:opacity .2s ease,transform .2s ease;z-index:40}
+.tab-swipe-indicator{position:fixed;top:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;padding:16px;border-radius:var(--radius);background:color-mix(in srgb,var(--surface) 85%,transparent);border:1px solid color-mix(in srgb,var(--accent) 70%,transparent);box-shadow:var(--shadow);pointer-events:none;opacity:0;transform:translate3d(var(--swipe-translate,0px),-50%,0);transition:opacity .25s cubic-bezier(.33,1,.68,1),transform .45s cubic-bezier(.22,.61,.36,1);z-index:40}
 .tab-swipe-indicator.show{opacity:.95}
 .tab-swipe-indicator[data-side="left"]{left:16px}
 .tab-swipe-indicator[data-side="right"]{right:16px}


### PR DESCRIPTION
## Summary
- add a coordinated tab transition animation that slides the active and incoming panels for smoother tab switches
- ensure swipe gestures feed the transition direction and prevent overlapping animations
- tweak styling for swipe indicators and panels to keep visuals crisp during animated swaps

## Testing
- npm test *(fails: __tests__/dm_notifications_dm.test.js – fails on main branch as well)*

------
https://chatgpt.com/codex/tasks/task_e_68da9ddf2ea8832ea34277a86269fda1