### PR TITLE
Slow MN24/7 ticker on small screens

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -404,6 +404,11 @@ label[data-animate-title]{
   margin-left:calc(-1 * var(--m24n-line-width));
   padding-left:calc(var(--m24n-line-width) + var(--m24n-line-gap));
 }
+@media(max-width:899px){
+  .news-ticker__track--m24n{
+    --ticker-duration:40s;
+  }
+}
 .news-ticker__track--m24n.is-animating{
   animation:ticker-scroll-m24n var(--ticker-duration) linear forwards;
 }


### PR DESCRIPTION
## Summary
- increase the MN24/7 ticker animation duration on viewports below 900px so it scrolls more slowly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daaf7de1b4832e87af95c9446ace12