### PR TITLE
Adjust MN24/7 ticker speed on iPhone 14 Pro Max

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -409,6 +409,18 @@ label[data-animate-title]{
     --ticker-duration:40s;
   }
 }
+@supports (-webkit-touch-callout:none){
+  @media screen and (device-width:430px) and (device-height:932px) and (-webkit-device-pixel-ratio:3){
+    .news-ticker__track--m24n{
+      --ticker-duration:55s;
+    }
+  }
+  @media screen and (device-width:932px) and (device-height:430px) and (-webkit-device-pixel-ratio:3){
+    .news-ticker__track--m24n{
+      --ticker-duration:55s;
+    }
+  }
+}
 .news-ticker__track--m24n.is-animating{
   animation:ticker-scroll-m24n var(--ticker-duration) linear forwards;
 }


### PR DESCRIPTION
## Summary
- extend the MN24/7 ticker CSS to detect iPhone 14 Pro Max viewports
- slow the ticker animation to 55 seconds in both portrait and landscape on that device

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab943ec44832e83c4019b46b1f632