### PR TITLE
Add autosave recovery support

### DIFF
--- a/__tests__/character_events.test.js
+++ b/__tests__/character_events.test.js
@@ -13,6 +13,10 @@ describe('character events', () => {
       listCloudBackups: jest.fn().mockResolvedValue([]),
       listCloudBackupNames: jest.fn().mockResolvedValue([]),
       loadCloudBackup: jest.fn().mockResolvedValue({}),
+      saveCloudAutosave: jest.fn(),
+      listCloudAutosaves: jest.fn().mockResolvedValue([]),
+      listCloudAutosaveNames: jest.fn().mockResolvedValue([]),
+      loadCloudAutosave: jest.fn().mockResolvedValue({}),
       deleteCloud: jest.fn()
     }));
 

--- a/__tests__/character_list_quotes.test.js
+++ b/__tests__/character_list_quotes.test.js
@@ -61,6 +61,7 @@ describe('character list displays names with quotes', () => {
       saveCharacter: jest.fn(),
       renameCharacter: jest.fn(),
       listRecoverableCharacters: jest.fn().mockResolvedValue([]),
+      saveAutoBackup: jest.fn(),
     }));
     await import('../scripts/main.js');
   });

--- a/__tests__/credits_cloud.test.js
+++ b/__tests__/credits_cloud.test.js
@@ -36,6 +36,7 @@ describe('credits autosave to cloud', () => {
       saveCharacter,
       renameCharacter: jest.fn(),
       listRecoverableCharacters: jest.fn(),
+      saveAutoBackup: jest.fn(),
     }));
 
     jest.unstable_mockModule('../scripts/modal.js', () => ({ show: jest.fn(), hide: jest.fn() }));

--- a/__tests__/dm_list_modal.test.js
+++ b/__tests__/dm_list_modal.test.js
@@ -39,6 +39,7 @@ describe('DM load from character list', () => {
       deleteCharacter: jest.fn(),
       saveCharacter: jest.fn(),
       renameCharacter: jest.fn(),
+      saveAutoBackup: jest.fn(),
     }));
 
     jest.unstable_mockModule('../scripts/modal.js', () => ({ show, hide }));

--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -33,6 +33,10 @@ describe('dm login', () => {
       listCloudBackups: jest.fn(async () => []),
       listCloudBackupNames: jest.fn(async () => []),
       loadCloudBackup: jest.fn(async () => ({})),
+      saveCloudAutosave: jest.fn(),
+      listCloudAutosaves: jest.fn(async () => []),
+      listCloudAutosaveNames: jest.fn(async () => []),
+      loadCloudAutosave: jest.fn(async () => ({})),
       deleteCloud: jest.fn(),
     }));
     await import('../scripts/modal.js');
@@ -92,6 +96,10 @@ describe('dm login', () => {
       listCloudBackups: jest.fn(async () => []),
       listCloudBackupNames: jest.fn(async () => []),
       loadCloudBackup: jest.fn(async () => ({})),
+      saveCloudAutosave: jest.fn(),
+      listCloudAutosaves: jest.fn(async () => []),
+      listCloudAutosaveNames: jest.fn(async () => []),
+      loadCloudAutosave: jest.fn(async () => ({})),
       deleteCloud: jest.fn(),
     }));
     await import('../scripts/modal.js');
@@ -134,6 +142,10 @@ describe('dm login', () => {
       listCloudBackups: jest.fn(async () => []),
       listCloudBackupNames: jest.fn(async () => []),
       loadCloudBackup: jest.fn(async () => ({})),
+      saveCloudAutosave: jest.fn(),
+      listCloudAutosaves: jest.fn(async () => []),
+      listCloudAutosaveNames: jest.fn(async () => []),
+      loadCloudAutosave: jest.fn(async () => ({})),
       deleteCloud: jest.fn(),
     }));
 

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -284,9 +284,11 @@ function initDMLogin(){
       if (loggedIn) {
         dmBtn.classList.add('dm-login-btn--inactive');
         dmBtn.setAttribute('aria-disabled', 'true');
+        dmBtn.style.opacity = '1';
       } else {
         dmBtn.classList.remove('dm-login-btn--inactive');
         dmBtn.removeAttribute('aria-disabled');
+        dmBtn.style.opacity = '';
       }
     }
     if (dmToggleBtn) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -12,6 +12,7 @@ import {
   saveCharacter,
   renameCharacter,
   listRecoverableCharacters,
+  saveAutoBackup,
 } from './characters.js';
 import { show, hide } from './modal.js';
 import { cacheCloudSaves, subscribeCloudSaves } from './storage.js';
@@ -2604,10 +2605,21 @@ async function renderRecoverList(name){
   let backups = [];
   try { backups = await listBackups(name); }
   catch (e) { console.error('Failed to list backups', e); }
-  if(backups.length === 0){
+  const manual = backups.filter(b => b.type !== 'auto').sort((a, b) => b.ts - a.ts).slice(0, 3);
+  const autos = backups.filter(b => b.type === 'auto').sort((a, b) => b.ts - a.ts).slice(0, 3);
+  const renderGroup = (title, entries, type) => {
+    if(entries.length === 0){
+      return `<div class="recover-group"><h4>${title}</h4><p class="recover-empty">No ${title.toLowerCase()} found.</p></div>`;
+    }
+    const items = entries
+      .map(b => `<div class="catalog-item"><button class="btn-sm" data-recover-ts="${b.ts}" data-recover-type="${type}">${name} - ${new Date(b.ts).toLocaleString()}</button></div>`)
+      .join('');
+    return `<div class="recover-group"><h4>${title}</h4>${items}</div>`;
+  };
+  if(manual.length === 0 && autos.length === 0){
     list.innerHTML = '<p>No backups found.</p>';
   } else {
-    list.innerHTML = backups.map(b=>`<div class="catalog-item"><button class="btn-sm" data-recover-ts="${b.ts}">${name} - ${new Date(b.ts).toLocaleString()}</button></div>`).join('');
+    list.innerHTML = `${renderGroup('Auto Saves', autos, 'auto')}${renderGroup('Manual Saves', manual, 'manual')}`;
   }
   show('modal-recover-list');
 }
@@ -2716,9 +2728,13 @@ if(recoverListEl){
   recoverListEl.addEventListener('click', e=>{
     const btn = e.target.closest('button[data-recover-ts]');
     if(btn){
-      pendingLoad = { name: recoverTarget, ts: Number(btn.dataset.recoverTs) };
+      const type = btn.dataset.recoverType || 'manual';
+      pendingLoad = { name: recoverTarget, ts: Number(btn.dataset.recoverTs), type };
       const text = $('load-confirm-text');
-      if(text) text.textContent = `Are you sure you would like to recover ${pendingLoad.name} from ${new Date(pendingLoad.ts).toLocaleString()}? All current progress will be lost if you haven't saved yet.`;
+      if(text){
+        const descriptor = type === 'auto' ? 'auto save created on' : 'manual save from';
+        text.textContent = `Are you sure you would like to recover ${pendingLoad.name} from the ${descriptor} ${new Date(pendingLoad.ts).toLocaleString()}? All current progress will be lost if you haven't saved yet.`;
+      }
       hide('modal-recover-list');
       show('modal-load');
     }
@@ -2731,7 +2747,7 @@ async function doLoad(){
   if(!pendingLoad) return;
   try{
     const data = pendingLoad.ts
-      ? await loadBackup(pendingLoad.name, pendingLoad.ts)
+      ? await loadBackup(pendingLoad.name, pendingLoad.ts, pendingLoad.type)
       : await loadCharacter(pendingLoad.name);
     deserialize(data);
     setCurrentCharacter(pendingLoad.name);
@@ -4437,6 +4453,36 @@ function redo(){
     });
   }
 })();
+
+const CLOUD_AUTO_SAVE_INTERVAL_MS = 3 * 60 * 1000;
+let scheduledAutoSaveId = null;
+let scheduledAutoSaveInFlight = false;
+
+async function performScheduledAutoSave(){
+  if(scheduledAutoSaveInFlight) return;
+  const name = currentCharacter();
+  if(!name) return;
+  try {
+    scheduledAutoSaveInFlight = true;
+    const snapshot = serialize();
+    await saveAutoBackup(snapshot, name);
+  } catch (err) {
+    console.error('Scheduled auto save failed', err);
+  } finally {
+    scheduledAutoSaveInFlight = false;
+  }
+}
+
+function ensureAutoSaveTimer(){
+  if(typeof window === 'undefined') return;
+  if(scheduledAutoSaveId !== null) return;
+  scheduledAutoSaveId = window.setInterval(performScheduledAutoSave, CLOUD_AUTO_SAVE_INTERVAL_MS);
+}
+
+ensureAutoSaveTimer();
+if(typeof window !== 'undefined'){
+  window.addEventListener('focus', performScheduledAutoSave, { passive: true });
+}
 $('btn-save').addEventListener('click', async () => {
   const btn = $('btn-save');
   const oldChar = currentCharacter();

--- a/styles/main.css
+++ b/styles/main.css
@@ -1115,6 +1115,10 @@ progress::-moz-progress-bar{
 .catalog-item:last-child{border-bottom:none}
 .catalog-item.active{background:var(--accent);color:var(--text-on-accent)}
 .catalog-item.active .pill{border-color:var(--text-on-accent);color:var(--text-on-accent)}
+#recover-list .recover-group{margin-bottom:16px}
+#recover-list .recover-group:last-child{margin-bottom:0}
+#recover-list .recover-group h4{margin:8px 4px;font-size:1rem;font-weight:600;color:var(--muted)}
+#recover-list .recover-empty{padding:8px 4px;color:var(--muted)}
 #char-list .catalog-item{grid-template-columns:1fr auto auto}
 #char-list .catalog-item a{color:inherit;text-decoration:none;display:block}
 .small{font-size:.9rem;color:var(--muted)}


### PR DESCRIPTION
## Summary
- create separate cloud storage for manual and automatic backups and expose new helpers
- schedule a three-minute autosave that records the current character and surfaces a new autosave category in the recovery modal
- adjust styling and tests, including DM login handling, to reflect the new recovery layout and autosave functionality

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daf67a22e4832ea54a0980c5de8d6c