### PR TITLE
Tighten MN24/7 news ticker styling

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -287,13 +287,14 @@ label[data-animate-title]{
   --m24n-highlight:#e84561;
   --m24n-text:#f4f6ff;
   --m24n-line-width:2px;
-  --m24n-line-gap:clamp(12px,3vw,18px);
+  --m24n-line-gap:clamp(4px,1.4vw,10px);
   --m24n-line-color:color-mix(in srgb,var(--m24n-highlight) 90%, rgba(7,11,19,.65));
-  margin-top:6px;
+  margin-top:0;
   background:linear-gradient(90deg,rgba(17,21,32,.9) 0%,rgba(24,31,48,.88) 62%,rgba(13,17,25,.92) 100%);
-  border-color:color-mix(in srgb,var(--accent) 60%, transparent);
+  border:2px solid var(--m24n-line-color);
+  border-radius:8px;
   box-shadow:0 14px 34px rgba(12,16,28,.48);
-  border-bottom:none;
+  overflow:hidden;
 }
 .news-ticker--m24n .news-ticker__inner{
   padding-left:0;
@@ -305,8 +306,8 @@ label[data-animate-title]{
   text-shadow:0 2px 10px rgba(0,0,0,.38);
   clip-path:none;
   border-radius:8px 0 0 8px;
-  padding-right:var(--m24n-line-width);
-  gap:clamp(6px,2vw,12px);
+  padding-right:calc(var(--m24n-line-width) + 2px);
+  gap:clamp(3px,1.2vw,8px);
   justify-content:center;
   flex:0 0 auto;
   min-width:var(--pennant-width);
@@ -337,7 +338,7 @@ label[data-animate-title]{
   box-shadow:0 0 12px rgba(0,0,0,.35);
 }
 .news-ticker__label--m24n .news-ticker__badge--live{
-  margin-right:var(--m24n-line-gap);
+  margin-right:clamp(1px, var(--m24n-line-gap), 12px);
 }
 .news-ticker__logo--m24n{
   position:relative;
@@ -348,8 +349,8 @@ label[data-animate-title]{
   min-width:unset;
   min-width:0;
   max-width:100%;
-  height:calc(100% - 10px);
-  padding:0 clamp(10px,2.4vw,14px);
+  height:calc(100% - 4px);
+  padding:0 clamp(8px,2.2vw,12px);
   margin-block:auto;
   border-radius:4px;
   background:linear-gradient(135deg,#f7f8ff 0%,#dce3ff 52%,#fefeff 100%);
@@ -389,8 +390,8 @@ label[data-animate-title]{
   text-shadow:0 1px 4px rgba(0,0,0,.4);
 }
 .news-ticker--m24n .news-ticker__badge{
-  margin-left:clamp(6px,2vw,10px);
-  padding:0 clamp(6px,2vw,10px);
+  margin-left:clamp(2px,1.2vw,6px);
+  padding:0 clamp(4px,1.6vw,8px);
   min-height:18px;
   font-size:.58rem;
   letter-spacing:.16em;
@@ -438,21 +439,21 @@ label[data-animate-title]{
   .news-ticker--m24n{
     height:40px;
     min-height:40px;
-    --m24n-line-gap:clamp(8px,2.6vw,12px);
+    --m24n-line-gap:clamp(3px,1.4vw,6px);
   }
   .news-ticker__label--m24n{
-    gap:clamp(4px,1.8vw,10px);
+    gap:clamp(2px,1.4vw,6px);
     padding-left:env(safe-area-inset-left, 0px);
-    padding-right:calc(var(--m24n-line-width) + clamp(6px,2vw,12px));
+    padding-right:calc(var(--m24n-line-width) + clamp(3px,1.4vw,6px));
   }
   .news-ticker__logo--m24n{
-    padding:0 clamp(8px,2.4vw,12px);
+    padding:0 clamp(6px,2.2vw,10px);
     font-size:clamp(.74rem,2.8vw,.94rem);
     letter-spacing:1px;
   }
   .news-ticker--m24n .news-ticker__badge{
-    margin-left:clamp(4px,1.8vw,8px);
-    padding:0 clamp(4px,1.8vw,8px);
+    margin-left:clamp(2px,1.2vw,6px);
+    padding:0 clamp(3px,1.4vw,6px);
     min-height:16px;
     font-size:.52rem;
     letter-spacing:.12em;
@@ -469,19 +470,19 @@ label[data-animate-title]{
 
 @media(max-width:400px){
   .news-ticker--m24n{
-    --m24n-line-gap:clamp(6px,1.8vw,10px);
+    --m24n-line-gap:clamp(2px,1vw,4px);
   }
   .news-ticker__label--m24n{
-    gap:clamp(3px,1.4vw,6px);
-    padding-right:calc(var(--m24n-line-width) + clamp(4px,1.6vw,8px));
+    gap:clamp(2px,1.2vw,5px);
+    padding-right:calc(var(--m24n-line-width) + clamp(2px,1.2vw,5px));
   }
   .news-ticker__logo--m24n{
-    padding:0 clamp(8px,2.6vw,12px);
+    padding:0 clamp(6px,2.2vw,10px);
     font-size:clamp(.7rem,2.6vw,.88rem);
     letter-spacing:1px;
   }
   .news-ticker--m24n .news-ticker__badge{
-    padding:0 clamp(4px,1.6vw,8px);
+    padding:0 clamp(3px,1.2vw,5px);
     font-size:.5rem;
     letter-spacing:.12em;
   }


### PR DESCRIPTION
## Summary
- round the MN24/7 ticker borders so they wrap the title banner and share its styling
- reduce spacing between the MN24/7 title, live badge, and feed track for a tighter layout
- align the MN24/7 ticker flush beneath the OMNI tips ticker

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db03310be4832e90a726b87aefc9c5