### PR TITLE
Remove Fun Tip menu button and toast trigger

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,6 @@
         <button id="btn-campaign" class="btn-sm">Campaign Log</button>
         <button id="btn-rules" class="btn-sm">Rules</button>
         <button id="btn-help" class="btn-sm">Help</button>
-        <button id="btn-fun" class="btn-sm">Fun Tip</button>
       </div>
     </div>
   </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2566,20 +2566,6 @@ const btnHelp = $('btn-help');
 if (btnHelp) {
   btnHelp.addEventListener('click', ()=>{ show('modal-help'); });
 }
-const btnFun = $('btn-fun');
-if (btnFun) {
-  btnFun.addEventListener('click', async () => {
-    try{
-      const getNextTip = await ensureFunTips();
-      if(typeof getNextTip === 'function'){
-        toast(getNextTip(),'info');
-      }
-    }catch(err){
-      console.error('Failed to load fun tips', err);
-      toast('Fun tips are powering up. Try again soon!', 'error');
-    }
-  });
-}
 const btnLoad = $('btn-load');
 async function openCharacterList(){
   await renderCharacterList();


### PR DESCRIPTION
## Summary
- remove the Fun Tip button from the main menu
- drop the toast handler so Fun Tip popups no longer appear from the menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db06540000832eadffd121568180aa