### PR TITLE
Smooth swipe tab transitions

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -546,13 +546,6 @@ footer p{
   margin-left:auto;
   margin-right:auto;
 }
-.tab-swipe-indicator{position:fixed;top:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;padding:16px;border-radius:var(--radius);background:color-mix(in srgb,var(--surface) 85%,transparent);border:1px solid color-mix(in srgb,var(--accent) 70%,transparent);box-shadow:var(--shadow);pointer-events:none;opacity:0;transform:translate3d(var(--swipe-translate,0px),-50%,0);transition:opacity .25s cubic-bezier(.33,1,.68,1),transform .45s cubic-bezier(.22,.61,.36,1);z-index:40}
-.tab-swipe-indicator.show{opacity:.95}
-.tab-swipe-indicator[data-side="left"]{left:16px}
-.tab-swipe-indicator[data-side="right"]{right:16px}
-.tab-swipe-icon{display:flex;align-items:center;justify-content:center}
-.tab-swipe-icon svg{width:42px;height:42px}
-.tab-swipe-label{font-size:.75rem;letter-spacing:.08em;text-transform:uppercase;color:var(--text);text-align:center}
 .grid{display:grid;gap:12px}
 .grid-1{grid-template-columns:1fr}
 .grid-2{grid-template-columns:1fr}


### PR DESCRIPTION
## Summary
- remove the swipe overlay icon when changing tabs via gestures
- animate the active and target tab panels during swipes for a smoother transition
- ensure panel cleanup clears temporary animation styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db17cb4970832ea96bce9dd97991e4