### PR TITLE
Adjust cloud auto-save frequency to two minutes

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4579,7 +4579,7 @@ function redo(){
   }
 })();
 
-const CLOUD_AUTO_SAVE_INTERVAL_MS = 3 * 60 * 1000;
+const CLOUD_AUTO_SAVE_INTERVAL_MS = 2 * 60 * 1000;
 let scheduledAutoSaveId = null;
 let scheduledAutoSaveInFlight = false;
 


### PR DESCRIPTION
## Summary
- decrease the scheduled cloud auto-save interval from three minutes to two minutes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db1a523c00832ead7c7af554f4b88c