### PR TITLE
Add padding fallback to keep combat tab centered

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -493,7 +493,10 @@ main{
   width:100%;
   max-width:var(--content-width);
   margin:0 auto 16px;
-  padding:0 calc(20px + env(safe-area-inset-right)) calc(4px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left));
+  padding:0 20px 4px;
+  padding-right:calc(20px + env(safe-area-inset-right));
+  padding-left:calc(20px + env(safe-area-inset-left));
+  padding-bottom:calc(4px + env(safe-area-inset-bottom));
 }
 fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:10px;margin-bottom:14px;box-shadow:var(--shadow);display:none;opacity:0;transform:translate3d(18px,0,0);cursor:default;pointer-events:none;will-change:opacity,transform;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);background-color:color-mix(in srgb,var(--surface) 5%,transparent)}
 fieldset[data-tab].card.animating{display:flex!important;pointer-events:none;animation:none!important}
@@ -530,7 +533,10 @@ footer{
   font-size:9pt;
   margin:0 auto;
   margin-top:auto;
-  padding:12px calc(20px + env(safe-area-inset-right)) calc(44px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left));
+  padding:12px 20px 44px;
+  padding-right:calc(20px + env(safe-area-inset-right));
+  padding-left:calc(20px + env(safe-area-inset-left));
+  padding-bottom:calc(44px + env(safe-area-inset-bottom));
   color:var(--muted);
   max-width:var(--content-width);
   width:100%;


### PR DESCRIPTION
## Summary
- add baseline padding to the main content area when safe-area environment variables are unsupported so the combat tab stays centered
- apply the same padding fallback to the footer to keep page chrome aligned with the combat layout

## Testing
- Manual verification in Chromium (screenshot attached)


------
https://chatgpt.com/codex/tasks/task_e_68db1fb6ba44832e86121b54de048208