### PR TITLE
Adjust DM login button and footer shadow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1055,7 +1055,7 @@
 <footer>
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
   <button id="dm-login" class="dm-login-btn" aria-label="DM Tools">
-    <img src="images/XoVrom.png" alt="XoVrom Industries logo">
+    <img class="dm-login-logo" src="images/XoVrom.png" alt="XoVrom Industries logo">
   </button>
 </footer>
 <div id="dm-tools-menu" class="dm-tools-menu" hidden>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1429,6 +1429,8 @@ select[required]:valid{
   max-width:160px;
   width:100%;
   height:auto;
+}
+.dm-login-logo{
   box-shadow:var(--shadow);
 }
 .dm-login-btn:disabled,.dm-login-btn.dm-login-btn--inactive{cursor:default;opacity:.65}


### PR DESCRIPTION
## Summary
- add a dedicated class to the DM login footer logo image
- remove the inherited button shadow and apply the drop shadow to the PNG instead

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db4eb170cc832eb1a5a7b6a508da5d