### PR TITLE
Center combat tab contents

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -564,24 +564,25 @@ fieldset[data-tab].card.animating{display:flex!important;pointer-events:none;ani
 fieldset[data-tab="combat"].card{
   flex-direction:column;
   align-items:center;
+  width:100%;
   --combat-max-width:min(100%, 640px);
 }
 fieldset[data-tab="combat"].card>*{
   width:var(--combat-max-width);
+  max-width:var(--combat-max-width);
   margin-inline:auto;
-  margin-left:auto;
-  margin-right:auto;
 }
 fieldset[data-tab="combat"].card .grid{
   width:100%;
+  max-width:var(--combat-max-width);
+  margin-inline:auto;
   justify-items:center;
 }
 fieldset[data-tab="combat"].card .grid>.card{width:100%}
 fieldset[data-tab="combat"].card .somf-card{
   width:100%;
+  max-width:var(--combat-max-width);
   margin-inline:auto;
-  margin-left:auto;
-  margin-right:auto;
 }
 main>:last-child{margin-bottom:0}
 fieldset[data-tab].card.active{display:flex;opacity:1;transform:translate3d(0,0,0);pointer-events:auto;animation:tab-panel-enter .45s cubic-bezier(.33,1,.68,1);animation-fill-mode:forwards}


### PR DESCRIPTION
## Summary
- ensure the combat tab container spans the available width and uses a shared max-width value
- apply the combat tab max-width to child grids and cards so they stay centered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db50e689ac832e924c7d5ebfd33d12