### PR TITLE
Hide DM login button after authentication

### DIFF
--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -57,8 +57,8 @@ describe('dm login', () => {
     const dmBtn = document.getElementById('dm-login');
     const menu = document.getElementById('dm-tools-menu');
     const toggle = document.getElementById('dm-tools-toggle');
-    expect(dmBtn.disabled).toBe(true);
-    expect(dmBtn.getAttribute('aria-disabled')).toBe('true');
+    expect(dmBtn.hidden).toBe(true);
+    expect(dmBtn.getAttribute('aria-hidden')).toBe('true');
     expect(toggle.hidden).toBe(false);
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     expect(menu.hidden).toBe(true);
@@ -116,7 +116,7 @@ describe('dm login', () => {
     const dmBtn = document.getElementById('dm-login');
     const menu = document.getElementById('dm-tools-menu');
     const toggle = document.getElementById('dm-tools-toggle');
-    expect(dmBtn.disabled).toBe(true);
+    expect(dmBtn.hidden).toBe(true);
     expect(toggle.hidden).toBe(false);
     expect(menu.hidden).toBe(true);
     toggle.click();

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -280,15 +280,11 @@ function initDMLogin(){
       renderStoredNotifications();
     }
     if (dmBtn){
-      dmBtn.disabled = loggedIn;
+      dmBtn.hidden = loggedIn;
       if (loggedIn) {
-        dmBtn.classList.add('dm-login-btn--inactive');
-        dmBtn.setAttribute('aria-disabled', 'true');
-        dmBtn.style.opacity = '1';
+        dmBtn.setAttribute('aria-hidden', 'true');
       } else {
-        dmBtn.classList.remove('dm-login-btn--inactive');
-        dmBtn.removeAttribute('aria-disabled');
-        dmBtn.style.opacity = '';
+        dmBtn.removeAttribute('aria-hidden');
       }
     }
     if (dmToggleBtn) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1494,8 +1494,6 @@ select[required]:valid{
 .dm-login-logo{
   box-shadow:var(--shadow);
 }
-.dm-login-btn:disabled,.dm-login-btn.dm-login-btn--inactive{cursor:default;opacity:.65}
-.dm-login-btn:disabled img,.dm-login-btn.dm-login-btn--inactive img{opacity:1}
 .dm-tools-menu{position:fixed;bottom:80px;left:18px;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:2000}
 .dm-tools-menu[hidden]{display:none}
 .dm-tools-menu button{background:transparent;color:var(--text);border:none;padding:8px 12px;text-align:left;min-width:160px}


### PR DESCRIPTION
## Summary
- hide the DM login button once a session is authenticated to avoid the disabled-state visual glitch
- remove obsolete disabled styles and update the DM login tests for the hidden state

## Testing
- npm test -- dm_login

------
https://chatgpt.com/codex/tasks/task_e_68db51860030832e8d9fbd4e668635cc