### PR TITLE
Restyle DM tools toggle button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1064,7 +1064,13 @@
   <button id="dm-tools-characters" class="btn-sm">Characters</button>
   <button id="dm-tools-logout" class="btn-sm">Logout</button>
 </div>
-<button id="dm-tools-toggle" class="dm-tools-toggle" hidden aria-haspopup="true" aria-controls="dm-tools-menu">DM Tools</button>
+<button id="dm-tools-toggle" class="dm-tools-toggle" hidden aria-haspopup="true" aria-controls="dm-tools-menu" aria-label="DM tools menu">
+  <svg class="dm-tools-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.592c.55 0 1.02.398 1.11.94l.214 1.285c.063.374.326.686.672.838.347.152.744.142 1.08-.026l1.155-.577a1.125 1.125 0 011.45.516l1.296 2.247a1.125 1.125 0 01-.286 1.431l-1.003.753a1.125 1.125 0 00-.401 1.13l.214 1.285c.09.542-.262 1.06-.78 1.12l-1.29.143a1.125 1.125 0 00-.966.86l-.213 1.285c-.091.542-.56.94-1.111.94h-2.591c-.55 0-1.02-.398-1.11-.94l-.214-1.285a1.125 1.125 0 00-.672-.838 1.125 1.125 0 00-1.08.027l-1.155.577a1.125 1.125 0 01-1.45-.516l-1.296-2.247a1.125 1.125 0 01.286-1.431l1.003-.753a1.125 1.125 0 00.401-1.13l-.214-1.285a1.125 1.125 0 01.78-1.12l1.29-.143a1.125 1.125 0 00.966-.86l.213-1.285z" />
+    <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+  </svg>
+  <span class="sr-only">DM Tools</span>
+</button>
 <div class="overlay hidden" id="dm-login-modal" aria-hidden="true">
   <section class="modal">
     <button id="dm-login-close" class="x" aria-label="Close">

--- a/styles/main.css
+++ b/styles/main.css
@@ -1495,13 +1495,49 @@ select[required]:valid{
 .dm-login-logo{
   box-shadow:var(--shadow);
 }
-.dm-tools-menu{position:fixed;bottom:80px;left:18px;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:2000}
+.dm-tools-menu{position:fixed;bottom:80px;left:18px;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);z-index:2000}
 .dm-tools-menu[hidden]{display:none}
 .dm-tools-menu button{background:transparent;color:var(--text);border:none;padding:8px 12px;text-align:left;min-width:160px}
 .dm-tools-menu button:hover{background:var(--accent);color:var(--text-on-accent)}
-.dm-tools-toggle{position:fixed;bottom:18px;left:18px;display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:10px 16px;border-radius:var(--radius);border:1px solid var(--accent);background:var(--accent);color:var(--text-on-accent);font-weight:600;box-shadow:var(--shadow);cursor:pointer;z-index:2100}
-.dm-tools-toggle:hover{background:var(--accent-2);border-color:var(--accent-2)}
+.dm-tools-toggle{
+  position:fixed;
+  bottom:18px;
+  left:18px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:56px;
+  height:56px;
+  padding:0;
+  border-radius:999px;
+  border:1px solid var(--line);
+  background:var(--surface);
+  color:var(--text);
+  box-shadow:var(--shadow);
+  cursor:pointer;
+  z-index:2100;
+  transition:var(--transition),transform .2s ease;
+}
+.dm-tools-toggle:hover,
+.dm-tools-toggle:focus-visible{
+  background:var(--surface-2);
+  color:var(--accent);
+  border-color:var(--accent);
+}
+.dm-tools-toggle:focus-visible{
+  outline:2px solid var(--accent);
+  outline-offset:3px;
+}
 .dm-tools-toggle[hidden]{display:none}
+.dm-tools-toggle__icon{
+  width:26px;
+  height:26px;
+  transition:transform .3s ease;
+}
+.dm-tools-toggle:hover .dm-tools-toggle__icon,
+.dm-tools-toggle:focus-visible .dm-tools-toggle__icon{
+  transform:rotate(25deg);
+}
 
 /* DM Tool (Shards of Many Fates) */
 .somf-dm{background:var(--surface);color:var(--text);border:1px solid var(--line);border-radius:var(--radius);padding:12px;margin:0 auto;width:100%;max-width:800px;max-height:calc(var(--vh,1vh)*100 - 32px);overflow:auto;-webkit-overflow-scrolling:touch}


### PR DESCRIPTION
## Summary
- replace the DM tools toggle label button with a circular SVG gear icon and accessible text
- restyle the toggle and menu border to use theme-aware surface, line, and accent colors with hover/focus animation

## Testing
- npm test -- --runTestsByPath __tests__/dm_login.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db6ce099d4832e9042ab31e5fb43c8