### PR TITLE
Remove hover effect from DM login button and add footer image shadow

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1486,15 +1486,14 @@ select[required]:valid{
   box-shadow:none;
   cursor:pointer;
 }
+.dm-login-btn:hover{filter:none;transform:none}
 .dm-login-btn img{
   display:block;
   max-width:160px;
   width:100%;
   height:auto;
 }
-.dm-login-logo{
-  box-shadow:var(--shadow);
-}
+.dm-login-logo{filter:drop-shadow(0 6px 12px rgba(0,0,0,.45))}
 .dm-tools-menu{position:fixed;bottom:80px;left:18px;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:2000}
 .dm-tools-menu[hidden]{display:none}
 .dm-tools-menu button{background:transparent;color:var(--text);border:none;padding:8px 12px;text-align:left;min-width:160px}


### PR DESCRIPTION
## Summary
- disable the hover transform/brightness effect on the DM Login button and remove its box shadow
- add a drop shadow directly to the DM Login footer PNG to keep a subtle depth effect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db6d8d3388832ea0bc2a409355c2c6