### PR TITLE
Remove DM login button hover and add footer logo shadow

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1484,7 +1484,14 @@ select[required]:valid{
   padding:0;
   background:transparent;
   box-shadow:none;
+  filter:none;
+  transform:none;
   cursor:pointer;
+}
+.dm-login-btn:hover,
+.dm-login-btn:focus{
+  filter:none;
+  transform:none;
 }
 .dm-login-btn img{
   display:block;
@@ -1493,7 +1500,7 @@ select[required]:valid{
   height:auto;
 }
 .dm-login-logo{
-  box-shadow:var(--shadow);
+  filter:drop-shadow(0 6px 12px rgba(0,0,0,.35));
 }
 .dm-tools-menu{position:fixed;bottom:80px;left:18px;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);z-index:2000}
 .dm-tools-menu[hidden]{display:none}


### PR DESCRIPTION
## Summary
- remove the hover animation from the DM Login button and keep it flat
- apply a drop shadow directly to the DM footer logo for subtle depth

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db882e04a0832eb49cc55e7a67aff8