### PR TITLE
Center combat tab contents

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -576,11 +576,15 @@ fieldset[data-tab="combat"].card>*{
   width:var(--combat-max-width);
   max-width:var(--combat-max-width);
   margin-inline:auto;
+  margin-left:auto;
+  margin-right:auto;
 }
 fieldset[data-tab="combat"].card .grid{
   width:100%;
   max-width:var(--combat-max-width);
   margin-inline:auto;
+  margin-left:auto;
+  margin-right:auto;
   justify-items:center;
 }
 fieldset[data-tab="combat"].card .grid>.card{width:100%}
@@ -588,6 +592,8 @@ fieldset[data-tab="combat"].card .somf-card{
   width:100%;
   max-width:var(--combat-max-width);
   margin-inline:auto;
+  margin-left:auto;
+  margin-right:auto;
 }
 main>:last-child{margin-bottom:0}
 fieldset[data-tab].card.active{display:flex;opacity:1;transform:translate3d(0,0,0);pointer-events:auto;animation:tab-panel-enter .45s cubic-bezier(.33,1,.68,1);animation-fill-mode:forwards}


### PR DESCRIPTION
## Summary
- ensure combat tab sections explicitly auto-center horizontally for browsers that ignore logical margin properties

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba57dcc0c832eaf971ded56fe99b6