### PR TITLE
Restore shard reveal experience and polish DM toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@
 </div>
 <button id="dm-tools-toggle" class="dm-tools-toggle" hidden aria-haspopup="true" aria-controls="dm-tools-menu" aria-label="DM tools menu">
   <svg class="dm-tools-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.592c.55 0 1.02.398 1.11.94l.214 1.285c.063.374.326.686.672.838.347.152.744.142 1.08-.026l1.155-.577a1.125 1.125 0 011.45.516l1.296 2.247a1.125 1.125 0 01-.286 1.431l-1.003.753a1.125 1.125 0 00-.401 1.13l.214 1.285c.09.542-.262 1.06-.78 1.12l-1.29.143a1.125 1.125 0 00-.966.86l-.213 1.285c-.091.542-.56.94-1.111.94h-2.591c-.55 0-1.02-.398-1.11-.94l-.214-1.285a1.125 1.125 0 00-.672-.838 1.125 1.125 0 00-1.08.027l-1.155.577a1.125 1.125 0 01-1.45-.516l-1.296-2.247a1.125 1.125 0 01.286-1.431l1.003-.753a1.125 1.125 0 00.401-1.13l-.214-1.285a1.125 1.125 0 01.78-1.12l1.29-.143a1.125 1.125 0 00.966-.86l.213-1.285z" />
+    <path stroke-linecap="round" stroke-linejoin="round" d="M6.633 10.5c-.05.495-.08.995-.08 1.5s.03 1.005.08 1.5l-1.358 1.022a.75.75 0 00-.196.942l1.5 2.598c.173.3.533.425.858.3l1.6-.64a9.06 9.06 0 001.299.75l.24 1.708c.045.33.324.58.658.58h3a.659.659 0 00.658-.58l.24-1.708a8.964 8.964 0 001.3-.75l1.598.64c.325.125.685 0 .858-.3l1.5-2.598a.75.75 0 00-.196-.942L17.367 13.5c.05-.495.08-.995.08-1.5s-.03-1.005-.08-1.5l1.358-1.022a.75.75 0 00.196-.942l-1.5-2.598a.75.75 0 00-.858-.3l-1.598.64a8.964 8.964 0 00-1.3-.75L13.525 4.32A.659.659 0 0012.867 3.75h-3a.659.659 0 00-.658.57l-.24 1.708a9.06 9.06 0 00-1.299.75l-1.6-.64a.75.75 0 00-.858.3l-1.5 2.598a.75.75 0 00.196.942L6.633 10.5z" />
     <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
   </svg>
   <span class="sr-only">DM Tools</span>
@@ -1350,6 +1350,12 @@
 <div id="load-animation" aria-hidden="true" hidden></div>
 <div id="draw-lightning" aria-hidden="true" hidden></div>
 <div id="draw-flash" aria-hidden="true" hidden></div>
+<div id="somf-reveal-toast" class="somf-reveal-toast" hidden>
+  <div class="somf-reveal-toast__card" role="alertdialog" aria-modal="true" aria-labelledby="somf-reveal-toast-title">
+    <h3 id="somf-reveal-toast-title">The Shards of Many Fates have revealed themselves to you, do you dare tempt Fate?</h3>
+    <button id="somf-reveal-toast-dismiss" class="somf-btn somf-primary somf-reveal-toast__dismiss">Eeeeeeehhh...</button>
+  </div>
+</div>
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
 </div>
 <script type="module" src="scripts/header-title.js"></script>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1522,19 +1522,22 @@ select[required]:valid{
   height:56px;
   padding:0;
   border-radius:999px;
-  border:1px solid var(--line);
-  background:var(--surface);
+  border:1px solid color-mix(in srgb,var(--line) 70%,transparent);
+  background:linear-gradient(135deg,color-mix(in srgb,var(--surface) 85%,transparent),color-mix(in srgb,var(--surface-2) 92%,transparent));
   color:var(--text);
-  box-shadow:var(--shadow);
+  box-shadow:0 12px 24px rgba(0,0,0,.35);
   cursor:pointer;
   z-index:2100;
-  transition:var(--transition),transform .2s ease;
+  transition:background-color .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease;
+  will-change:transform,box-shadow;
+  transform:translateZ(0);
 }
 .dm-tools-toggle:hover,
 .dm-tools-toggle:focus-visible{
-  background:var(--surface-2);
+  background:linear-gradient(135deg,color-mix(in srgb,var(--surface-2) 92%,transparent),color-mix(in srgb,var(--surface-3, var(--surface-2)) 96%,transparent));
   color:var(--accent);
-  border-color:var(--accent);
+  border-color:color-mix(in srgb,var(--accent) 60%,transparent);
+  box-shadow:0 16px 32px rgba(0,0,0,.45);
 }
 .dm-tools-toggle:focus-visible{
   outline:2px solid var(--accent);
@@ -1598,6 +1601,10 @@ select[required]:valid{
 .somf-dm__toasts{position:fixed;right:12px;bottom:12px;display:flex;flex-direction:column;gap:8px;z-index:9999}
 .somf-dm__queue{position:fixed;right:12px;bottom:60px;margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:4px;z-index:9998}
 .somf-dm__queue li{background:#0b1119;color:#e6f1ff;border:1px solid #1b2532;border-radius:8px;padding:6px 10px;cursor:pointer;min-width:200px}
+.somf-reveal-toast{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.82);backdrop-filter:blur(6px);z-index:4600;padding:24px}
+.somf-reveal-toast__card{background:var(--surface);color:var(--text);border:1px solid color-mix(in srgb,var(--accent) 18%,var(--line));border-radius:18px;box-shadow:0 18px 48px rgba(0,0,0,.45);padding:32px 28px;max-width:min(420px,90vw);text-align:center;display:flex;flex-direction:column;gap:18px}
+.somf-reveal-toast__card h3{margin:0;font-size:1.5rem;font-weight:700;letter-spacing:.01em;line-height:1.4;text-transform:uppercase}
+.somf-reveal-toast__dismiss{align-self:center;min-width:180px}
 #modal-somf-dm{padding:0}
 #modal-somf-dm .somf-dm{max-width:800px;max-height:calc(var(--vh,1vh)*100 - 32px);width:100%;height:100%;border-radius:var(--radius);display:flex;flex-direction:column;overflow:hidden}
 #modal-somf-dm .somf-dm__tab{flex:1;overflow:auto;-webkit-overflow-scrolling:touch}


### PR DESCRIPTION
## Summary
- refresh the DM tools floating action button visuals and swap in a cleaner gear icon
- add a shared shard reveal sequence with lightning flash, centered toast, and forced refresh handling
- trigger the reveal sequence when shards are revealed for both DM and player views while skipping repeats after reload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dba7fcc508832ebaaeccf68fb400f2