### PR TITLE
Replace unload handler for audio context

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -636,9 +636,16 @@ function applyLockIcons(root=document){
   qsa('button[data-lock]', root).forEach(btn=>{ applyLockIcon(btn); });
 }
 let audioCtx = null;
-window.addEventListener('unload', () => {
+const closeAudioContext = () => {
   if (audioCtx && typeof audioCtx.close === 'function') {
     audioCtx.close();
+  }
+};
+
+window.addEventListener('pagehide', closeAudioContext, { once: true });
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'hidden') {
+    closeAudioContext();
   }
 });
 function playTone(type){


### PR DESCRIPTION
## Summary
- replace deprecated unload listener with pagehide and visibilitychange handlers to close the audio context safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb5b5f028832e8417efdcba20ed3a