### PR TITLE
Fix launch animation media probes and Firebase import

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,9 @@
     playsinline
     preload="auto"
     webkit-playsinline
+    data-src-webm="media/launch-animation.webm"
+    data-src-mp4="media/launch-animation.mp4"
   >
-    <source src="media/launch-animation.webm" type="video/webm"/>
-    <source src="media/launch-animation.mp4" type="video/mp4"/>
     <source src="images/b02fb7b3-095b-4e40-9e4e-20fb5ee3b4b9.mp4" type="video/mp4"/>
     Sorry, your browser does not support the launch animation video.
   </video>

--- a/scripts/somf-firebase.js
+++ b/scripts/somf-firebase.js
@@ -1,5 +1,21 @@
-import firebase from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js';
-import 'https://www.gstatic.com/firebasejs/9.22.2/firebase-database-compat.js';
+async function loadFirebaseCompat(){
+  if (window.firebase?.database) {
+    return window.firebase;
+  }
+
+  await Promise.all([
+    import('https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js'),
+    import('https://www.gstatic.com/firebasejs/9.22.2/firebase-database-compat.js')
+  ]);
+
+  if (!window.firebase?.database) {
+    throw new Error('Failed to load Firebase compat libraries.');
+  }
+
+  return window.firebase;
+}
+
+const firebase = await loadFirebaseCompat();
 
 const firebaseConfig = {
   databaseURL: 'https://ccccg-7d6b6-default-rtdb.firebaseio.com'


### PR DESCRIPTION
## Summary
- load the Firebase compat bundles dynamically so `firebase` is defined before initialization
- defer wiring launch animation sources until the files are confirmed to exist, preventing 404 errors

## Testing
- npm test -- --runTestsByPath __tests__/player_shards_default.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dbb5da1dd8832e80b960b7a775522a