### PR TITLE
Fix accessibility labels for ability and skill grids

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1558,7 +1558,7 @@ const ABILS = ['str','dex','con','int','wis','cha'];
 const abilGrid = $('abil-grid');
 abilGrid.innerHTML = ABILS.map(a=>`
   <div class="ability-box">
-    <label>${a.toUpperCase()}</label>
+    <label for="${a}">${a.toUpperCase()}</label>
     <div class="score">
       <select id="${a}"></select>
       <span class="mod" id="${a}-mod">+0</span>
@@ -1569,7 +1569,7 @@ ABILS.forEach(a=>{ const sel=$(a); for(let v=10; v<=28; v++) sel.add(new Option(
 const saveGrid = $('saves');
 saveGrid.innerHTML = ABILS.map(a=>`
   <div class="ability-box">
-    <label>${a.toUpperCase()}</label>
+    <span class="ability-label">${a.toUpperCase()}</span>
     <div class="score"><span class="score-val" id="save-${a}">+0</span></div>
     <label class="inline"><input type="checkbox" id="save-${a}-prof"/> Proficient</label>
     <button class="btn-sm" data-roll-save="${a}">Roll</button>
@@ -1600,7 +1600,7 @@ const SKILLS = [
 const skillGrid = $('skills');
 skillGrid.innerHTML = SKILLS.map((s,i)=>`
   <div class="ability-box">
-    <label>${s.name}</label>
+    <span class="ability-label">${s.name}</span>
     <div class="score"><span class="score-val" id="skill-${i}">+0</span></div>
     <label class="inline"><input type="checkbox" id="skill-${i}-prof"/> Proficient</label>
     <button class="btn-sm" data-roll-skill="${i}">Roll</button>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1273,12 +1273,14 @@ body.modal-open [data-launch-shell]> :not(.overlay){pointer-events:none;user-sel
   gap:6px;
 }
 
-.ability-box label{
+.ability-box label,
+.ability-box .ability-label{
   margin-bottom:0;
 }
 
 /* Ensure skill names like "Sleight of Hand" fit on one line */
-#skills .ability-box label{
+#skills .ability-box label,
+#skills .ability-box .ability-label{
   font-size:0.85rem;
   white-space:nowrap;
 }


### PR DESCRIPTION
## Summary
- associate ability score labels with their select inputs for better accessibility
- replace decorative labels in the save and skill grids with semantic spans and update styling to match

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbb7f00f20832e81a1927c95eb8e29