### PR TITLE
Preserve welcome modal when skipping launch animation

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -355,7 +355,19 @@ const LAUNCH_MAX_WAIT = 12000;
   if(skipButton){
     const handleSkip = event => {
       event.preventDefault();
+      let shouldRestoreWelcome = false;
+      const welcomeModal = document.getElementById('modal-welcome');
+      if (welcomeModal && !welcomeModal.classList.contains('hidden')) {
+        shouldRestoreWelcome = true;
+      }
       finalizeLaunch();
+      if (shouldRestoreWelcome) {
+        window.requestAnimationFrame(() => {
+          if (welcomeModal && welcomeModal.classList.contains('hidden')) {
+            show('modal-welcome');
+          }
+        });
+      }
     };
     skipButton.addEventListener('click', handleSkip);
   }


### PR DESCRIPTION
## Summary
- prevent the launch skip button from hiding the welcome modal
- restore the welcome dialog if it was open when the animation is skipped

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbbb1cdbc8832e9f5e66465c23169d