### PR TITLE
Add input lock when skipping launch animation

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -28,6 +28,8 @@ body.launching{overflow:hidden;height:100vh;height:100dvh;background:#000}
   margin:0 auto;
 }
 body.launching .app-shell{opacity:0}
+body.launch-input-locked{user-select:none;-webkit-user-select:none;touch-action:none}
+body.launch-input-locked>*{pointer-events:none!important}
 #launch-animation{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:0;background:#000;z-index:2000;opacity:0;pointer-events:none;transition:opacity .6s ease,visibility .6s ease;visibility:hidden;width:100vw;height:100vh;height:100dvh;min-height:100vh;min-height:100dvh;box-sizing:border-box}
 body.launching #launch-animation{opacity:1;visibility:visible;pointer-events:auto}
 #launch-animation[data-hidden="true"]{opacity:0;visibility:hidden;pointer-events:none}


### PR DESCRIPTION
## Summary
- add a temporary input lock when the launch animation is skipped so the welcome modal has time to appear
- add CSS to disable pointer events while the launch input lock is active

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbea9297ec832ea5490b2e70dbf53d