### PR TITLE
Adjust layout spacing for tab content

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -554,7 +554,7 @@ label[data-animate-title]{
 }
 @keyframes ticker-scroll{from{transform:translate3d(100%,0,0)}to{transform:translate3d(calc(-100% - var(--ticker-gap)),0,0)}}
 main{
-  flex:1 0 auto;
+  flex:0 0 auto;
   width:100%;
   max-width:var(--content-width);
   margin:0 auto 16px;
@@ -608,7 +608,7 @@ footer{
   text-align:center;
   font-size:9pt;
   margin:0 auto;
-  margin-top:auto;
+  margin-top:0;
   padding:12px 20px 44px;
   padding-right:calc(20px + env(safe-area-inset-right));
   padding-left:calc(20px + env(safe-area-inset-left));


### PR DESCRIPTION
## Summary
- stop the main content column from stretching to fill the viewport so tab panels shrink to their content
- let the footer sit directly beneath the active tab card by removing its auto top margin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf08f2684832e86bb9e20c7f58dd3