### PR TITLE
Improve welcome modal timing and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,16 +816,16 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
-    <h3>Welcome to the Catalyst Core!</h3>
+    <h3 class="welcome-title">Welcome to the <span class="welcome-title-break">Catalyst Core!</span></h3>
     <p><u>Create or Load Your Hero Profile</u><br>
     This is your Vigilante record. Without it, you don’t exist in the Core.</p>
     <p aria-hidden="true">&nbsp;</p>
     <p><u>Use the Tabs</u><br>
-    Combat: Track your combat stats.<br>
-    Stats: Track your abilities, and skills.<br>
-    Powers: Track your powers and signature moves.<br>
-    Gear: Requisition, equip, upgrade and update your arsenal.<br>
-    Personal Details: Log your mission details and personal intel.</p>
+    <span class="welcome-tab-label">Combat:</span> Track your combat stats.<br>
+    <span class="welcome-tab-label">Stats:</span> Track your abilities, and skills.<br>
+    <span class="welcome-tab-label">Powers:</span> Track your powers and signature moves.<br>
+    <span class="welcome-tab-label">Gear:</span> Requisition, equip, upgrade and update your arsenal.<br>
+    <span class="welcome-tab-label">Personal Details:</span> Log your mission details and personal intel.</p>
     <p aria-hidden="true">&nbsp;</p>
     <p><u>Save &amp; Sync</u><br>
     Auto-Save every 2 minutes to O.M.N.I.’s network. No excuses for lost data.</p>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -124,16 +124,23 @@ function dismissWelcomeModal() {
   hide(WELCOME_MODAL_ID);
 }
 
-function queueWelcomeModal() {
+function queueWelcomeModal(options = {}) {
   if (welcomeModalDismissed || welcomeModalQueued) return;
   welcomeModalQueued = true;
+  const triggerShow = () => {
+    welcomeModalQueued = false;
+    maybeShowWelcomeModal();
+  };
+
+  if (options.immediate) {
+    triggerShow();
+    return;
+  }
+
   const schedule = typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
     ? window.requestAnimationFrame
     : (cb => setTimeout(cb, 0));
-  schedule(() => {
-    welcomeModalQueued = false;
-    maybeShowWelcomeModal();
-  });
+  schedule(triggerShow);
 }
 (async function setupLaunchAnimation(){
   const body = document.body;
@@ -191,7 +198,7 @@ function queueWelcomeModal() {
 
   const finalizeReveal = () => {
     body.classList.remove('launching');
-    queueWelcomeModal();
+    queueWelcomeModal({ immediate: true });
     if(launchEl){
       launchEl.addEventListener('transitionend', cleanupLaunchShell, { once: true });
       window.setTimeout(cleanupLaunchShell, 1000);

--- a/styles/main.css
+++ b/styles/main.css
@@ -17,6 +17,8 @@ body,h1,h2,h3,h4,p,figure,blockquote,dl,dd{margin:0}
 html{height:100%;background:var(--bg);transition:var(--transition);scroll-behavior:smooth;-webkit-tap-highlight-color:transparent}
 body{min-height:100%;margin:0;background:transparent;color:var(--text);font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased;overflow-x:hidden;line-height:1.6;font-size:clamp(.95rem,2.2vw,1rem);transition:var(--transition);opacity:1;padding:0}
 body.launching{overflow:hidden;height:100vh;height:100dvh;background:#000}
+body.launching [data-launch-shell]{pointer-events:none;touch-action:none}
+body.launching [data-launch-shell] *{pointer-events:none}
 .app-shell{
   opacity:1;
   transition:opacity .6s ease;
@@ -1245,6 +1247,12 @@ body.modal-open [data-launch-shell]> :not(.overlay){pointer-events:none;user-sel
 #modal-help{align-items:flex-start;overflow-y:auto}
 #modal-help .modal{max-height:none}
 #modal-welcome .modal{font-size:.85rem;line-height:1.4}
+#modal-welcome .welcome-title{margin-bottom:8px}
+#modal-welcome .welcome-title-break{display:inline}
+#modal-welcome .welcome-tab-label{text-decoration:underline;font-weight:600}
+@media (max-width:480px){
+  #modal-welcome .welcome-title-break{display:block}
+}
 #modal-welcome .actions{justify-content:center;width:100%}
 #modal-help .feature-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px;font-size:90%}
 #modal-help .feature-list li{display:flex;flex-direction:column;align-items:flex-start;gap:2px}


### PR DESCRIPTION
## Summary
- split the welcome modal title into a responsive two-line layout on small screens and underline the tab labels for clarity
- prevent touch interaction with the app shell while the launch animation plays and re-enable it once the modal opens
- show the welcome modal immediately after the launch sequence completes by allowing immediate queue execution

## Testing
- npm test -- --runTestsByPath __tests__/dummy.test.js *(fails: ENOENT: no such file or directory, open '/workspace/CCCCG/__tests__/dummy.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_68dc1e53d678832e9284919d091f1bad