### PR TITLE
Rewrite help modal copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -849,182 +849,131 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
-    <h3>How to Use the Tracker</h3>
+    <h3>Catalyst Core Help</h3>
     <p>
-      Catalyst Core keeps your entire character sheet at your fingertips. The guide below walks through every
-      feature so you can confidently build, track, and play without leaving the table.
+      Keep this reference open while you play to understand what each tab, modal, and control in the current build is designed to
+      do.
     </p>
     <h4>Getting Started</h4>
     <ul class="feature-list">
       <li>
-        <b>Launch Experience</b>
-        The animated splash runs only the first time you open the app in a session. Tap <i>Skip</i> if you want to jump
-        straight into the sheet, or simply wait for the video to finish and the interface will unlock automatically.
-        Returning players can disable the animation by choosing <i>Skip</i>; the app remembers your preference until you
-        refresh the page.
+        <b>Launch &amp; Welcome</b>
+        The intro video plays the first time you open the sheet during a visit. Tap <i>Skip</i> on the welcome modal or wait for the
+        clip to finish and the sheet unlocks automatically for the rest of the session.
       </li>
       <li>
-        <b>Theme Controls</b>
-        Tap the Catalyst Core logo in the header to rotate between light, high-contrast, and dark themes tailored for
-        different lighting conditions. The currently selected theme persists locally, so your preferred look is waiting the
-        next time you open the tracker. If you switch devices, just tap the logo again to instantly reapply your favorite mode.
+        <b>Create or Load</b>
+        Start from the welcome modal or open <i>Load / Save</i> from the menu to create a new hero, switch between existing records,
+        or recover a backup.
+      </li>
+      <li>
+        <b>Offline Ready</b>
+        Once your character data loads, the tracker continues working without a connection. Changes sync the next time you come
+        back online.
+      </li>
+    </ul>
+    <h4>Navigating the Sheet</h4>
+    <ul class="feature-list">
+      <li>
+        <b>Tabs</b>
+        Use the tab bar to swap between Combat, Abilities, Powers, Gear, and Story. Combat handles HP, SP, status tracking, dice
+        tools, and Resonance Points. Abilities keeps ability scores, saves, and skills linked to your proficiency bonus. Powers
+        stores reusable cards and Signature Moves. Gear tracks loadouts, credits, and catalog imports. Story captures identity
+        details, classifications, reputation, and notes.
       </li>
       <li>
         <b>Main Menu</b>
-        Open the menu button in the top right to access Load / Save, View Mode, Encounter, Action Log, Campaign Log, Rules,
-        and Help. Every menu option opens a modal with detailed controls while keeping your character sheet intact behind it.
-        If you are on a touch device, the menu respects focus trapping so you can dismiss it with a single tap outside or on the
-        close button.
+        The header menu button opens overlays for Load / Save, View Mode, Encounter / Initiative, Action Log, Campaign Log, Rules,
+        and this Help screen. Each modal floats above the sheet so you never lose context, and you can close any of them with Esc
+        or by tapping outside.
+      </li>
+      <li>
+        <b>Themes &amp; Visibility</b>
+        Click the Catalyst Core logo to cycle through every available theme. Your selection is stored locally, and certain
+        Story-tab classifications apply their matching palette automatically.
       </li>
     </ul>
     <h4>Managing Characters</h4>
     <ul class="feature-list">
       <li>
-        <b>Create, Load, and Save</b>
-        Choose <i>Load / Save</i> to open the character manager where you can create new heroes, load existing ones, or recover
-        backups. The tracker saves automatically, but manual saves let you capture milestones before major encounters. Backups
-        sync across browsers that share the same account so you can pick up where you left off on any device.
+        <b>Autosave &amp; Manual Saves</b>
+        Character changes write to local storage automatically while you edit. Use the <i>Save</i> button in Load / Save to create a
+        manual snapshot before big scenes.
       </li>
       <li>
+        <b>Recover Backups</b>
+        <i>Recover Save</i> lists recent autosaves and manual backups with timestamps. Restoring one replaces the sheet only after
+        you confirm, giving you a safe way to undo mistakes.
+      </li>
+      <li>
+        <b>PIN Protection</b>
+        Assign a numeric PIN to any character from the Load / Save manager. The sheet will request that code before loading or
+        editing that record on shared devices.
+      </li>
+    </ul>
+    <h4>Session Tools</h4>
+    <ul class="feature-list">
+      <li>
         <b>View Mode</b>
-        Toggle View Mode from the menu to lock all inputs and present a read-only sheet for quick reference or screen sharing.
-        While in View Mode, buttons show their interactive tooltips but do not allow edits, ensuring accidental taps never change
-        your stats. Toggle View Mode off to return to full editing control.
+        Toggle View Mode from the menu to hide editing widgets and present a read-only layout. Switch back to continue updating
+        stats.
+      </li>
+      <li>
+        <b>Encounter / Initiative</b>
+        Add combatants with their initiative values, then step through turns with <i>Prev Turn</i> and <i>Next Turn</i>. Use <i>Reset</i>
+        when a fight ends.
       </li>
       <li>
         <b>Action Log</b>
-        The Action Log captures every stat change, roll, and note in chronological order. Open it to review recent decisions,
-        and select <i>Full Log</i> for an expanded view that is perfect for session recaps. Clearing the log does not delete
-        your character—only the recorded history—so you can archive or export notes before wiping it.
+        Automated events such as damage, healing, rests, and resource adjustments appear here. Open the full log for a
+        chronological history.
       </li>
       <li>
         <b>Campaign Log</b>
-        Use the Campaign Log to store story beats, NPC details, and lore discoveries separate from mechanical notes. Entries are
-        timestamped automatically, letting you reconstruct adventures session by session. You can delete outdated items individually,
-        keeping the log curated without starting over.
-      </li>
-    </ul>
-    <h4>Tabs and Gameplay Tools</h4>
-    <ul class="feature-list">
-      <li>
-        <b>Combat Tab</b>
-        Manage HP, SP, temporary bonuses, and death saves in one place, with quick-access buttons for common adjustments.
-        Tap defenses or initiative to edit values, and use the inline dice roller and coin flipper for instant results. Death save
-        trackers light up with success or failure so you always know where you stand in the fight.
+        Capture session highlights as short entries. Each note stays tied to the active character and saves automatically.
       </li>
       <li>
-        <b>Abilities Tab</b>
-        Adjust core ability scores, calculate derived modifiers, and track proficiency bonuses that power many other parts of the
-        sheet. The tab keeps your current character level in sync, ensuring saving throws and skill bonuses remain accurate as you
-        level up. Each field supports keyboard input and mobile number pads for fast updates.
-      </li>
-      <li>
-        <b>Powers Tab</b>
-        Record spells, techniques, or signature abilities, complete with usage counts and descriptions. Collapse and expand entries
-        to focus on the powers you need during the current encounter while keeping the rest archived below. Reset usage counters after
-        rests with a single tap to maintain accurate tracking across sessions.
-      </li>
-      <li>
-        <b>Gear Tab</b>
-        Log equipment, consumables, and currencies alongside notes about location or attunement. Drag to reorder items so your most
-        important gear sits at the top, and archive spent consumables without deleting them by moving them to the story section. The
-        tab is optimized for both long lists and concise loadouts thanks to its responsive layout.
-      </li>
-      <li>
-        <b>Story Tab</b>
-        Capture background elements, character goals, and world hooks in structured sections. Rich text formatting keeps key names
-        and locations easy to spot, and the content autosaves as you type. Use this space to store session summaries or reminders for
-        your next adventure.
-      </li>
-      <li>
-        <b>Encounter Tracker</b>
-        Launch the Encounter modal from the menu to manage initiative, turn order, and combatant statuses. Add allies and enemies with
-        custom initiative scores, then advance rounds with the Prev and Next buttons that highlight the active participant. Reset the
-        tracker when combat ends to start fresh in moments.
-      </li>
-    </ul>
-    <h4>Advanced Tips</h4>
-    <ul class="feature-list">
-      <li>
-        <b>Keyboard and Accessibility</b>
-        Every input supports keyboard navigation, and tab order follows the sheet layout so you can update stats quickly without a mouse.
-        Screen reader labels mirror on-screen terminology, ensuring accessible play for all party members. Use the skip link at the top of
-        the page to jump directly to the main content when navigating via keyboard.
-      </li>
-      <li>
-        <b>Data Safety</b>
-        The tracker saves changes locally in real time and mirrors them to cloud storage when an internet connection is detected. If you
-        need to switch browsers, export from Load / Save and import on the new device to carry your character forward. For extra security,
-        enable a PIN on individual characters so only players with the code can modify them.
-      </li>
-      <li>
-        <b>Sync and Recovery</b>
-        Automatic backups run periodically, creating both manual and auto-save recovery points. Should you need to roll back, open Load /
-        Save, choose <i>Recover</i>, and select the timestamp you want to restore. The app keeps your current sheet safe until you confirm
-        the recovery, giving you a preview before committing to the change.
+        <b>Rules Reference</b>
+        The Rules modal provides quick summaries of key mechanics while keeping the character sheet visible behind it.
       </li>
     </ul>
     <h4>Frequently Asked Questions</h4>
-    <ul class="qa-list">
+    <ul class="feature-list">
       <li>
-        <b>Can I use the tracker offline?</b>
-        Absolutely. The tracker caches its interface and stores your characters in local browser storage, allowing full offline play once it
-        has loaded. Any changes you make while offline sync automatically the next time you reconnect, so you never lose progress from a
-        session in the field.
+        <b>How often does the sheet save?</b>
+        Autosave runs in the background while you edit. Use <i>Save</i> in the Load / Save modal any time you want to capture an
+        explicit checkpoint.
       </li>
       <li>
         <b>How do I change the theme?</b>
-        Tap the Catalyst Core logo at the top of the screen to cycle between available themes in order. The app remembers your last
-        selection, so you only need to change it again if you want a different style. Each theme adjusts colors across the entire interface
-        to maintain readability and accessibility.
+        Tap the Catalyst Core logo. Each press advances to the next palette, and Story classifications with theme tie-ins can set
+        their own look automatically.
       </li>
       <li>
-        <b>What is the fastest way to update HP or SP?</b>
-        Open the Combat tab and tap your current HP or SP values to reveal increment controls and direct edit fields. You can apply damage or
-        healing with quick buttons, or type exact numbers when precision matters. Every change is logged so you can review the sequence later
-        if questions arise.
+        <b>Where do I track Resonance Points?</b>
+        The Combat tab includes the Resonance Point track and Heroic Surge callouts so you can see current and aftermath states at
+        a glance.
       </li>
       <li>
-        <b>Can I track initiative within the app?</b>
-        Yes—the Encounter modal is designed for initiative tracking. Add each combatant with a name and initiative score, then use the Prev
-        and Next buttons to rotate turns while the active participant is highlighted. You can reset the list at the end of combat without
-        disturbing any other character data.
+        <b>Can I work offline?</b>
+        Yes. After the app loads once, it functions offline. Any edits you make sync the next time you reconnect.
       </li>
       <li>
-        <b>How do I organize my powers or spells?</b>
-        Visit the Powers tab to create entries with descriptions, usage counters, and tags for quick filtering. You can reorder items and
-        collapse those you do not need at the moment, keeping the list focused during intense encounters. After a rest, tap the reset option
-        to restore usage counts across the board.
+        <b>How do I restore an earlier state?</b>
+        Use <i>Recover Save</i> to browse timestamps for autosaves and manual backups, then confirm the one you need.
       </li>
       <li>
-        <b>What happens if I accidentally change something important?</b>
-        The Action Log records every adjustment with timestamps so you can identify what changed and when. Use the log to undo manual edits or
-        to confirm the correct value after accidental taps. For additional safety, enable View Mode while sharing your screen so observers do
-        not alter values inadvertently.
+        <b>Where can I find gear options?</b>
+        Open the Gear tab and tap the catalog button to browse equipment from the bundled data files or add custom entries.
       </li>
       <li>
-        <b>Can I keep story notes separate from mechanical data?</b>
-        Definitely. The Story tab provides rich text fields for narrative details, while the Campaign Log tracks chronological session notes.
-        Use them together to preserve both world lore and mechanical milestones without cluttering your combat interface. Since everything is
-        autosaved, you can jot down ideas mid-session without breaking your flow.
+        <b>How do I keep narrative notes?</b>
+        Pair the Story tab’s questions and freeform notes with the Campaign Log’s timestamped entries for a complete journal of the
+        character and the campaign.
       </li>
       <li>
-        <b>How do backups and recovery work?</b>
-        The Load / Save manager lists recent manual saves and automated backups with timestamps. Selecting <i>Recover</i> lets you preview the
-        version you want before committing, ensuring you revert only when you're sure. Recoveries create a new backup of your current state so
-        you can reverse course if you change your mind.
-      </li>
-      <li>
-        <b>Is my data secure if I share a device?</b>
-        You can assign PIN protection to specific characters from the Load / Save interface. Once enabled, the tracker requests the PIN before
-        edits are made, preventing unauthorized changes on shared tablets or kiosks. Remember to disable the PIN when you intentionally hand off
-        the character to another player.
-      </li>
-      <li>
-        <b>What if I need rules references while playing?</b>
-        The Rules option in the main menu opens the integrated rules compendium tailored for Catalyst Core. Use it to search terminology,
-        confirm conditions, or browse quick-start guides without leaving the tracker. Pair it with the Campaign Log for a complete reference
-        library during every session.
+        <b>How do I secure my character on a shared device?</b>
+        Set a PIN in Load / Save. The sheet asks for that code before someone can open or edit the character.
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Summary
- replace the help modal content with updated sections covering getting started steps, navigation, character management, session tools, and FAQs that reflect the current build
- remove DM-focused guidance from the help modal so the reference focuses on player-facing workflows like autosave, theme switching, and resonance tracking

## Testing
- not run (HTML content update)


------
https://chatgpt.com/codex/tasks/task_e_68dc5ef1c848832eab0b81950006875e