### PR TITLE
Add cloud-backed campaign log backlog and default actor

### DIFF
--- a/__tests__/campaign_log_character_name.test.js
+++ b/__tests__/campaign_log_character_name.test.js
@@ -45,6 +45,7 @@ function setupDom() {
 }
 
 describe('campaign log includes character name', () => {
+  let characters;
   beforeEach(async () => {
     jest.resetModules();
     localStorage.clear();
@@ -56,8 +57,8 @@ describe('campaign log includes character name', () => {
       json: async () => null,
     });
     window.confirm = jest.fn(() => true);
-    localStorage.setItem('last-save', 'Alice');
     await import('../scripts/main.js');
+    characters = await import('../scripts/characters.js');
     document.dispatchEvent(new Event('DOMContentLoaded'));
   });
 
@@ -66,12 +67,21 @@ describe('campaign log includes character name', () => {
     delete window.confirm;
   });
 
-  test('records current character name', () => {
+  test('defaults to mysterious force when no character loaded', () => {
     const entry = document.getElementById('campaign-entry');
     entry.value = 'Test note';
     document.getElementById('campaign-add').click();
     const stored = JSON.parse(localStorage.getItem('campaign-log'));
-    expect(stored[0].name).toBe('Alice');
+    expect(stored[stored.length - 1].name).toBe('A Mysterious Force');
+  });
+
+  test('records active character name once loaded', () => {
+    characters.setCurrentCharacter('Alice');
+    const entry = document.getElementById('campaign-entry');
+    entry.value = 'Hero note';
+    document.getElementById('campaign-add').click();
+    const stored = JSON.parse(localStorage.getItem('campaign-log'));
+    expect(stored[stored.length - 1].name).toBe('Alice');
   });
 });
 

--- a/__tests__/character_events.test.js
+++ b/__tests__/character_events.test.js
@@ -17,7 +17,11 @@ describe('character events', () => {
       listCloudAutosaves: jest.fn().mockResolvedValue([]),
       listCloudAutosaveNames: jest.fn().mockResolvedValue([]),
       loadCloudAutosave: jest.fn().mockResolvedValue({}),
-      deleteCloud: jest.fn()
+      deleteCloud: jest.fn(),
+      appendCampaignLogEntry: jest.fn().mockResolvedValue({ id: 'test', t: Date.now(), name: '', text: '' }),
+      deleteCampaignLogEntry: jest.fn().mockResolvedValue(),
+      fetchCampaignLogEntries: jest.fn().mockResolvedValue([]),
+      subscribeCampaignLog: () => null,
     }));
 
     const { saveCharacter, deleteCharacter } = await import('../scripts/characters.js');

--- a/__tests__/credits_cloud.test.js
+++ b/__tests__/credits_cloud.test.js
@@ -41,7 +41,14 @@ describe('credits autosave to cloud', () => {
 
     jest.unstable_mockModule('../scripts/modal.js', () => ({ show: jest.fn(), hide: jest.fn() }));
 
-    jest.unstable_mockModule('../scripts/storage.js', () => ({ cacheCloudSaves: () => {}, subscribeCloudSaves: () => {} }));
+    jest.unstable_mockModule('../scripts/storage.js', () => ({
+      cacheCloudSaves: () => {},
+      subscribeCloudSaves: () => {},
+      appendCampaignLogEntry: jest.fn().mockResolvedValue({ id: 'test', t: Date.now(), name: '', text: '' }),
+      deleteCampaignLogEntry: jest.fn().mockResolvedValue(),
+      fetchCampaignLogEntries: jest.fn().mockResolvedValue([]),
+      subscribeCampaignLog: () => null,
+    }));
 
     global.toast = jest.fn();
     global.confirm = jest.fn(() => true);

--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -38,6 +38,10 @@ describe('dm login', () => {
       listCloudAutosaveNames: jest.fn(async () => []),
       loadCloudAutosave: jest.fn(async () => ({})),
       deleteCloud: jest.fn(),
+      appendCampaignLogEntry: jest.fn().mockResolvedValue({ id: 'test', t: Date.now(), name: '', text: '' }),
+      deleteCampaignLogEntry: jest.fn().mockResolvedValue(),
+      fetchCampaignLogEntries: jest.fn().mockResolvedValue([]),
+      subscribeCampaignLog: () => null,
     }));
     await import('../scripts/modal.js');
     await import('../scripts/dm.js');
@@ -101,6 +105,10 @@ describe('dm login', () => {
       listCloudAutosaveNames: jest.fn(async () => []),
       loadCloudAutosave: jest.fn(async () => ({})),
       deleteCloud: jest.fn(),
+      appendCampaignLogEntry: jest.fn().mockResolvedValue({ id: 'test', t: Date.now(), name: '', text: '' }),
+      deleteCampaignLogEntry: jest.fn().mockResolvedValue(),
+      fetchCampaignLogEntries: jest.fn().mockResolvedValue([]),
+      subscribeCampaignLog: () => null,
     }));
     await import('../scripts/modal.js');
     await import('../scripts/dm.js');
@@ -147,6 +155,10 @@ describe('dm login', () => {
       listCloudAutosaveNames: jest.fn(async () => []),
       loadCloudAutosave: jest.fn(async () => ({})),
       deleteCloud: jest.fn(),
+      appendCampaignLogEntry: jest.fn().mockResolvedValue({ id: 'test', t: Date.now(), name: '', text: '' }),
+      deleteCampaignLogEntry: jest.fn().mockResolvedValue(),
+      fetchCampaignLogEntries: jest.fn().mockResolvedValue([]),
+      subscribeCampaignLog: () => null,
     }));
 
     await import('../scripts/dm.js');
@@ -171,12 +183,12 @@ describe('dm login', () => {
     const { currentCharacter } = await import('../scripts/characters.js');
     await import('../scripts/dm.js');
 
-    expect(currentCharacter()).toBe('The DM');
+    expect(currentCharacter()).toBeNull();
 
     document.getElementById('dm-tools-logout').click();
 
     expect(sessionStorage.getItem('dmLoggedIn')).toBeNull();
-    expect(currentCharacter()).toBe('The DM');
+    expect(currentCharacter()).toBeNull();
     expect(localStorage.getItem('last-save')).toBe('The DM');
   });
 });

--- a/index.html
+++ b/index.html
@@ -1104,6 +1104,20 @@
       <button id="campaign-add" class="btn-sm" style="max-width:140px">Add Entry</button>
     </div>
     <div id="campaign-log" class="catalog"></div>
+    <div class="actions actions--center"><button id="campaign-view-backlog" class="btn-sm" type="button" disabled aria-disabled="true">View Backlog</button></div>
+    <div class="actions"><button class="btn-sm" data-close>Close</button></div>
+  </div>
+</div>
+
+<div class="overlay hidden" id="modal-campaign-backlog" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Campaign Log Backlog</h3>
+    <div id="campaign-backlog" class="catalog"></div>
     <div class="actions"><button class="btn-sm" data-close>Close</button></div>
   </div>
 </div>

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -96,11 +96,6 @@ async function verifyPin(name) {
 let currentName = null;
 
 export function currentCharacter() {
-  if (currentName) return currentName;
-  try {
-    const last = localStorage.getItem('last-save');
-    if (last) currentName = last;
-  } catch {}
   return currentName;
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -47,6 +47,7 @@ header::before{content:none}
   header::before{content:"";position:absolute;inset:0;background:color-mix(in srgb,var(--surface) 92%, transparent);-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);pointer-events:none;z-index:-1}
 }
 .actions{display:flex;gap:calc(6px * 1.15);flex-wrap:wrap}
+.actions.actions--center{justify-content:center}
 .dropdown{position:relative;display:flex;align-items:center;justify-self:center;grid-column:5;margin-left:0}
 .menu{position:absolute;top:calc(100% + 4px);right:0;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50;opacity:0;transform:translateY(-10px) scale(.96);visibility:hidden;transition:opacity .24s cubic-bezier(.22,1,.36,1),transform .24s cubic-bezier(.22,1,.36,1);pointer-events:none;transform-origin:top right;will-change:opacity,transform}
 .menu.show{opacity:1;transform:translateY(0) scale(1);visibility:visible;pointer-events:auto}


### PR DESCRIPTION
## Summary
- add Firebase-backed campaign log helpers and realtime subscription
- limit the campaign modal to the last 100 entries and expose a backlog modal synced to the cloud
- default campaign/action entries to “A Mysterious Force” until a character loads and update tests for the new behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc6422be64832e9d3379526172a68f