### PR TITLE
Improve welcome modal timing after launch

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -138,7 +138,33 @@ function maybeShowWelcomeModal() {
     unlockTouchControls();
     return;
   }
+  const wasHidden = modal.classList.contains('hidden');
   show(WELCOME_MODAL_ID);
+
+  if (!wasHidden) {
+    if (!document.body?.classList?.contains('launching')) {
+      unlockTouchControls();
+    }
+    return;
+  }
+
+  const body = document.body;
+  const schedule = typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
+    ? window.requestAnimationFrame.bind(window)
+    : (cb => setTimeout(cb, 0));
+
+  if (body && body.classList.contains('launching')) {
+    const waitForLaunchEnd = () => {
+      if (!body.classList.contains('launching')) {
+        unlockTouchControls();
+        return;
+      }
+      schedule(waitForLaunchEnd);
+    };
+    schedule(waitForLaunchEnd);
+    return;
+  }
+
   unlockTouchControls();
 }
 
@@ -226,7 +252,6 @@ function queueWelcomeModal({ immediate = false } = {}) {
 
   const finalizeReveal = () => {
     body.classList.remove('launching');
-    queueWelcomeModal({ immediate: true });
     if(launchEl){
       launchEl.addEventListener('transitionend', cleanupLaunchShell, { once: true });
       window.setTimeout(cleanupLaunchShell, 1000);
@@ -238,6 +263,7 @@ function queueWelcomeModal({ immediate = false } = {}) {
     revealCalled = true;
     detachMessaging();
     cleanupUserGestures();
+    queueWelcomeModal({ immediate: true });
     if(typeof window !== 'undefined' && Object.prototype.hasOwnProperty.call(window, '__resetLaunchVideo')){
       try {
         delete window.__resetLaunchVideo;


### PR DESCRIPTION
## Summary
- request the welcome modal as soon as the launch reveal begins so it is ready when the animation ends
- wait to release the touch lock until the launch state clears, avoiding interaction gaps

## Testing
- npm test -- --runTestsByPath __tests__/modal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc65a60b98832e8a430e8cca35df85