### PR TITLE
Center primary navigation tabs

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -75,7 +75,17 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 [data-tip]:hover::after,[data-tip]:focus::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--surface-2);color:var(--text);padding:4px 8px;border-radius:var(--radius);box-shadow:var(--shadow);white-space:nowrap;font-size:.75rem;z-index:1500}
 .breadcrumb,.breadcrumbs{display:none}
 .top{display:grid;grid-template-columns:repeat(5,1fr);align-items:center;gap:calc(6px * 1.15);position:relative}
-.tabs{display:grid;grid-template-columns:repeat(5,1fr);align-items:center;gap:calc(4px * 1.15);width:100%;transition:opacity .4s ease,transform .4s ease}
+.tabs{
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  gap:calc(4px * 1.15);
+  flex-wrap:wrap;
+  width:100%;
+  max-width:var(--content-width);
+  margin-inline:auto;
+  transition:opacity .4s ease,transform .4s ease;
+}
 .tabs-title{
   padding:0 8px;
   font-size:clamp(1.1rem,3.6vw,1.75rem);


### PR DESCRIPTION
## Summary
- update the primary tab bar layout to use a centered flex container
- ensure the navigation row maintains equal spacing on both sides regardless of viewport width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc71d4f42c832e85335867fe7de2f6