### PR TITLE
Create dedicated Cinematic Action Point card

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,6 +326,10 @@
           <button id="sp-full" class="btn-sm">Reset SP</button>
         </div>
         <button id="long-rest" class="btn-sm">Long Rest</button>
+      </fieldset>
+      <fieldset class="card cap-field">
+        <legend data-animate-title>Cinematic Action Point</legend>
+        <p class="card-info">Each session grants one Cinematic Action Point—a wildcard for heroic stunts, clutch rerolls, or narrative swings. Check it when you spend the boost; it stays used until a Long Rest or session reset.</p>
         <div class="cap-box">
           <label for="cap-check">
             <input type="checkbox" id="cap-check"/>

--- a/styles/main.css
+++ b/styles/main.css
@@ -181,6 +181,12 @@ label[data-animate-title]{
   margin-bottom:0;
 }
 
+.card-info{
+  font-size:.95rem;
+  line-height:1.5;
+  color:var(--muted);
+}
+
 .tabs .tab{justify-self:center}
 
 .tabs-title .logo{
@@ -1228,7 +1234,7 @@ progress::-moz-progress-bar{
 
 .sp-field #sp-temp{flex:0 0 60px;max-width:60px;}
 .sp-field #long-rest{width:100%;margin-top:8px;}
-.sp-field .cap-box{margin-top:8px;}
+.cap-field .cap-box{margin-top:8px;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:8px;display:flex;flex-direction:column;gap:10px;transition:box-shadow .3s ease-in-out;background:color-mix(in srgb,var(--surface) 5%,transparent);background-color:color-mix(in srgb,var(--surface) 5%,transparent);-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);margin-left:auto;margin-right:auto;width:100%;max-width:var(--content-width);font-size:1.1rem}
 .gear-card .gear-card-title{margin:0}
 .gear-card .gear-card-action{align-self:flex-start}


### PR DESCRIPTION
## Summary
- move the Cinematic Action Point control into its own card next to the SP tools
- add descriptive copy so players understand when and how to spend the point
- style the new card description and update the CAP spacing rule

## Testing
- npm test -- action_log

------
https://chatgpt.com/codex/tasks/task_e_68dd072cbebc832ea995c52ee1a1845a