### PR TITLE
Adjust layout of power and signature move buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,13 +459,13 @@
   <!-- POWERS -->
   <fieldset data-tab="powers" class="card">
     <h2 class="card-title">Powers</h2>
-    <div class="inline" style="justify-content:flex-end">
+    <div style="display:flex;justify-content:flex-end;margin-bottom:16px">
       <button id="add-power" style="max-width:180px">Add Power</button>
     </div>
     <div class="grid grid-2" id="powers"></div>
 
-    <div class="inline" style="justify-content:space-between;margin-top:8px">
-      <h3 style="margin:0">Signature Moves</h3>
+    <h3 style="margin:16px 0 8px">Signature Moves</h3>
+    <div style="display:flex;justify-content:flex-end;margin-bottom:16px">
       <button id="add-sig" style="max-width:200px">Add Signature Move</button>
     </div>
     <div class="grid grid-2" id="sigs"></div>


### PR DESCRIPTION
## Summary
- place the Add Power button directly beneath the Powers header while retaining right-aligned positioning
- separate the Signature Moves heading from its button so the control appears directly underneath the title

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd07c95fa0832ea017a6def43ed9ab