### PR TITLE
Center load modal action buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -740,7 +740,7 @@
 
 
 <div class="overlay hidden" id="modal-load-list" aria-hidden="true">
-  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+  <div class="modal modal--load-save" role="dialog" aria-modal="true" tabindex="-1">
     <button class="x" data-close aria-label="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
@@ -748,7 +748,7 @@
     </button>
     <h3>All Characters</h3>
     <div id="char-list" class="catalog"></div>
-    <div class="actions">
+    <div class="actions actions--center modal--load-save__actions">
       <button id="btn-save" class="btn-sm" type="button">Save</button>
       <button id="recover-save" class="btn-sm" type="button">Recover Save</button>
       <button id="create-character" class="btn-sm" type="button">Create New</button>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1264,6 +1264,9 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
 .modal .x{position:sticky;top:8px;margin-left:auto;margin-right:8px;background:transparent;border:none;color:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;width:32px;height:32px;transition:var(--transition);z-index:2}
 .modal .x:hover{color:var(--accent)}
 .modal .actions{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}
+.modal.modal--load-save{display:flex;flex-direction:column}
+.modal.modal--load-save .catalog{flex:1 1 auto}
+.modal.modal--load-save .modal--load-save__actions{justify-content:center;margin-top:auto;margin-left:auto;margin-right:auto}
 #dm-characters-modal .modal.dm-characters{max-width:none;width:100%;height:100%;max-height:none;display:flex;flex-direction:column}
 #dm-characters-modal .dm-characters-list{list-style:none;margin:0;padding:0;flex:1;overflow:auto}
 #dm-character-modal .modal.dm-character{max-width:none;width:100%;height:100%;max-height:none;display:flex;flex-direction:column}


### PR DESCRIPTION
## Summary
- move the load/save modal buttons into a bottom-centered footer by updating its markup and styles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd092715f4832ebf2bd839fc4900dd