### PR TITLE
Align tickers with header edges

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
       </svg>
     </button>
   </nav>
-  <div class="news-ticker" role="status" aria-live="polite" aria-labelledby="news-ticker-label">
+  <div class="news-ticker" role="status" aria-live="polite" aria-labelledby="news-ticker-label" data-expand-edge>
     <div class="news-ticker__inner">
       <span class="news-ticker__label" id="news-ticker-label">
         <span class="news-ticker__logo" aria-hidden="true" role="presentation"></span>
@@ -203,7 +203,7 @@
       </div>
     </div>
   </div>
-  <div class="news-ticker news-ticker--m24n" role="status" aria-live="polite" aria-labelledby="m24n-ticker-label">
+  <div class="news-ticker news-ticker--m24n" role="status" aria-live="polite" aria-labelledby="m24n-ticker-label" data-expand-edge>
     <div class="news-ticker__inner">
       <span class="news-ticker__label news-ticker__label--m24n" id="m24n-ticker-label">
         <span class="news-ticker__logo news-ticker__logo--m24n" aria-hidden="true">MN24/7:</span>

--- a/styles/main.css
+++ b/styles/main.css
@@ -242,6 +242,11 @@ label[data-animate-title]{
   box-sizing:border-box;
   box-shadow:0 12px 30px color-mix(in srgb,var(--accent) 10%, transparent);
 }
+.news-ticker[data-expand-edge]{
+  margin-left:calc(-1 * (20px + env(safe-area-inset-left, 0px)));
+  margin-right:calc(-1 * (20px + env(safe-area-inset-right, 0px)));
+  width:calc(100% + (20px + env(safe-area-inset-left, 0px)) + (20px + env(safe-area-inset-right, 0px)));
+}
 .news-ticker::before{
   content:"";
   position:absolute;
@@ -258,7 +263,7 @@ label[data-animate-title]{
   width:100%;
   height:100%;
   padding-block:0;
-  padding-right:calc(22px + env(safe-area-inset-right));
+  padding-right:env(safe-area-inset-right, 0px);
 }
 .news-ticker__label{
   position:relative;


### PR DESCRIPTION
## Summary
- extend both header tickers to offset the surrounding header padding and span the full width of the shell
- remove the extra right-side padding so ticker content can sit flush against the container edge while still respecting safe areas

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd0fe5ae84832e92ad41472a2e8ebf