### PR TITLE
Adjust header and footer spacing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -42,7 +42,7 @@ h1{font-size:clamp(1.75rem,4.6vw,2rem);font-weight:700;color:var(--accent)}
 h2{font-size:clamp(1.35rem,3.8vw,1.5rem);font-weight:600;color:var(--accent)}
 h3{font-size:clamp(1.1rem,3.2vw,1.25rem);font-weight:600}
 h4{font-size:clamp(1rem,2.8vw,1.1rem);font-weight:600}
-header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding-top:calc(4px * 1.15);padding-right:env(safe-area-inset-right, 0px);padding-bottom:calc(4px * 1.15);padding-left:env(safe-area-inset-left, 0px);display:flex;flex-direction:column;gap:calc(6px * 1.15);isolation:isolate}
+header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding-top:calc(4px * 1.15);padding-right:calc(16px + env(safe-area-inset-right, 0px));padding-bottom:calc(4px * 1.15);padding-left:calc(16px + env(safe-area-inset-left, 0px));display:flex;flex-direction:column;gap:calc(6px * 1.15);isolation:isolate}
 header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(calc(-10px * 1.15))}
 header::before{content:none}
 @supports ((-webkit-backdrop-filter:blur(0)) or (backdrop-filter:blur(0))){
@@ -607,7 +607,7 @@ label[data-animate-title]{
 }
 @keyframes ticker-scroll{from{transform:translate3d(100%,0,0)}to{transform:translate3d(calc(-100% - var(--ticker-gap)),0,0)}}
 main{
-  flex:0 0 auto;
+  flex:1 0 auto;
   width:100%;
   max-width:100%;
   margin:0 0 16px;
@@ -674,10 +674,10 @@ footer{
   font-size:9pt;
   margin:0 auto;
   margin-top:0;
-  padding:12px 20px 44px;
-  padding-right:calc(20px + env(safe-area-inset-right));
-  padding-left:calc(20px + env(safe-area-inset-left));
-  padding-bottom:calc(44px + env(safe-area-inset-bottom));
+  padding:12px 20px 15px;
+  padding-right:calc(20px + env(safe-area-inset-right, 0px));
+  padding-left:calc(20px + env(safe-area-inset-left, 0px));
+  padding-bottom:calc(15px + env(safe-area-inset-bottom, 0px));
   color:var(--muted);
   max-width:var(--shell-width);
   width:100%;


### PR DESCRIPTION
## Summary
- increase horizontal padding on the header so the theme logo button and main menu button sit further from the viewport edges
- let the main content grow to fill the viewport and tighten footer padding so the DM login button rests 15px from the bottom

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4b28d9f4832e9b786641a4368dbd