### PR TITLE
Ensure DM shard controls require realtime sync

### DIFF
--- a/__tests__/dm_enable_shards_push_state.test.js
+++ b/__tests__/dm_enable_shards_push_state.test.js
@@ -55,7 +55,7 @@ test('DM enabling shards pushes state to active browsers', async () => {
   expect(playerCard.hidden).toBe(false);
 });
 
-test('DM toggle reveals shards without realtime database', async () => {
+test('DM toggle does not reveal shards without realtime database', async () => {
   delete window._somf_db;
   localStorage.clear();
 
@@ -76,10 +76,18 @@ test('DM toggle reveals shards without realtime database', async () => {
   expect(playerCard.hidden).toBe(true);
 
   const toggle = document.getElementById('somfDM-playerCard');
+  expect(toggle.disabled).toBe(true);
+
   toggle.checked = true;
   toggle.dispatchEvent(new Event('change'));
   await new Promise(r => setTimeout(r, 0));
 
-  expect(playerCard.hidden).toBe(false);
+  // Offline toggles should not change visibility and should restore the switch state
+  expect(playerCard.hidden).toBe(true);
+  expect(toggle.checked).toBe(false);
+
+  const toasts = document.getElementById('somfDM-toasts');
+  expect(toasts.children.length).toBeGreaterThan(0);
+  expect(toasts.textContent).toMatch(/Cloud Sync Offline/i);
 });
 

--- a/__tests__/somf_dm_spawn_npc.test.js
+++ b/__tests__/somf_dm_spawn_npc.test.js
@@ -49,7 +49,7 @@ const overlayTemplate = () => `
   <audio id="somfDM-ping"></audio>
 `;
 
-test('DM spawn NPC button reveals shard-linked allies', async () => {
+test('DM spawn NPC button stays disabled without realtime sync', async () => {
   delete window._somf_db;
   const notice = [{
     key: 'test',
@@ -66,15 +66,12 @@ test('DM spawn NPC button reveals shard-linked allies', async () => {
   await new Promise(r => setTimeout(r, 0));
 
   const spawnBtn = document.getElementById('somfDM-spawnNPC');
-  expect(spawnBtn.disabled).toBe(false);
+  expect(spawnBtn.disabled).toBe(true);
   expect(spawnBtn.textContent).toContain('NPC');
 
   spawnBtn.click();
 
   const modal = document.getElementById('somfDM-npcModal');
-  expect(modal.classList.contains('hidden')).toBe(false);
-  expect(modal.getAttribute('aria-hidden')).toBe('false');
-
-  const card = document.getElementById('somfDM-npcModalCard');
-  expect(card.textContent).toContain('Knight-Commander Aerin Valis');
+  expect(modal.classList.contains('hidden')).toBe(true);
+  expect(modal.getAttribute('aria-hidden')).toBe('true');
 });


### PR DESCRIPTION
## Summary
- gate the DM shard controls behind the realtime database connection so toggles, resolves, and NPC spawns only run when cloud sync is active
- add realtime mode listeners that disable controls offline, restore hidden toggle state, and surface inline toasts when actions are blocked
- update DM tool unit tests to assert the offline restrictions and toast messaging

## Testing
- npm test -- dm_enable_shards_push_state.test.js somf_dm_spawn_npc.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd4bed095c832e8dea9bc15f0fc6e5