### PR TITLE
Keep header title inline on small screens

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -97,10 +97,8 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 
 @media(max-width:600px){
   .top{
-    grid-template-columns:minmax(0, 1fr) minmax(0, 1fr);
-    grid-template-areas:
-      "logo menu"
-      "title title";
+    grid-template-columns:auto minmax(0, 1fr) auto;
+    grid-template-areas:"logo title menu";
   }
 }
 .tabs{


### PR DESCRIPTION
## Summary
- keep the header grid layout consistent on narrow viewports so the title stays between the logo button and menu trigger

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd946219c4832e91ad2edd5ed1504a