### PR TITLE
Refine title font spacing

### DIFF
--- a/src/DecryptedText.jsx
+++ b/src/DecryptedText.jsx
@@ -431,7 +431,11 @@ export default function DecryptedText({
         style={styles.measure}
       >
         {measurementText.split('').map((char, index) => (
-          <span key={`measure-${index}`} className={className}>
+          <span
+            key={`measure-${index}`}
+            className={className}
+            data-char={char === ' ' ? 'space' : char}
+          >
             {char}
           </span>
         ))}
@@ -452,7 +456,11 @@ export default function DecryptedText({
           const isRevealedOrDone = revealedIndices.has(index) || !isScrambling || !isHovering;
 
           return (
-            <span key={index} className={isRevealedOrDone ? className : encryptedClassName}>
+            <span
+              key={index}
+              className={isRevealedOrDone ? className : encryptedClassName}
+              data-char={char === ' ' ? 'space' : char}
+            >
               {char}
             </span>
           );

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,4 +1,4 @@
-:root{--bg-color:#0e1117;--bg:var(--bg-color) url('../images/Dark.PNG?v=2') center/cover no-repeat fixed;--surface:#151a23;--surface-2:#0b0f16;--text:#f3f4f6;--muted:#9ca3af;--accent:#3b82f6;--accent-2:#1e40af;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#fff;--radius:12px;--control-min-height:44px;--tracker-pill-height:36px;--transition:background-color .4s ease-in-out,color .4s ease-in-out,border-color .4s ease-in-out,transform .4s ease-in-out,opacity .4s ease-in-out;--success:#16a34a;--error:#dc2626;--icon-success:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2316a34a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");--icon-error:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23dc2626' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E");--chevron:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%2020%2020'%20fill%3D'none'%20stroke%3D'currentColor'%20stroke-width%3D'2'%20stroke-linecap%3D'round'%20stroke-linejoin%3D'round'%3E%3Cpath%20d%3D'M6%208l4%204%204-4'%2F%3E%3C%2Fsvg%3E");--vh:1vh;--app-max-width:clamp(320px,96vw,1100px);--content-width:min(var(--app-max-width),100vw);--modal-width:var(--content-width);--shell-width:100vw}
+:root{--bg-color:#0e1117;--bg:var(--bg-color) url('../images/Dark.PNG?v=2') center/cover no-repeat fixed;--surface:#151a23;--surface-2:#0b0f16;--text:#f3f4f6;--muted:#9ca3af;--accent:#3b82f6;--accent-2:#1e40af;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#fff;--radius:12px;--control-min-height:44px;--tracker-pill-height:36px;--transition:background-color .4s ease-in-out,color .4s ease-in-out,border-color .4s ease-in-out,transform .4s ease-in-out,opacity .4s ease-in-out;--success:#16a34a;--error:#dc2626;--icon-success:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2316a34a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");--icon-error:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23dc2626' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E");--chevron:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%2020%2020'%20fill%3D'none'%20stroke%3D'currentColor'%20stroke-width%3D'2'%20stroke-linecap%3D'round'%20stroke-linejoin%3D'round'%3E%3Cpath%20d%3D'M6%208l4%204%204-4'%2F%3E%3C%2Fsvg%3E");--vh:1vh;--app-max-width:clamp(320px,96vw,1100px);--content-width:min(var(--app-max-width),100vw);--modal-width:var(--content-width);--shell-width:100vw;--title-letter-spacing:0.015em;--title-word-spacing:-0.02em;--title-character-gap:0.02em;--title-letter-spacing-uppercase:0.07em;--title-word-spacing-uppercase:-0.015em;--title-space-width:calc(.5em + var(--title-word-spacing));}
 @font-face{font-family:'CFTechnoMania Slanted';src:url('../CFTechnoMania-Slanted.ttf') format('truetype');font-weight:400;font-style:normal;font-display:swap}
 @font-face{font-family:'Race Sport';src:url('../Race Sport.ttf') format('truetype');font-weight:400;font-style:normal;font-display:swap}
 :root.theme-light{--bg-color:#f9fafb;--bg:var(--bg-color) url('../images/Light.PNG?v=2') center/cover no-repeat fixed;--surface:#fff;--surface-2:#f3f4f6;--text:#111827;--muted:#6b7280;--accent:#3b82f6;--accent-2:#1e40af;--line:rgba(0,0,0,.1);--shadow:0 8px 28px rgba(0,0,0,.2);--text-on-accent:#fff;--success:#16a34a;--error:#dc2626;--icon-success:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2316a34a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");--icon-error:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23dc2626' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E")}
@@ -37,7 +37,7 @@ body.launching #launch-animation{opacity:1;visibility:visible;pointer-events:aut
 #launch-animation video{width:calc(100% + constant(safe-area-inset-left) + constant(safe-area-inset-right));height:calc(100% + constant(safe-area-inset-top) + constant(safe-area-inset-bottom));margin-left:calc(-1 * constant(safe-area-inset-left));margin-right:calc(-1 * constant(safe-area-inset-right));margin-top:calc(-1 * constant(safe-area-inset-top));margin-bottom:calc(-1 * constant(safe-area-inset-bottom));width:calc(100% + env(safe-area-inset-left) + env(safe-area-inset-right));height:calc(100% + env(safe-area-inset-top) + env(safe-area-inset-bottom));margin-left:calc(-1 * env(safe-area-inset-left));margin-right:calc(-1 * env(safe-area-inset-right));margin-top:calc(-1 * env(safe-area-inset-top));margin-bottom:calc(-1 * env(safe-area-inset-bottom));max-width:none;max-height:none;display:block;object-fit:cover;pointer-events:none}
 @media (min-width:1200px){#launch-animation video{object-fit:contain;max-width:100vw;max-height:100vh}}
 ::selection{background:var(--accent);color:var(--text-on-accent)}
-h1,h2,h3,h4{font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;line-height:1.25;margin:0 0 .5em}
+h1,h2,h3,h4{font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;letter-spacing:var(--title-letter-spacing);word-spacing:var(--title-word-spacing);line-height:1.25;margin:0 0 .5em}
 h1{font-size:clamp(1.75rem,4.6vw,2rem);font-weight:700;color:var(--accent)}
 h2{font-size:clamp(1.35rem,3.8vw,1.5rem);font-weight:600;color:var(--accent)}
 h3{font-size:clamp(1.1rem,3.2vw,1.25rem);font-weight:600}
@@ -123,7 +123,7 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
   align-items:center;
   justify-content:center;
   gap:8px;
-  font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;
+  font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;letter-spacing:var(--title-letter-spacing);word-spacing:var(--title-word-spacing);
   min-width:0;
   grid-area:title;
   justify-self:center;
@@ -178,14 +178,33 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 .header-decrypted,
 .animated-decrypted{
   display:inline-flex;
-  gap:0.05em;
-  letter-spacing:0.03em;
+  gap:var(--title-character-gap);
+  letter-spacing:var(--title-letter-spacing);
+  word-spacing:var(--title-word-spacing);
 }
 
 .header-decrypted__char,
 .animated-decrypted__char{
   color:inherit;
   transition:color .3s ease,text-shadow .3s ease;
+}
+
+.header-decrypted__char,
+.animated-decrypted__char,
+.header-decrypted__char--scrambling,
+.animated-decrypted__char--scrambling{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  flex:0 0 auto;
+  min-width:0;
+}
+
+.header-decrypted__char[data-char="space"],
+.animated-decrypted__char[data-char="space"],
+.header-decrypted__char--scrambling[data-char="space"],
+.animated-decrypted__char--scrambling[data-char="space"]{
+  width:var(--title-space-width);
 }
 
 .header-decrypted__char--scrambling,
@@ -195,8 +214,7 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 }
 
 [data-animate-title]{
-  font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;
-  letter-spacing:0.05em;
+  font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;letter-spacing:var(--title-letter-spacing);word-spacing:var(--title-word-spacing);
 }
 
 span[data-animate-title]{
@@ -679,8 +697,8 @@ fieldset[data-tab="combat"] .card{
 }
 main>:last-child{margin-bottom:0}
 fieldset[data-tab].card.active{opacity:1;transform:translate3d(0,0,0);pointer-events:auto;visibility:visible;filter:blur(0)saturate(1);position:relative;inset:auto;margin-bottom:14px}
-fieldset[data-tab].card>legend{font-size:clamp(1.1rem,3.4vw,1.5rem);font-weight:600;color:var(--accent);margin:0 0 6px;font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif}
-.card-title{font-size:clamp(1.1rem,3.4vw,1.5rem);font-weight:600;color:var(--accent);margin:0 0 10px;font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif}
+fieldset[data-tab].card>legend{font-size:clamp(1.1rem,3.4vw,1.5rem);font-weight:600;color:var(--accent);margin:0 0 6px;font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;letter-spacing:var(--title-letter-spacing);word-spacing:var(--title-word-spacing)}
+.card-title{font-size:clamp(1.1rem,3.4vw,1.5rem);font-weight:600;color:var(--accent);margin:0 0 10px;font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;letter-spacing:var(--title-letter-spacing);word-spacing:var(--title-word-spacing)}
 p{max-width:var(--shell-width)}
 footer{
   text-align:center;
@@ -1768,7 +1786,7 @@ select[required]:valid{
 .app-alert.is-visible{opacity:1;pointer-events:auto}
 .app-alert__card{background:var(--surface);color:var(--text);border-radius:20px;border:1px solid rgba(255,255,255,.16);box-shadow:0 28px 60px rgba(0,0,0,.65);max-width:460px;width:100%;padding:28px 24px;display:flex;flex-direction:column;gap:16px;text-align:center;transform:translateY(12px) scale(.97);transition:transform .3s ease,box-shadow .3s ease}
 .app-alert.is-visible .app-alert__card{transform:translateY(0) scale(1);box-shadow:0 32px 70px rgba(0,0,0,.7)}
-.app-alert__title{margin:0;font-family:'CFTechnoMania Slanted',sans-serif;font-size:22px;letter-spacing:.12em;text-transform:uppercase}
+.app-alert__title{margin:0;font-family:'CFTechnoMania Slanted',sans-serif;font-size:22px;letter-spacing:var(--title-letter-spacing-uppercase);word-spacing:var(--title-word-spacing-uppercase);text-transform:uppercase}
 .app-alert__message{margin:0;font-size:16px;line-height:1.6}
 .app-alert__button{align-self:center;padding:12px 32px;border-radius:999px;border:none;background:var(--accent);color:var(--text-on-accent);font-size:15px;font-weight:600;cursor:pointer;letter-spacing:.08em;text-transform:uppercase;box-shadow:0 16px 40px rgba(59,130,246,.45);transition:transform .25s ease,box-shadow .25s ease}
 .app-alert__button:hover{transform:translateY(-2px);box-shadow:0 22px 54px rgba(59,130,246,.55)}
@@ -1785,7 +1803,7 @@ body.app-alert-active{overflow:hidden}
 .somf-reveal-alert.is-visible{opacity:1;pointer-events:auto}
 .somf-reveal-alert__card{background:var(--surface);color:var(--text);border-radius:24px;border:1px solid rgba(255,255,255,.12);box-shadow:0 32px 60px rgba(0,0,0,.6);width:100%;max-width:var(--content-width);padding:32px 28px;text-align:center;display:flex;flex-direction:column;gap:18px;transform:translateY(12px) scale(.98);transition:transform .35s ease,box-shadow .35s ease}
 .somf-reveal-alert.is-visible .somf-reveal-alert__card{transform:translateY(0) scale(1);box-shadow:0 40px 70px rgba(0,0,0,.65)}
-.somf-reveal-alert__title{margin:0;font-family:'CFTechnoMania Slanted',sans-serif;font-size:24px;letter-spacing:.08em;text-transform:uppercase}
+.somf-reveal-alert__title{margin:0;font-family:'CFTechnoMania Slanted',sans-serif;font-size:24px;letter-spacing:var(--title-letter-spacing-uppercase);word-spacing:var(--title-word-spacing-uppercase);text-transform:uppercase}
 .somf-reveal-alert__text{margin:0;font-size:16px;line-height:1.5}
 .somf-reveal-alert__btn{align-self:center;padding:12px 28px;border-radius:999px;border:none;background:var(--accent);color:var(--text-on-accent);font-size:16px;font-weight:600;cursor:pointer;box-shadow:0 18px 44px rgba(59,130,246,.45);transition:transform .25s ease,box-shadow .25s ease}
 .somf-reveal-alert__btn:hover{transform:translateY(-2px);box-shadow:0 22px 54px rgba(59,130,246,.55)}
@@ -1798,6 +1816,6 @@ body.somf-reveal-active{overflow:hidden}
 }
 
 
-:root{--bg-color:#0e1117;--bg:var(--bg-color) url('../images/Dark.PNG?v=2') center/cover no-repeat fixed;--surface:#151a23;--surface-2:#0b0f16;--text:#f3f4f6;--muted:#9ca3af;--accent:#3b82f6;--accent-2:#1e40af;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#fff;--radius:12px;--control-min-height:44px;--tracker-pill-height:36px;--transition:background-color .4s ease-in-out,color .4s ease-in-out,border-color .4s ease-in-out,transform .4s ease-in-out,opacity .4s ease-in-out;--success:#16a34a;--error:#dc2626;--icon-success:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2316a34a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");--icon-error:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23dc2626' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E");--chevron:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%2020%2020'%20fill%3D'none'%20stroke%3D'currentColor'%20stroke-width%3D'2'%20stroke-linecap%3D'round'%20stroke-linejoin%3D'round'%3E%3Cpath%20d%3D'M6%208l4%204%204-4'%2F%3E%3C%2Fsvg%3E");--vh:1vh;--app-max-width:clamp(320px,96vw,1100px);--content-width:min(var(--app-max-width),100vw);--modal-width:var(--content-width);--shell-width:100vw}
+:root{--bg-color:#0e1117;--bg:var(--bg-color) url('../images/Dark.PNG?v=2') center/cover no-repeat fixed;--surface:#151a23;--surface-2:#0b0f16;--text:#f3f4f6;--muted:#9ca3af;--accent:#3b82f6;--accent-2:#1e40af;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#fff;--radius:12px;--control-min-height:44px;--tracker-pill-height:36px;--transition:background-color .4s ease-in-out,color .4s ease-in-out,border-color .4s ease-in-out,transform .4s ease-in-out,opacity .4s ease-in-out;--success:#16a34a;--error:#dc2626;--icon-success:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2316a34a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");--icon-error:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23dc2626' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E");--chevron:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%2020%2020'%20fill%3D'none'%20stroke%3D'currentColor'%20stroke-width%3D'2'%20stroke-linecap%3D'round'%20stroke-linejoin%3D'round'%3E%3Cpath%20d%3D'M6%208l4%204%204-4'%2F%3E%3C%2Fsvg%3E");--vh:1vh;--app-max-width:clamp(320px,96vw,1100px);--content-width:min(var(--app-max-width),100vw);--modal-width:var(--content-width);--shell-width:100vw;--title-letter-spacing:0.015em;--title-word-spacing:-0.02em;--title-character-gap:0.02em;--title-letter-spacing-uppercase:0.07em;--title-word-spacing-uppercase:-0.015em;--title-space-width:calc(.5em + var(--title-word-spacing));}
 @font-face{font-family:'CFTechnoMania Slanted';src:url('../CFTechnoMania-Slanted.ttf') format('truetype');font-weight:400;font-style:normal;font-display:swap}
 :root.theme-light{--bg-color:#f9fafb;--bg:var(--bg-color) url('../images/Light.PNG?v=2') center/cover no-repeat fixed;--surface:#fff;--surface-2:#f3f4f6;--text:#111827;--muted:#6b7280;--accent:#3b82f6;--accent-2:#1e40af;--line:rgba(0,0,0,.1);--shadow:0 8px 28px rgba(0,0,0,.2);--text-on-accent:#fff;--success:#16a34a;--error:#dc2626;--icon-success:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2316a34a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");--icon-error:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23dc2626' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E")}


### PR DESCRIPTION
## Summary
- add reusable spacing variables for the CFTechnoMania title font and apply them to headings, tabs, cards, and alerts
- tighten decrypted title character layout, tagging spaces so their widths can be reduced without affecting animation
- reduce animated title gaps and align word spacing so titles render more compactly across the app

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ddf47ba814832e8d82d12a1de2fd85