### PR TITLE
Remove visible Cloud Sync restored toast

### DIFF
--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -2680,10 +2680,9 @@
       }
       this.updateRealtimeState();
       if (previous !== hasRealtime && previous != null) {
-        const message = hasRealtime
-          ? '<strong>Cloud Sync Restored</strong> The shard deck is now live.'
-          : '<strong>Cloud Sync Lost</strong> Changes are paused until connection returns.';
-        this.toast(message);
+        if (!hasRealtime) {
+          this.toast('<strong>Cloud Sync Lost</strong> Changes are paused until connection returns.');
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- suppress the Cloud Sync restored toast that should remain hidden
- retain the Cloud Sync lost toast so users are still warned about outages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddf7d2dc88832ebfb6c9470197ce9a