### PR TITLE
Improve Shards toast handling

### DIFF
--- a/__tests__/dm_enable_shards_push_state.test.js
+++ b/__tests__/dm_enable_shards_push_state.test.js
@@ -87,7 +87,6 @@ test('DM toggle does not reveal shards without realtime database', async () => {
   expect(toggle.checked).toBe(false);
 
   const toasts = document.getElementById('somfDM-toasts');
-  expect(toasts.children.length).toBeGreaterThan(0);
-  expect(toasts.textContent).toMatch(/Cloud Sync Offline/i);
+  expect(toasts.children.length).toBe(0);
 });
 

--- a/__tests__/somf_offline_notice_toast.test.js
+++ b/__tests__/somf_offline_notice_toast.test.js
@@ -36,7 +36,7 @@ function setupDom() {
   `;
 }
 
-test('offline shard draw raises DM toast that links to details', async () => {
+test('offline shard draw does not raise DM toast', async () => {
   jest.resetModules();
   localStorage.clear();
   sessionStorage.clear();
@@ -66,13 +66,5 @@ test('offline shard draw raises DM toast that links to details', async () => {
   await new Promise(r => setTimeout(r, 0));
 
   const toastHost = document.getElementById('somfDM-toasts');
-  expect(toastHost.children.length).toBe(1);
-
-  const toast = toastHost.firstElementChild;
-  expect(toast.textContent).toContain('The Echo');
-
-  toast.click();
-  // openDM should make modal visible when structure exists
-  const dmModal = document.getElementById('modal-somf-dm');
-  expect(dmModal.classList.contains('hidden')).toBe(false);
+  expect(toastHost.children.length).toBe(0);
 });

--- a/__tests__/somf_player_toast.test.js
+++ b/__tests__/somf_player_toast.test.js
@@ -1,0 +1,96 @@
+import { jest } from '@jest/globals';
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.useRealTimers();
+  localStorage.clear();
+  sessionStorage.clear();
+  document.body.innerHTML = '';
+  delete window.toast;
+  delete window.dismissToast;
+  delete window.logAction;
+  delete window.queueCampaignLogEntry;
+});
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="toast"></div>
+    <section id="somf-min">
+      <button id="somf-min-draw" type="button"></button>
+      <input id="somf-min-count" type="number">
+    </section>
+    <div id="somf-min-modal" hidden>
+      <div data-somf-dismiss></div>
+      <button id="somf-min-close" type="button"></button>
+      <img id="somf-min-image" alt="">
+    </div>
+  `;
+}
+
+test('player receives shard toast and logs entries', async () => {
+  setupDom();
+  localStorage.setItem('somf_hidden__ccampaign-001', 'false');
+  localStorage.setItem('somf_notices__ccampaign-001', JSON.stringify([]));
+
+  window.toast = jest.fn((message, opts = {}) => {
+    const toastEl = document.getElementById('toast');
+    if (toastEl) {
+      toastEl.textContent = message;
+      toastEl.classList.add('show');
+    }
+    window.dispatchEvent(new CustomEvent('cc:toast-shown', { detail: { message, options: opts } }));
+  });
+
+  window.dismissToast = jest.fn(() => {
+    const toastEl = document.getElementById('toast');
+    if (toastEl) {
+      toastEl.classList.remove('show');
+    }
+    window.dispatchEvent(new CustomEvent('cc:toast-dismissed'));
+  });
+
+  window.logAction = jest.fn();
+  window.queueCampaignLogEntry = jest.fn();
+
+  await import(`../shard-of-many-fates.js?player-toast=${Date.now()}`);
+
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  const notice = {
+    key: 'toast-test',
+    count: 1,
+    ids: ['ECHO'],
+    names: ['The Echo'],
+    ts: Date.now(),
+  };
+  localStorage.setItem('somf_notices__ccampaign-001', JSON.stringify([notice]));
+  window.dispatchEvent(new CustomEvent('somf-local-notice', { detail: { action: 'add', notice } }));
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  expect(window.toast).toHaveBeenCalled();
+  const [message, options] = window.toast.mock.calls[0];
+  expect(message).toBe('The Shards reveal The Echo.');
+  expect(options).toMatchObject({
+    type: 'info',
+    somf: expect.objectContaining({
+      context: 'player-shard',
+      shardId: 'ECHO',
+      noticeKey: 'toast-test',
+      noticeIndex: 0,
+    }),
+  });
+
+  expect(window.logAction).toHaveBeenCalledWith('The Shards: Revealed shard: The Echo');
+  expect(window.queueCampaignLogEntry).toHaveBeenCalledWith('Revealed shard: The Echo', expect.objectContaining({ name: 'The Shards' }));
+
+  const toastEl = document.getElementById('toast');
+  expect(toastEl.dataset.somfShardId).toBe('ECHO');
+
+  toastEl.click();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  expect(window.dismissToast).toHaveBeenCalled();
+  const modal = document.getElementById('somf-min-modal');
+  expect(modal.hidden).toBe(false);
+});


### PR DESCRIPTION
## Summary
- suppress DM Cloud Sync messaging by disabling shard toast rendering
- add player shard reveal toast that logs to the action log and campaign log as "The Shards"
- expose a helper for campaign log entries and broadcast toast lifecycle events for consumers
- cover the new behaviour with automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de294923fc832ea54184c535e04b51