### PR TITLE
Add DM mini-games deployment tools with cloud sync

### DIFF
--- a/SuperheroMiniGames/ClueTracker/README.txt
+++ b/SuperheroMiniGames/ClueTracker/README.txt
@@ -1,1 +1,11 @@
-README for Clue Tracker with full instructions.
+Clue Tracker tasks a hero with connecting scattered intel before the trail goes cold. The DM supplies a dossier of clues and the player must arrange them in the correct sequence to reveal the target.
+
+## Fast Edit Knobs
+- **Clues to Reveal** *(number, default 3)* – Controls how many verified clues are available at the start of play.
+- **Time per Clue (seconds)** *(number, default 90)* – Sets the window the player has to respond before the system automatically exposes the next clue.
+- **Include Red Herrings** *(toggle, default off)* – Adds misleading hints that must be disproved before they contaminate the evidence chain.
+
+## Deployment Tips
+1. Brief the player on the scene and drop the corresponding clue card set.
+2. Adjust the fast edit knobs in the DM tools and deploy the mini-game to the target hero.
+3. During play, use the deployment tracker to escalate the situation if the timer runs out or if too many red herrings are accepted.

--- a/SuperheroMiniGames/CodeBreaker/README.txt
+++ b/SuperheroMiniGames/CodeBreaker/README.txt
@@ -1,1 +1,11 @@
-README for CodeBreaker with full instructions.
+Code Breaker simulates a hostile encryption console. Heroes race to decode the passphrase before the lock engages and activates the villain's contingency plan.
+
+## Fast Edit Knobs
+- **Code Length** *(number, default 5)* – Determines how many characters the hero must unscramble.
+- **Attempt Limit** *(number, default 6)* – Sets the number of failed guesses allowed before the console wipes itself.
+- **Cipher Set** *(select, default Alphanumeric)* – Chooses the symbol set presented to the player (classic letters, quantum glyphs, or emoji runes).
+
+## Deployment Tips
+1. Deploy the puzzle to the hero who is interfacing with the console.
+2. Use the attempt tracker to narrate alarms, countermeasures, or team assistance when the limit runs low.
+3. Switching cipher sets mid-scene is a great way to escalate difficulty for seasoned operatives.

--- a/SuperheroMiniGames/LockdownOverride/README.txt
+++ b/SuperheroMiniGames/LockdownOverride/README.txt
@@ -1,1 +1,11 @@
-README for Lockdown Override with full instructions.
+Lockdown Override challenges a hero to stabilise a base security system before automated defences escalate. The player must reroute power, silence alarms, and reset locks while the timer counts down.
+
+## Fast Edit Knobs
+- **Security Level** *(select, default Amber)* – Sets the number of subsystems that must be cleared (Green is easiest, Crimson is the full gauntlet).
+- **Override Timer (seconds)** *(number, default 300)* – Controls how long the hero has before the lockdown seals permanently.
+- **Hazard Suppression Enabled** *(toggle, default on)* – When on, traps pause during the mini-game; when off, narrate stray lasers, gas jets, or drones interfering with the hero.
+
+## Deployment Tips
+1. Pair the security level with the current scene stakes—Crimson works well for major set pieces.
+2. Use the hazard toggle to inject dynamic complications if other players want to assist.
+3. If the timer expires, trigger a narrative twist such as a rival faction breaking through or the base sealing the heroes inside.

--- a/SuperheroMiniGames/PowerSurge/README.txt
+++ b/SuperheroMiniGames/PowerSurge/README.txt
@@ -1,1 +1,11 @@
-README for Power Surge with full instructions.
+Power Surge places the hero at an unstable generator. They must balance output, ride out wave surges, and keep the facility intact.
+
+## Fast Edit Knobs
+- **Stability Target (%)** *(number, default 80)* – The operating window the hero must maintain to avert meltdown.
+- **Surge Waves** *(number, default 3)* – Number of escalating surges that slam the hero before the grid stabilises.
+- **Stability Checks** *(select, default Skill Tests)* – Defines the type of rolls or narrative beats required (skill, power, or mixed challenges).
+
+## Deployment Tips
+1. The surge waves make great narrative beats—announce each wave as a new phase of the encounter.
+2. Adjust the stability target to reflect how battered the generator already is.
+3. Pair different stability check types with specific party members for collaborative scenes.

--- a/SuperheroMiniGames/StratagemHero/README.txt
+++ b/SuperheroMiniGames/StratagemHero/README.txt
@@ -1,1 +1,11 @@
-README for Stratagem Hero with full instructions.
+Stratagem Hero is a tactical planning board. The player orchestrates an operation, allocates assets, and reacts to unfolding intel.
+
+## Fast Edit Knobs
+- **Mission Profile** *(select, default Rescue)* – Sets the scenario focus: infiltration, rescue, or sabotage.
+- **Intel Level** *(select, default Briefed)* – Chooses how much support HQ provides, from blind drops to full overwatch.
+- **Team Synergy Boost** *(toggle, default off)* – Grants a one-time teamwork advantage that can shift the odds during critical actions.
+
+## Deployment Tips
+1. Use the mission profile to mirror the story beat the heroes are tackling.
+2. Adjust the intel level mid-play to represent evolving support or setbacks.
+3. Activate the synergy boost when players coordinate a clever plan and reward their collaboration.

--- a/SuperheroMiniGames/TechLockpick/README.txt
+++ b/SuperheroMiniGames/TechLockpick/README.txt
@@ -1,1 +1,11 @@
-README for Tech Lockpick with full instructions.
+Tech Lockpick lets a hero bypass advanced security. They strip shielding, spoof biometrics, and coax alien tech to obey.
+
+## Fast Edit Knobs
+- **Lock Complexity** *(select, default Standard)* – Dictates how many distinct subsystems must be solved.
+- **Failures Allowed** *(number, default 2)* – The number of strike tokens the hero can accumulate before the lock seals.
+- **Support Drones Available** *(toggle, default on)* – When active, provides a single-use AI assist that can auto-clear one subsystem.
+
+## Deployment Tips
+1. Deploy to gadgeteers or tech-savvy characters when the team hits a secure vault.
+2. Spend failures to introduce sparks, counter-hacks, or collateral damage opportunities.
+3. If support drones are active, describe their personality to keep the scene lively.

--- a/__tests__/dm_mini_games.test.js
+++ b/__tests__/dm_mini_games.test.js
@@ -1,0 +1,232 @@
+import { jest } from '@jest/globals';
+import { DM_PIN } from '../scripts/dm-pin.js';
+
+function setupDom() {
+  document.body.innerHTML = `
+    <button id="dm-login"></button>
+    <button id="dm-tools-toggle"></button>
+    <div id="dm-tools-menu" hidden>
+      <button id="dm-tools-tsomf"></button>
+      <button id="dm-tools-notifications"></button>
+      <button id="dm-tools-characters"></button>
+      <button id="dm-tools-mini-games"></button>
+      <button id="dm-tools-logout"></button>
+    </div>
+    <div id="dm-login-modal" class="hidden" aria-hidden="true">
+      <input id="dm-login-pin" />
+      <button id="dm-login-submit"></button>
+      <button id="dm-login-close"></button>
+    </div>
+    <div id="dm-notifications-modal" class="hidden" aria-hidden="true">
+      <ul id="dm-notifications-list"></ul>
+      <button id="dm-notifications-close"></button>
+    </div>
+    <div id="dm-characters-modal" class="hidden" aria-hidden="true">
+      <ul id="dm-characters-list"></ul>
+      <button id="dm-characters-close"></button>
+    </div>
+    <div id="dm-character-modal" class="hidden" aria-hidden="true">
+      <div id="dm-character-sheet"></div>
+      <button id="dm-character-close"></button>
+    </div>
+    <div id="dm-mini-games-modal" class="overlay hidden" aria-hidden="true">
+      <section class="modal dm-mini-games">
+        <button id="dm-mini-games-close"></button>
+        <div class="dm-mini-games__layout">
+          <aside class="dm-mini-games__sidebar">
+            <h4 class="dm-mini-games__section-title">Library</h4>
+            <ul id="dm-mini-games-list" class="dm-mini-games__list"></ul>
+          </aside>
+          <div class="dm-mini-games__content">
+            <header class="dm-mini-games__header">
+              <div class="dm-mini-games__heading">
+                <h4 id="dm-mini-games-title"></h4>
+                <p id="dm-mini-games-tagline"></p>
+              </div>
+              <a id="dm-mini-games-launch" hidden></a>
+            </header>
+            <section class="dm-mini-games__section">
+              <div id="dm-mini-games-knobs" class="dm-mini-games__knobs"></div>
+            </section>
+            <section class="dm-mini-games__section">
+              <div class="dm-mini-games__deploy-form">
+                <label class="dm-mini-games__field">
+                  <span>Target</span>
+                  <select id="dm-mini-games-player"></select>
+                </label>
+                <label class="dm-mini-games__field">
+                  <span>Custom</span>
+                  <input id="dm-mini-games-player-custom" type="text" />
+                </label>
+                <label class="dm-mini-games__field">
+                  <span>Notes</span>
+                  <textarea id="dm-mini-games-notes"></textarea>
+                </label>
+              </div>
+              <div class="dm-mini-games__actions">
+                <button id="dm-mini-games-refresh-players" type="button"></button>
+                <button id="dm-mini-games-deploy" type="button"></button>
+              </div>
+            </section>
+            <section class="dm-mini-games__section dm-mini-games__section--scroll">
+              <pre id="dm-mini-games-readme" class="dm-mini-games__readme"></pre>
+            </section>
+            <section class="dm-mini-games__section dm-mini-games__section--scroll">
+              <div class="dm-mini-games__section-header">
+                <h5>Deployments</h5>
+                <div class="dm-mini-games__section-actions">
+                  <button id="dm-mini-games-refresh" type="button"></button>
+                </div>
+              </div>
+              <ul id="dm-mini-games-deployments" class="dm-mini-games__deployments"></ul>
+            </section>
+          </div>
+        </div>
+      </section>
+    </div>
+  `;
+}
+
+async function initDmModule() {
+  jest.resetModules();
+  setupDom();
+  global.fetch = jest.fn();
+  global.toast = jest.fn();
+  global.dismissToast = jest.fn();
+
+  const show = jest.fn();
+  const hide = jest.fn();
+
+  jest.unstable_mockModule('../scripts/modal.js', () => ({ show, hide }));
+
+  const listCharacters = jest.fn(async () => ['Hero One', 'Hero Two']);
+  const loadCharacter = jest.fn(async () => ({}));
+  const setCurrentCharacter = jest.fn();
+
+  jest.unstable_mockModule('../scripts/characters.js', () => ({
+    listCharacters,
+    loadCharacter,
+    setCurrentCharacter,
+  }));
+
+  const sampleGame = {
+    id: 'clue-tracker',
+    name: 'Clue Tracker',
+    tagline: 'Connect the dots',
+    url: 'SuperheroMiniGames/ClueTracker/ClueTracker.html',
+    knobs: [
+      { key: 'cluesToReveal', label: 'Clues to reveal', type: 'number', min: 1, max: 6, step: 1, default: 3 }
+    ]
+  };
+
+  let deploymentsCallback = null;
+
+  const deployMiniGame = jest.fn(async payload => ({
+    ...payload,
+    id: 'mg-123',
+    status: 'pending',
+    player: payload.player.trim(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }));
+
+  jest.unstable_mockModule('../scripts/mini-games.js', () => ({
+    listMiniGames: () => [sampleGame],
+    getMiniGame: () => sampleGame,
+    getDefaultConfig: () => ({ cluesToReveal: 3 }),
+    loadMiniGameReadme: async () => 'Briefing text',
+    subscribeToDeployments: callback => {
+      deploymentsCallback = callback;
+      callback([]);
+      return jest.fn();
+    },
+    refreshDeployments: async () => [],
+    deployMiniGame,
+    updateDeployment: jest.fn(async () => {}),
+    deleteDeployment: jest.fn(async () => {}),
+    summarizeConfig: () => 'Clues to reveal: 3',
+    MINI_GAME_STATUS_OPTIONS: [
+      { value: 'pending', label: 'Pending' },
+      { value: 'active', label: 'In Progress' },
+      { value: 'completed', label: 'Completed' },
+      { value: 'cancelled', label: 'Cancelled' },
+    ],
+    getStatusLabel: value => value,
+    formatKnobValue: () => '3',
+  }));
+
+  window.dmNotify = jest.fn();
+
+  await import('../scripts/dm.js');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+
+  return {
+    show,
+    hide,
+    listCharacters,
+    deployMiniGame,
+    getDeploymentsCallback: () => deploymentsCallback,
+  };
+}
+
+async function completeLogin() {
+  const loginPromise = window.dmRequireLogin();
+  const pinInput = document.getElementById('dm-login-pin');
+  pinInput.value = DM_PIN;
+  document.getElementById('dm-login-submit').dispatchEvent(new Event('click'));
+  await loginPromise;
+}
+
+describe('DM mini-game tooling', () => {
+  test('deploys a mini-game to the selected character', async () => {
+    const { show, listCharacters, deployMiniGame, getDeploymentsCallback } = await initDmModule();
+
+    await completeLogin();
+
+    const miniGamesBtn = document.getElementById('dm-tools-mini-games');
+    miniGamesBtn.dispatchEvent(new Event('click'));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(show).toHaveBeenCalledWith('dm-mini-games-modal');
+    expect(listCharacters).toHaveBeenCalled();
+
+    const playerSelect = document.getElementById('dm-mini-games-player');
+    playerSelect.value = 'Hero One';
+    const notesField = document.getElementById('dm-mini-games-notes');
+    notesField.value = 'Bring backup';
+
+    const deployBtn = document.getElementById('dm-mini-games-deploy');
+    deployBtn.dispatchEvent(new Event('click'));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(deployMiniGame).toHaveBeenCalledTimes(1);
+    expect(deployMiniGame.mock.calls[0][0]).toMatchObject({
+      gameId: 'clue-tracker',
+      player: 'Hero One',
+      notes: 'Bring backup',
+    });
+    expect(global.toast).toHaveBeenCalledWith('Mini-game deployed', 'success');
+
+    const deploymentsCallback = getDeploymentsCallback();
+    const miniGamesModal = document.getElementById('dm-mini-games-modal');
+    miniGamesModal.classList.remove('hidden');
+    miniGamesModal.setAttribute('aria-hidden', 'false');
+    deploymentsCallback?.([
+      {
+        id: 'mg-123',
+        player: 'Hero One',
+        status: 'pending',
+        gameName: 'Clue Tracker',
+        config: { cluesToReveal: 3 },
+        createdAt: Date.now(),
+      }
+    ]);
+
+    const deploymentsList = document.getElementById('dm-mini-games-deployments');
+    expect(deploymentsList.textContent).toContain('Hero One');
+  });
+});

--- a/__tests__/mini_games_cloud.test.js
+++ b/__tests__/mini_games_cloud.test.js
@@ -1,0 +1,106 @@
+import { jest } from '@jest/globals';
+
+const CLOUD_URL = 'https://ccccg-7d6b6-default-rtdb.firebaseio.com/miniGames';
+
+describe('mini-games cloud integration helpers', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('deployMiniGame pushes sanitized payload and refreshes cache', async () => {
+    const { deployMiniGame } = await import('../scripts/mini-games.js');
+
+    const putResponse = { ok: true, json: async () => ({}), text: async () => '' };
+    const getResponse = { ok: true, json: async () => ({}) };
+
+    global.fetch
+      .mockImplementationOnce(async (url, options) => {
+        expect(url.startsWith(`${CLOUD_URL}/Hero%20Prime/`)).toBe(true);
+        expect(options.method).toBe('PUT');
+        const body = JSON.parse(options.body);
+        expect(body.player).toBe('Hero Prime');
+        expect(body.gameId).toBe('clue-tracker');
+        expect(body.config).toEqual({ cluesToReveal: 5 });
+        expect(body.status).toBe('pending');
+        return putResponse;
+      })
+      .mockImplementationOnce(async (url) => {
+        expect(url).toBe(`${CLOUD_URL}.json`);
+        return getResponse;
+      });
+
+    const created = await deployMiniGame({
+      gameId: 'clue-tracker',
+      player: '  Hero   Prime  ',
+      config: { cluesToReveal: 5 },
+      notes: 'Good luck',
+      issuedBy: 'DM'
+    });
+
+    expect(created.player).toBe('Hero Prime');
+    expect(created.status).toBe('pending');
+    expect(created.id).toMatch(/^mg-/);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('subscribePlayerDeployments polls the cloud for updates', async () => {
+    const { subscribePlayerDeployments } = await import('../scripts/mini-games.js');
+
+    const firstResponse = {
+      ok: true,
+      json: async () => ({
+        'mg-one': {
+          id: 'mg-one',
+          gameId: 'clue-tracker',
+          gameName: 'Clue Tracker',
+          player: 'Hero Name',
+          createdAt: 5,
+          status: 'pending'
+        }
+      })
+    };
+    const secondResponse = { ok: true, json: async () => ({}) };
+
+    let resolveFirst;
+    let resolveSecond;
+    global.fetch
+      .mockImplementationOnce(() => new Promise(resolve => { resolveFirst = resolve; }))
+      .mockImplementationOnce(() => new Promise(resolve => { resolveSecond = resolve; }));
+
+    let firstResolveEntries;
+    let secondResolveEntries;
+    const firstCall = new Promise(resolve => { firstResolveEntries = resolve; });
+    const secondCall = new Promise(resolve => { secondResolveEntries = resolve; });
+    const callback = jest.fn(entries => {
+      if (callback.mock.calls.length === 1) {
+        firstResolveEntries?.(entries);
+      } else if (callback.mock.calls.length === 2) {
+        secondResolveEntries?.(entries);
+      }
+    });
+
+    const unsubscribe = subscribePlayerDeployments('  Hero   Name ', callback, { intervalMs: 1 });
+
+    resolveFirst?.(firstResponse);
+    await firstCall;
+
+    expect(global.fetch).toHaveBeenCalledWith(`${CLOUD_URL}/Hero%20Name.json`);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0][0][0]).toMatchObject({ id: 'mg-one', player: 'Hero Name' });
+
+    await jest.advanceTimersByTimeAsync(1000);
+    resolveSecond?.(secondResponse);
+    await secondCall;
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    await jest.runOnlyPendingTimersAsync();
+  });
+});

--- a/__tests__/mini_games_player_invite.test.js
+++ b/__tests__/mini_games_player_invite.test.js
@@ -1,0 +1,265 @@
+import { jest } from '@jest/globals';
+
+const nativeGetElementById = document.getElementById.bind(document);
+
+function createStubElement() {
+  return {
+    innerHTML: '',
+    value: '',
+    style: { setProperty: () => {}, getPropertyValue: () => '' },
+    classList: {
+      add: () => {},
+      remove: () => {},
+      contains: () => false,
+      toggle: () => {},
+    },
+    setAttribute: () => {},
+    getAttribute: () => null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    appendChild: () => {},
+    removeChild: () => {},
+    contains: () => false,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    focus: () => {},
+    click: () => {},
+    add: () => {},
+    textContent: '',
+    disabled: false,
+    hidden: true,
+    dataset: {},
+    getBoundingClientRect: () => ({ left: 0, top: 0, width: 0, height: 0 }),
+  };
+}
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="app-alert" class="overlay" aria-hidden="true">
+      <div class="app-alert__card">
+        <h2 class="app-alert__title"></h2>
+        <p data-app-alert-message></p>
+        <button data-app-alert-dismiss type="button"></button>
+      </div>
+    </div>
+    <div id="toast"></div>
+    <div id="abil-grid"></div>
+    <div id="saves"></div>
+    <div id="mini-game-invite" class="overlay hidden" aria-hidden="true">
+      <section class="modal mini-game-invite">
+        <header class="mini-game-invite__header">
+          <h3 id="mini-game-invite-title" class="mini-game-invite__title"></h3>
+          <p id="mini-game-invite-message" class="mini-game-invite__message"></p>
+        </header>
+        <div class="mini-game-invite__game">
+          <div id="mini-game-invite-game" class="mini-game-invite__name"></div>
+          <p id="mini-game-invite-tagline" class="mini-game-invite__tagline"></p>
+        </div>
+        <div id="mini-game-invite-summary" class="mini-game-invite__summary"></div>
+        <div id="mini-game-invite-notes" class="mini-game-invite__notes" hidden>
+          <h4 class="mini-game-invite__notes-title">Briefing</h4>
+          <p id="mini-game-invite-notes-text" class="mini-game-invite__notes-text"></p>
+        </div>
+        <footer class="mini-game-invite__actions">
+          <button id="mini-game-invite-decline" type="button"></button>
+          <button id="mini-game-invite-accept" type="button"></button>
+        </footer>
+      </section>
+    </div>
+    <input id="superhero" value="Hero One" />
+  `;
+
+  document.getElementById = (id) => nativeGetElementById(id) || createStubElement();
+}
+
+async function initMainModule() {
+  jest.resetModules();
+  setupDom();
+  global.fetch = jest.fn();
+  global.toast = jest.fn();
+  global.dismissToast = jest.fn();
+  window.open = jest.fn(() => ({}));
+  window.matchMedia = window.matchMedia || (() => ({ matches: false, addListener: () => {}, removeListener: () => {} }));
+  window.scrollTo = window.scrollTo || (() => {});
+
+  const show = jest.fn();
+  const hide = jest.fn();
+
+  jest.unstable_mockModule('../scripts/modal.js', () => ({ show, hide }));
+
+  jest.unstable_mockModule('../scripts/helpers.js', () => ({
+    $: (id) => document.getElementById(id),
+    qs: (sel) => document.querySelector(sel),
+    qsa: (sel) => Array.from(document.querySelectorAll(sel)),
+    num: Number,
+    mod: (a, b) => ((a % b) + b) % b,
+    calculateArmorBonus: () => 0,
+    revertAbilityScore: () => 0,
+  }));
+
+  jest.unstable_mockModule('../scripts/faction.js', () => ({
+    setupFactionRepTracker: () => {},
+    ACTION_HINTS: {},
+    updateFactionRep: () => {},
+    migratePublicOpinionSnapshot: (data) => data,
+  }));
+
+  const currentCharacter = jest.fn(() => 'Hero One');
+
+  jest.unstable_mockModule('../scripts/characters.js', () => ({
+    currentCharacter,
+    setCurrentCharacter: () => {},
+    listCharacters: async () => ['Hero One'],
+    loadCharacter: async () => ({}),
+    loadBackup: async () => ({}),
+    listBackups: async () => [],
+    deleteCharacter: async () => {},
+    saveCharacter: async () => {},
+    renameCharacter: async () => {},
+    listRecoverableCharacters: async () => [],
+    saveAutoBackup: async () => {},
+  }));
+
+  let subscribeCallback = null;
+  const updateDeployment = jest.fn(async () => {});
+
+  const gameDefinition = {
+    id: 'clue-tracker',
+    name: 'Clue Tracker',
+    tagline: 'Connect the evidence',
+    url: 'game.html',
+    knobs: [
+      { key: 'difficulty', label: 'Difficulty', type: 'number', default: 3 }
+    ]
+  };
+
+  jest.unstable_mockModule('../scripts/mini-games.js', () => ({
+    formatKnobValue: (knob, value) => String(value ?? ''),
+    getMiniGame: () => gameDefinition,
+    subscribePlayerDeployments: (player, callback) => {
+      subscribeCallback = callback;
+      callback([]);
+      return jest.fn();
+    },
+    summarizeConfig: () => 'Difficulty: 3',
+    updateDeployment,
+  }));
+
+  jest.unstable_mockModule('../scripts/storage.js', () => ({
+    cacheCloudSaves: () => {},
+    subscribeCloudSaves: () => () => {},
+    appendCampaignLogEntry: async () => {},
+    deleteCampaignLogEntry: async () => {},
+    fetchCampaignLogEntries: async () => [],
+    subscribeCampaignLog: () => () => {},
+  }));
+
+  jest.unstable_mockModule('../scripts/pin.js', () => ({
+    hasPin: async () => false,
+    setPin: async () => {},
+    verifyPin: async () => true,
+    clearPin: async () => {},
+    syncPin: async () => {},
+  }));
+
+  jest.unstable_mockModule('../scripts/catalog-utils.js', () => ({
+    buildPriceIndex: () => new Map(),
+    decodeCatalogBuffer: () => [],
+    extractPriceValue: () => 0,
+    normalizeCatalogRow: (row) => row,
+    normalizeCatalogToken: (token) => token,
+    normalizePriceRow: (row) => row,
+    parseCsv: () => [],
+    sanitizeNormalizedCatalogEntry: (entry) => entry,
+    sortCatalogRows: (rows) => rows,
+    splitValueOptions: () => [],
+    tierRank: () => 0,
+  }));
+
+  await import('../scripts/main.js');
+
+  return {
+    show,
+    hide,
+    getSubscribeCallback: () => subscribeCallback,
+    updateDeployment,
+  };
+}
+
+describe('player mini-game invitations', () => {
+  test('accepting an invite updates the deployment and launches the game', async () => {
+    const { show, hide, getSubscribeCallback, updateDeployment } = await initMainModule();
+    const callback = getSubscribeCallback();
+    expect(typeof callback).toBe('function');
+
+    const entry = {
+      id: 'mg-7',
+      player: 'Hero One',
+      status: 'pending',
+      gameId: 'clue-tracker',
+      gameName: 'Clue Tracker',
+      gameUrl: 'game.html',
+      config: { difficulty: 3 },
+      notes: 'Finish within 5 minutes',
+      createdAt: Date.now(),
+    };
+
+    callback([entry]);
+    await Promise.resolve();
+
+    expect(show).toHaveBeenCalledWith('mini-game-invite');
+    const toastEl = document.getElementById('toast');
+    expect(toastEl.textContent).toBe('Incoming mini-game: Clue Tracker');
+
+    const acceptBtn = document.getElementById('mini-game-invite-accept');
+    acceptBtn.dispatchEvent(new Event('click'));
+
+    await Promise.resolve();
+
+    expect(updateDeployment).toHaveBeenCalledWith(
+      'Hero One',
+      'mg-7',
+      expect.objectContaining({ status: 'active' })
+    );
+    expect(hide).toHaveBeenCalledWith('mini-game-invite');
+    expect(window.open).toHaveBeenCalledWith('game.html', '_blank', 'noopener');
+    expect(toastEl.textContent).toBe('Mini-game accepted');
+  });
+
+  test('declining an invite cancels the deployment and does not launch the game', async () => {
+    const { hide, getSubscribeCallback, updateDeployment } = await initMainModule();
+    const callback = getSubscribeCallback();
+
+    const entry = {
+      id: 'mg-8',
+      player: 'Hero One',
+      status: 'pending',
+      gameId: 'clue-tracker',
+      gameName: 'Clue Tracker',
+      gameUrl: 'game.html',
+      config: { difficulty: 2 },
+      createdAt: Date.now(),
+    };
+
+    callback([entry]);
+    await Promise.resolve();
+
+    window.open.mockClear();
+    const toastEl = document.getElementById('toast');
+    toastEl.textContent = '';
+
+    const declineBtn = document.getElementById('mini-game-invite-decline');
+    declineBtn.dispatchEvent(new Event('click'));
+
+    await Promise.resolve();
+
+    expect(updateDeployment).toHaveBeenCalledWith(
+      'Hero One',
+      'mg-8',
+      expect.objectContaining({ status: 'cancelled' })
+    );
+    expect(hide).toHaveBeenCalledWith('mini-game-invite');
+    expect(window.open).not.toHaveBeenCalled();
+    expect(toastEl.textContent).toBe('Mini-game declined');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -1183,6 +1183,7 @@
   <button id="dm-tools-tsomf" class="btn-sm">TSoMF</button>
   <button id="dm-tools-notifications" class="btn-sm">Notifications</button>
   <button id="dm-tools-characters" class="btn-sm">Characters</button>
+  <button id="dm-tools-mini-games" class="btn-sm">Mini-Games</button>
   <button id="dm-tools-logout" class="btn-sm">Logout</button>
 </div>
 <button id="dm-tools-toggle" class="dm-tools-toggle" hidden aria-haspopup="true" aria-controls="dm-tools-menu" aria-label="DM tools menu">
@@ -1234,6 +1235,71 @@
       </svg>
     </button>
     <div id="dm-character-sheet" class="dm-character-sheet" title="Character Sheet"></div>
+  </section>
+</div>
+<div class="overlay hidden" id="dm-mini-games-modal" aria-hidden="true">
+  <section class="modal dm-mini-games">
+    <button id="dm-mini-games-close" class="x" aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Deploy Mini-Games</h3>
+    <div class="dm-mini-games__layout">
+      <aside class="dm-mini-games__sidebar">
+        <h4 class="dm-mini-games__section-title">Library</h4>
+        <ul id="dm-mini-games-list" class="dm-mini-games__list" role="listbox" aria-label="Mini-game library"></ul>
+      </aside>
+      <div class="dm-mini-games__content">
+        <header class="dm-mini-games__header">
+          <div class="dm-mini-games__heading">
+            <h4 id="dm-mini-games-title" class="dm-mini-games__title">Select a mini-game</h4>
+            <p id="dm-mini-games-tagline" class="dm-mini-games__tagline"></p>
+          </div>
+          <a id="dm-mini-games-launch" class="dm-mini-games__launch" href="#" target="_blank" rel="noopener" hidden>Open Player View</a>
+        </header>
+        <section class="dm-mini-games__section">
+          <h5>Fast Edit Controls</h5>
+          <div id="dm-mini-games-knobs" class="dm-mini-games__knobs"></div>
+        </section>
+        <section class="dm-mini-games__section">
+          <h5>Deployment Target</h5>
+          <div class="dm-mini-games__deploy-form">
+            <label class="dm-mini-games__field">
+              <span>Select character</span>
+              <select id="dm-mini-games-player">
+                <option value="">Loading…</option>
+              </select>
+            </label>
+            <label class="dm-mini-games__field">
+              <span>Or enter name</span>
+              <input id="dm-mini-games-player-custom" type="text" placeholder="Custom target name"/>
+            </label>
+            <label class="dm-mini-games__field">
+              <span>DM notes (optional)</span>
+              <textarea id="dm-mini-games-notes" rows="2" placeholder="Add private context for the player"></textarea>
+            </label>
+            <div class="dm-mini-games__actions">
+              <button id="dm-mini-games-refresh-players" type="button" class="btn-sm">Refresh Characters</button>
+              <button id="dm-mini-games-deploy" type="button" class="somf-btn somf-primary">Deploy Mini-Game</button>
+            </div>
+          </div>
+        </section>
+        <section class="dm-mini-games__section dm-mini-games__section--scroll">
+          <h5>Mini-Game Briefing</h5>
+          <pre id="dm-mini-games-readme" class="dm-mini-games__readme" tabindex="0">Select a mini-game to view its briefing.</pre>
+        </section>
+        <section class="dm-mini-games__section dm-mini-games__section--scroll">
+          <div class="dm-mini-games__section-header">
+            <h5>Active Deployments</h5>
+            <div class="dm-mini-games__section-actions">
+              <button id="dm-mini-games-refresh" type="button" class="btn-sm">Refresh</button>
+            </div>
+          </div>
+          <ul id="dm-mini-games-deployments" class="dm-mini-games__deployments"></ul>
+        </section>
+      </div>
+    </div>
   </section>
 </div>
 <div class="overlay hidden" id="modal-somf-dm" aria-hidden="true">

--- a/index.html
+++ b/index.html
@@ -1302,6 +1302,28 @@
     </div>
   </section>
 </div>
+
+<div class="overlay hidden" id="mini-game-invite" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="mini-game-invite-title" data-modal-static>
+  <section class="modal mini-game-invite">
+    <header class="mini-game-invite__header">
+      <h3 id="mini-game-invite-title" class="mini-game-invite__title">Incoming Mini-Game Assignment</h3>
+      <p id="mini-game-invite-message" class="mini-game-invite__message"></p>
+    </header>
+    <div class="mini-game-invite__game">
+      <div id="mini-game-invite-game" class="mini-game-invite__name"></div>
+      <p id="mini-game-invite-tagline" class="mini-game-invite__tagline"></p>
+    </div>
+    <div id="mini-game-invite-summary" class="mini-game-invite__summary"></div>
+    <div id="mini-game-invite-notes" class="mini-game-invite__notes" hidden>
+      <h4 class="mini-game-invite__notes-title">Briefing</h4>
+      <p id="mini-game-invite-notes-text" class="mini-game-invite__notes-text"></p>
+    </div>
+    <footer class="mini-game-invite__actions">
+      <button id="mini-game-invite-decline" type="button" class="btn-sm mini-game-invite__decline">Decline</button>
+      <button id="mini-game-invite-accept" type="button" class="somf-btn somf-primary mini-game-invite__accept">Accept &amp; Launch</button>
+    </footer>
+  </section>
+</div>
 <div class="overlay hidden" id="modal-somf-dm" aria-hidden="true">
   <section id="somf-dm" class="modal somf-dm">
     <button id="somfDM-close" class="x" aria-label="Close">

--- a/scripts/mini-games.js
+++ b/scripts/mini-games.js
@@ -1,0 +1,539 @@
+const MINI_GAMES = [
+  {
+    id: 'clue-tracker',
+    name: 'Clue Tracker',
+    folder: 'ClueTracker',
+    url: 'SuperheroMiniGames/ClueTracker/ClueTracker.html',
+    tagline: 'Connect scattered evidence before the trail goes cold.',
+    knobs: [
+      {
+        key: 'cluesToReveal',
+        label: 'Clues to reveal',
+        type: 'number',
+        min: 1,
+        max: 12,
+        step: 1,
+        default: 3,
+        description: 'How many clues are unlocked for the player at the start of the mini-game.'
+      },
+      {
+        key: 'timePerClue',
+        label: 'Time per clue (seconds)',
+        type: 'number',
+        min: 15,
+        max: 600,
+        step: 15,
+        default: 90,
+        description: 'How long the player has to respond before the next clue is automatically exposed.'
+      },
+      {
+        key: 'includeRedHerrings',
+        label: 'Include red herrings',
+        type: 'toggle',
+        default: false,
+        description: 'Adds misleading hints that require additional investigation to clear.'
+      }
+    ]
+  },
+  {
+    id: 'code-breaker',
+    name: 'Code Breaker',
+    folder: 'CodeBreaker',
+    url: 'SuperheroMiniGames/CodeBreaker/CodeBreaker.html',
+    tagline: 'Crack the villain\'s encryption before the final lock engages.',
+    knobs: [
+      {
+        key: 'codeLength',
+        label: 'Code length',
+        type: 'number',
+        min: 3,
+        max: 10,
+        step: 1,
+        default: 5,
+        description: 'Number of characters the player must decode to succeed.'
+      },
+      {
+        key: 'attemptLimit',
+        label: 'Attempt limit',
+        type: 'number',
+        min: 1,
+        max: 12,
+        step: 1,
+        default: 6,
+        description: 'How many incorrect submissions are allowed before the console locks.'
+      },
+      {
+        key: 'cipherSet',
+        label: 'Cipher set',
+        type: 'select',
+        default: 'alphanumeric',
+        options: [
+          { value: 'alphanumeric', label: 'Alphanumeric' },
+          { value: 'glyph', label: 'Quantum Glyphs' },
+          { value: 'emoji', label: 'Emoji Override' }
+        ],
+        description: 'Determines the iconography used in the puzzle.'
+      }
+    ]
+  },
+  {
+    id: 'lockdown-override',
+    name: 'Lockdown Override',
+    folder: 'LockdownOverride',
+    url: 'SuperheroMiniGames/LockdownOverride/LockdownOverride.html',
+    tagline: 'Stabilise the base before automated defences engage.',
+    knobs: [
+      {
+        key: 'securityLevel',
+        label: 'Security level',
+        type: 'select',
+        default: 'amber',
+        options: [
+          { value: 'green', label: 'Green' },
+          { value: 'amber', label: 'Amber' },
+          { value: 'crimson', label: 'Crimson' }
+        ],
+        description: 'Higher levels add more countermeasures for the player to disarm.'
+      },
+      {
+        key: 'overrideTimer',
+        label: 'Override timer (seconds)',
+        type: 'number',
+        min: 30,
+        max: 900,
+        step: 30,
+        default: 300,
+        description: 'Total time before the lockdown seals permanently.'
+      },
+      {
+        key: 'hazardSuppression',
+        label: 'Hazard suppression enabled',
+        type: 'toggle',
+        default: true,
+        description: 'When on, automated traps pause while the player works. When off they remain active.'
+      }
+    ]
+  },
+  {
+    id: 'power-surge',
+    name: 'Power Surge',
+    folder: 'PowerSurge',
+    url: 'SuperheroMiniGames/PowerSurge/PowerSurge.html',
+    tagline: 'Balance unstable energy flows before the generator ruptures.',
+    knobs: [
+      {
+        key: 'energyTarget',
+        label: 'Stability target (%)',
+        type: 'number',
+        min: 10,
+        max: 100,
+        step: 5,
+        default: 80,
+        description: 'The output level the player must maintain to succeed.'
+      },
+      {
+        key: 'surgeWaves',
+        label: 'Surge waves',
+        type: 'number',
+        min: 1,
+        max: 8,
+        step: 1,
+        default: 3,
+        description: 'Number of escalating waves before the reactor stabilises.'
+      },
+      {
+        key: 'stabilityChecks',
+        label: 'Stability checks',
+        type: 'select',
+        default: 'skill',
+        options: [
+          { value: 'skill', label: 'Skill Tests' },
+          { value: 'power', label: 'Power Challenges' },
+          { value: 'mixed', label: 'Mixed Tests' }
+        ],
+        description: 'Defines the type of tests required to dampen each surge.'
+      }
+    ]
+  },
+  {
+    id: 'stratagem-hero',
+    name: 'Stratagem Hero',
+    folder: 'StratagemHero',
+    url: 'SuperheroMiniGames/StratagemHero/StratagemHero.html',
+    tagline: 'Coordinate the team\'s tactical response to an evolving crisis.',
+    knobs: [
+      {
+        key: 'missionProfile',
+        label: 'Mission profile',
+        type: 'select',
+        default: 'rescue',
+        options: [
+          { value: 'infiltration', label: 'Infiltration' },
+          { value: 'rescue', label: 'Rescue' },
+          { value: 'sabotage', label: 'Sabotage' }
+        ],
+        description: 'Sets the overall objective the player must solve.'
+      },
+      {
+        key: 'intelLevel',
+        label: 'Intel level',
+        type: 'select',
+        default: 'briefed',
+        options: [
+          { value: 'blind', label: 'Blind Drop' },
+          { value: 'briefed', label: 'Briefed' },
+          { value: 'overwatch', label: 'Overwatch Support' }
+        ],
+        description: 'Controls how much guidance the player receives from HQ.'
+      },
+      {
+        key: 'teamBoost',
+        label: 'Team synergy boost',
+        type: 'toggle',
+        default: false,
+        description: 'When enabled, grants a one-time advantage die for cooperative actions.'
+      }
+    ]
+  },
+  {
+    id: 'tech-lockpick',
+    name: 'Tech Lockpick',
+    folder: 'TechLockpick',
+    url: 'SuperheroMiniGames/TechLockpick/TechLockpick.html',
+    tagline: 'Bypass alien security architecture with finesse or brute force.',
+    knobs: [
+      {
+        key: 'lockComplexity',
+        label: 'Lock complexity',
+        type: 'select',
+        default: 'standard',
+        options: [
+          { value: 'standard', label: 'Standard' },
+          { value: 'advanced', label: 'Advanced' },
+          { value: 'exotic', label: 'Exotic' }
+        ],
+        description: 'Determines how many unique subsystems must be solved.'
+      },
+      {
+        key: 'failuresAllowed',
+        label: 'Failures allowed',
+        type: 'number',
+        min: 0,
+        max: 6,
+        step: 1,
+        default: 2,
+        description: 'Number of strike tokens the player can accumulate before the lock seals.'
+      },
+      {
+        key: 'supportDrones',
+        label: 'Support drones available',
+        type: 'toggle',
+        default: true,
+        description: 'Adds AI helpers that can clear a subsystem once per encounter.'
+      }
+    ]
+  }
+];
+
+const STATUS_OPTIONS = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'active', label: 'In Progress' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'cancelled', label: 'Cancelled' }
+];
+
+const README_BASE_PATH = 'SuperheroMiniGames';
+const README_FILENAME = 'README.txt';
+const CLOUD_MINI_GAMES_URL = 'https://ccccg-7d6b6-default-rtdb.firebaseio.com/miniGames';
+const POLL_INTERVAL_MS = 15000;
+
+const readmeCache = new Map();
+const listeners = new Set();
+let pollTimer = null;
+let pollPromise = null;
+let cachedDeployments = [];
+
+function cloneOptions(options) {
+  if (!Array.isArray(options)) return undefined;
+  return options.map(opt => ({ ...opt }));
+}
+
+function cloneGame(game) {
+  return {
+    ...game,
+    knobs: game.knobs.map(knob => ({ ...knob, options: cloneOptions(knob.options) }))
+  };
+}
+
+export function listMiniGames() {
+  return MINI_GAMES.map(cloneGame);
+}
+
+export function getMiniGame(id) {
+  const game = MINI_GAMES.find(item => item.id === id);
+  return game ? cloneGame(game) : null;
+}
+
+function ensureGame(id) {
+  const game = MINI_GAMES.find(item => item.id === id);
+  if (!game) throw new Error(`Unknown mini-game: ${id}`);
+  return game;
+}
+
+export function getDefaultConfig(id) {
+  const game = ensureGame(id);
+  const config = {};
+  game.knobs.forEach(knob => {
+    if (Object.prototype.hasOwnProperty.call(knob, 'default')) {
+      config[knob.key] = knob.default;
+      return;
+    }
+    switch (knob.type) {
+      case 'toggle':
+        config[knob.key] = false;
+        break;
+      case 'number':
+        config[knob.key] = knob.min ?? 0;
+        break;
+      default:
+        config[knob.key] = '';
+    }
+  });
+  return config;
+}
+
+export function formatKnobValue(knob, value) {
+  switch (knob.type) {
+    case 'toggle':
+      return value ? 'Enabled' : 'Disabled';
+    case 'select': {
+      const opt = knob.options?.find(o => o.value === value);
+      return opt ? opt.label : String(value ?? '');
+    }
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value)
+        ? value.toString()
+        : String(value ?? '');
+    default:
+      return String(value ?? '');
+  }
+}
+
+export function summarizeConfig(id, config = {}) {
+  const game = ensureGame(id);
+  return game.knobs
+    .map(knob => {
+      if (!Object.prototype.hasOwnProperty.call(config, knob.key)) return null;
+      const raw = config[knob.key];
+      if (knob.type === 'toggle' && typeof raw !== 'boolean') return `${knob.label}: ${raw ? 'Enabled' : 'Disabled'}`;
+      return `${knob.label}: ${formatKnobValue(knob, raw)}`;
+    })
+    .filter(Boolean)
+    .join(', ');
+}
+
+export const MINI_GAME_STATUS_OPTIONS = STATUS_OPTIONS.map(opt => ({ ...opt }));
+
+export function getStatusLabel(value) {
+  const opt = STATUS_OPTIONS.find(option => option.value === value);
+  return opt ? opt.label : value;
+}
+
+function encodePathSegment(segment) {
+  return encodeURIComponent(segment).replace(/%2F/g, '/');
+}
+
+function encodePath(path) {
+  return path
+    .split('/')
+    .map(encodePathSegment)
+    .join('/');
+}
+
+async function fetchReadme(game) {
+  if (readmeCache.has(game.id)) {
+    return readmeCache.get(game.id);
+  }
+  try {
+    const res = await fetch(`${README_BASE_PATH}/${game.folder}/${README_FILENAME}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const text = await res.text();
+    readmeCache.set(game.id, text);
+    return text;
+  } catch (err) {
+    const fallback = 'README unavailable.';
+    readmeCache.set(game.id, fallback);
+    console.error(`Failed to load README for ${game.name}`, err);
+    return fallback;
+  }
+}
+
+export async function loadMiniGameReadme(id) {
+  const game = ensureGame(id);
+  return fetchReadme(game);
+}
+
+async function fetchDeploymentsFromCloud() {
+  const res = await fetch(`${CLOUD_MINI_GAMES_URL}.json`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  return data || {};
+}
+
+function transformDeploymentData(raw) {
+  const entries = [];
+  if (!raw || typeof raw !== 'object') return entries;
+  for (const [player, record] of Object.entries(raw)) {
+    if (!record || typeof record !== 'object') continue;
+    for (const [id, details] of Object.entries(record)) {
+      if (!details || typeof details !== 'object') continue;
+      entries.push({
+        player,
+        id,
+        ...details
+      });
+    }
+  }
+  entries.sort((a, b) => {
+    const aTime = typeof a.updatedAt === 'number' ? a.updatedAt : typeof a.createdAt === 'number' ? a.createdAt : 0;
+    const bTime = typeof b.updatedAt === 'number' ? b.updatedAt : typeof b.createdAt === 'number' ? b.createdAt : 0;
+    return bTime - aTime;
+  });
+  return entries;
+}
+
+function safeClone(value) {
+  if (typeof structuredClone === 'function') {
+    try { return structuredClone(value); } catch {}
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function notifyListeners() {
+  const snapshot = safeClone(cachedDeployments);
+  listeners.forEach(listener => {
+    try {
+      listener(snapshot);
+    } catch (err) {
+      console.error('Mini-game listener error', err);
+    }
+  });
+}
+
+async function pollDeployments(force = false) {
+  if (pollPromise) {
+    return pollPromise;
+  }
+  if (!force && pollTimer === null && listeners.size === 0) {
+    return cachedDeployments;
+  }
+  pollPromise = (async () => {
+    try {
+      const raw = await fetchDeploymentsFromCloud();
+      cachedDeployments = transformDeploymentData(raw);
+      notifyListeners();
+    } catch (err) {
+      console.error('Failed to load mini-game deployments', err);
+    } finally {
+      pollPromise = null;
+    }
+    return cachedDeployments;
+  })();
+  return pollPromise;
+}
+
+function startPolling() {
+  if (pollTimer !== null) return;
+  pollDeployments(true).catch(() => {});
+  pollTimer = setInterval(() => {
+    pollDeployments(false).catch(() => {});
+  }, POLL_INTERVAL_MS);
+}
+
+function stopPolling() {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}
+
+export function subscribeToDeployments(callback) {
+  if (typeof callback !== 'function') return () => {};
+  listeners.add(callback);
+  startPolling();
+  callback(safeClone(cachedDeployments));
+  return () => {
+    listeners.delete(callback);
+    if (listeners.size === 0) {
+      stopPolling();
+    }
+  };
+}
+
+export async function refreshDeployments() {
+  return pollDeployments(true);
+}
+
+function randomId() {
+  return `mg-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sanitizePlayer(player = '') {
+  return player.trim().replace(/\s+/g, ' ');
+}
+
+export async function deployMiniGame({ gameId, player, config = {}, notes = '', issuedBy = '' } = {}) {
+  const game = ensureGame(gameId);
+  const trimmedPlayer = sanitizePlayer(player);
+  if (!trimmedPlayer) throw new Error('Player name is required');
+  const deploymentId = randomId();
+  const ts = Date.now();
+  const payload = {
+    id: deploymentId,
+    gameId: game.id,
+    gameName: game.name,
+    gameUrl: game.url,
+    config,
+    player: trimmedPlayer,
+    status: 'pending',
+    notes: typeof notes === 'string' ? notes.trim() : '',
+    issuedBy: issuedBy || 'DM',
+    createdAt: ts,
+    updatedAt: ts
+  };
+  const url = `${CLOUD_MINI_GAMES_URL}/${encodePath(trimmedPlayer)}/${encodePath(deploymentId)}.json`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  await pollDeployments(true);
+  return payload;
+}
+
+export async function updateDeployment(player, id, updates = {}) {
+  const trimmedPlayer = sanitizePlayer(player);
+  if (!trimmedPlayer || !id) throw new Error('Invalid deployment reference');
+  const patch = {
+    ...updates,
+    updatedAt: Date.now()
+  };
+  const url = `${CLOUD_MINI_GAMES_URL}/${encodePath(trimmedPlayer)}/${encodePath(id)}.json`;
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch)
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  await pollDeployments(true);
+}
+
+export async function deleteDeployment(player, id) {
+  const trimmedPlayer = sanitizePlayer(player);
+  if (!trimmedPlayer || !id) throw new Error('Invalid deployment reference');
+  const url = `${CLOUD_MINI_GAMES_URL}/${encodePath(trimmedPlayer)}/${encodePath(id)}.json`;
+  const res = await fetch(url, { method: 'DELETE' });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  await pollDeployments(true);
+}

--- a/scripts/modal.js
+++ b/scripts/modal.js
@@ -51,14 +51,14 @@ qsa('.overlay.hidden').forEach(ov => { ov.style.display = 'none'; });
 // Close modal on overlay click
 qsa('.overlay').forEach(ov => {
   ov.addEventListener('click', e => {
-    if (e.target === ov) hide(ov.id);
+    if (e.target === ov && !ov.hasAttribute('data-modal-static')) hide(ov.id);
   });
 });
 
 // Allow closing with Escape key
 document.addEventListener('keydown', e => {
   if (e.key === 'Escape' && openModals > 0) {
-    const open = qsa('.overlay').find(o => !o.classList.contains('hidden'));
+    const open = qsa('.overlay').find(o => !o.classList.contains('hidden') && !o.hasAttribute('data-modal-static'));
     if (open) hide(open.id);
   }
 });

--- a/styles/main.css
+++ b/styles/main.css
@@ -1361,6 +1361,59 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
 #dm-characters-modal .dm-characters-list{list-style:none;margin:0;padding:0;flex:1;overflow:auto}
 #dm-character-modal .modal.dm-character{max-width:none;width:100%;height:100%;max-height:none;display:flex;flex-direction:column}
 #dm-character-modal .dm-character-sheet{flex:1;overflow:auto}
+#dm-mini-games-modal .modal.dm-mini-games{max-width:min(1080px,100%);width:100%;height:100%;max-height:none;display:flex;flex-direction:column;gap:16px;overflow:hidden}
+.dm-mini-games__layout{display:flex;gap:16px;flex:1 1 auto;min-height:0}
+.dm-mini-games__sidebar{flex:0 0 240px;display:flex;flex-direction:column;gap:8px;min-height:0}
+.dm-mini-games__section-title{margin:0;font-size:.9rem;font-weight:600;color:var(--muted)}
+.dm-mini-games__list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px;overflow:auto;border:1px solid var(--line);border-radius:var(--radius);padding:8px}
+.dm-mini-games__list li{margin:0}
+.dm-mini-games__list button{width:100%;text-align:left;background:transparent;border:1px solid var(--line);border-radius:var(--radius);padding:8px 10px;display:flex;flex-direction:column;gap:4px;color:inherit;cursor:pointer;transition:var(--transition)}
+.dm-mini-games__list button:hover{border-color:var(--accent);color:var(--accent)}
+.dm-mini-games__list button[aria-selected="true"]{background:var(--accent);border-color:var(--accent);color:var(--text-on-accent)}
+.dm-mini-games__list button[aria-selected="true"] .dm-mini-games__list-tagline{color:var(--text-on-accent)}
+.dm-mini-games__list-title{font-weight:600}
+.dm-mini-games__list-tagline{font-size:.8rem;color:var(--muted)}
+.dm-mini-games__content{flex:1 1 auto;display:flex;flex-direction:column;gap:16px;min-height:0}
+.dm-mini-games__header{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;flex-wrap:wrap}
+.dm-mini-games__heading{display:flex;flex-direction:column;gap:4px}
+.dm-mini-games__title{margin:0;font-size:1.1rem}
+.dm-mini-games__tagline{margin:0;font-size:.9rem;color:var(--muted)}
+.dm-mini-games__launch{align-self:flex-start;text-decoration:none;font-size:.85rem;border:1px solid var(--accent);padding:6px 10px;border-radius:var(--radius);color:var(--accent);transition:var(--transition)}
+.dm-mini-games__launch:hover{background:var(--accent);color:var(--text-on-accent)}
+.dm-mini-games__section{display:flex;flex-direction:column;gap:12px}
+.dm-mini-games__section>h5{margin:0;font-size:.85rem;font-weight:600;color:var(--muted)}
+.dm-mini-games__knobs{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
+.dm-mini-games__knob{border:1px solid var(--line);border-radius:var(--radius);padding:10px;display:flex;flex-direction:column;gap:8px;background:rgba(0,0,0,.1)}
+.theme-light .dm-mini-games__knob{background:rgba(255,255,255,.04)}
+.dm-mini-games__knob label{display:flex;flex-direction:column;gap:6px;font-weight:600;font-size:.9rem}
+.dm-mini-games__knob small{font-size:.75rem;color:var(--muted);font-weight:400}
+.dm-mini-games__knob input[type="number"],.dm-mini-games__knob input[type="text"],.dm-mini-games__knob select{width:100%}
+.dm-mini-games__knob-toggle{display:flex;align-items:center;gap:8px;font-weight:600;font-size:.9rem}
+.dm-mini-games__deploy-form{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+.dm-mini-games__field{display:flex;flex-direction:column;gap:6px;font-size:.85rem}
+.dm-mini-games__field span{font-weight:600}
+.dm-mini-games__field textarea{min-height:64px;resize:vertical}
+.dm-mini-games__actions{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
+.dm-mini-games__readme{margin:0;border:1px solid var(--line);border-radius:var(--radius);padding:12px;line-height:1.4;font-family:var(--font-mono,monospace);font-size:.78rem;white-space:pre-wrap;background:rgba(0,0,0,.35);flex:1 1 auto;overflow:auto}
+.theme-light .dm-mini-games__readme{background:rgba(0,0,0,.05)}
+.dm-mini-games__section--scroll{flex:1 1 220px;min-height:0}
+.dm-mini-games__section-header{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.dm-mini-games__section-actions{display:flex;gap:8px}
+.dm-mini-games__deployments{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:12px;overflow:auto}
+.dm-mini-games__deployment{border:1px solid var(--line);border-radius:var(--radius);padding:10px;display:flex;flex-direction:column;gap:8px;background:rgba(0,0,0,.15)}
+.theme-light .dm-mini-games__deployment{background:rgba(255,255,255,.08)}
+.dm-mini-games__deployment[data-status="completed"]{border-color:var(--success)}
+.dm-mini-games__deployment[data-status="active"]{border-color:var(--accent)}
+.dm-mini-games__deployment[data-status="cancelled"]{border-color:var(--error)}
+.dm-mini-games__deployment-header{display:flex;flex-direction:column;gap:4px}
+.dm-mini-games__deployment-meta{font-size:.75rem;color:var(--muted);display:flex;flex-wrap:wrap;gap:8px}
+.dm-mini-games__deployment-summary{font-size:.85rem}
+.dm-mini-games__deployment-notes{font-size:.8rem;color:var(--muted)}
+.dm-mini-games__deployment-actions{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
+.dm-mini-games__deployment-actions select{min-width:140px}
+.dm-mini-games__empty{padding:12px;border:1px dashed var(--line);border-radius:var(--radius);text-align:center;color:var(--muted)}
+@media(max-width:960px){.dm-mini-games__layout{flex-direction:column}.dm-mini-games__sidebar{flex:0 0 auto}.dm-mini-games__list{max-height:180px}}
+@media(max-width:720px){#dm-mini-games-modal .modal.dm-mini-games{padding:16px}.dm-mini-games__header{flex-direction:column;align-items:flex-start}.dm-mini-games__deploy-form{grid-template-columns:1fr}}
 #modal-help{align-items:flex-start;overflow-y:auto}
 #modal-help .modal{max-height:none}
 #modal-welcome .modal{font-size:.85rem;line-height:1.4}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1414,6 +1414,26 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
 .dm-mini-games__empty{padding:12px;border:1px dashed var(--line);border-radius:var(--radius);text-align:center;color:var(--muted)}
 @media(max-width:960px){.dm-mini-games__layout{flex-direction:column}.dm-mini-games__sidebar{flex:0 0 auto}.dm-mini-games__list{max-height:180px}}
 @media(max-width:720px){#dm-mini-games-modal .modal.dm-mini-games{padding:16px}.dm-mini-games__header{flex-direction:column;align-items:flex-start}.dm-mini-games__deploy-form{grid-template-columns:1fr}}
+.mini-game-invite{max-width:min(420px,100%);display:flex;flex-direction:column;gap:16px;padding:20px 24px}
+.mini-game-invite__header{display:flex;flex-direction:column;gap:6px;text-align:center}
+.mini-game-invite__title{margin:0;font-size:1.05rem}
+.mini-game-invite__message{margin:0;font-size:.9rem;color:var(--muted)}
+.mini-game-invite__game{display:flex;flex-direction:column;gap:6px;align-items:center;text-align:center}
+.mini-game-invite__name{font-weight:600;font-size:1rem}
+.mini-game-invite__tagline{margin:0;font-size:.85rem;color:var(--muted)}
+.mini-game-invite__summary{border:1px solid var(--line);border-radius:var(--radius);padding:12px;font-size:.85rem;line-height:1.5;background:rgba(0,0,0,.15)}
+.theme-light .mini-game-invite__summary{background:rgba(0,0,0,.05)}
+.mini-game-invite__summary ul{margin:0;padding-left:20px;display:flex;flex-direction:column;gap:4px}
+.mini-game-invite__notes{border-left:3px solid var(--accent);border-radius:var(--radius);padding:12px;background:rgba(59,130,246,.08);display:flex;flex-direction:column;gap:6px}
+.theme-light .mini-game-invite__notes{background:rgba(59,130,246,.12)}
+.mini-game-invite__notes-title{margin:0;font-size:.82rem;letter-spacing:.08em;text-transform:uppercase;color:var(--accent)}
+.mini-game-invite__notes-text{margin:0;font-size:.88rem;line-height:1.5}
+.mini-game-invite__actions{display:flex;flex-wrap:wrap;gap:12px;justify-content:space-between}
+.mini-game-invite__decline{flex:1 1 120px;border:1px solid var(--error);color:var(--error);background:transparent;padding:10px 12px;border-radius:var(--radius);font-weight:600;cursor:pointer;transition:var(--transition)}
+.mini-game-invite__decline:hover{background:rgba(244,63,94,.1)}
+.mini-game-invite__decline:focus-visible{outline:2px solid var(--error);outline-offset:2px}
+.mini-game-invite__accept{flex:1 1 160px;text-align:center;padding:12px 16px;font-weight:600}
+@media(max-width:540px){.mini-game-invite{padding:18px}.mini-game-invite__actions{flex-direction:column}.mini-game-invite__decline,.mini-game-invite__accept{flex:1 1 auto;width:100%}}
 #modal-help{align-items:flex-start;overflow-y:auto}
 #modal-help .modal{max-height:none}
 #modal-welcome .modal{font-size:.85rem;line-height:1.4}


### PR DESCRIPTION
## Summary
- add a dedicated mini-games runtime that defines fast-edit knobs and syncs deployments through Firebase
- extend the DM tools UI with a Mini-Games menu entry and modal for configuring and launching mini-game deployments
- style the new modal layout and document the adjustable knobs inside each mini-game README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de4415b7f8832e888459300b0c0804