### PR TITLE
Adjust DM tools toggle styling and touch responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -1178,21 +1178,21 @@
   <button id="dm-login" class="dm-login-btn" aria-label="DM Tools">
     <img class="dm-login-logo" src="images/XoVrom.png" alt="XoVrom Industries logo">
   </button>
+  <div id="dm-tools-menu" class="dm-tools-menu" hidden>
+    <button id="dm-tools-tsomf" class="btn-sm" type="button">TSoMF</button>
+    <button id="dm-tools-notifications" class="btn-sm" type="button">Notifications</button>
+    <button id="dm-tools-characters" class="btn-sm" type="button">Characters</button>
+    <button id="dm-tools-mini-games" class="btn-sm" type="button">Mini-Games</button>
+    <button id="dm-tools-logout" class="btn-sm" type="button">Logout</button>
+  </div>
+  <button id="dm-tools-toggle" class="dm-tools-toggle" type="button" hidden aria-haspopup="true" aria-controls="dm-tools-menu" aria-label="DM tools menu">
+    <svg class="dm-tools-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
+      <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+    </svg>
+    <span class="sr-only">DM Tools</span>
+  </button>
 </footer>
-<div id="dm-tools-menu" class="dm-tools-menu" hidden>
-  <button id="dm-tools-tsomf" class="btn-sm">TSoMF</button>
-  <button id="dm-tools-notifications" class="btn-sm">Notifications</button>
-  <button id="dm-tools-characters" class="btn-sm">Characters</button>
-  <button id="dm-tools-mini-games" class="btn-sm">Mini-Games</button>
-  <button id="dm-tools-logout" class="btn-sm">Logout</button>
-</div>
-<button id="dm-tools-toggle" class="dm-tools-toggle" hidden aria-haspopup="true" aria-controls="dm-tools-menu" aria-label="DM tools menu">
-  <svg class="dm-tools-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M11.079 2.25c-.267 0-.525.105-.714.293l-1.08 1.08a1.125 1.125 0 01-.53.296l-1.527.305a1.125 1.125 0 00-.876.918l-.211 1.298a1.125 1.125 0 01-.466.748l-1.12.706a1.125 1.125 0 00-.39.93v1.51c0 .376.196.725.39.93l1.12.706c.21.133.356.352.4.6l.21 1.299c.08.51.484.893.99.993l1.526.305c.246.049.472.177.642.363l1.08 1.08c.188.188.447.293.714.293s.525-.105.714-.293l1.08-1.08c.17-.186.396-.314.642-.363l1.526-.305a1.125 1.125 0 00.99-.993l.21-1.299c.044-.248.19-.467.4-.6l1.12-.706c.194-.205.39-.554.39-.93v-1.51c0-.376-.196-.725-.39-.93l-1.12-.706a1.125 1.125 0 01-.4-.6l-.21-1.299a1.125 1.125 0 00-.99-.993l-1.526-.305a1.125 1.125 0 01-.642-.363l-1.08-1.08a1.012 1.012 0 00-.714-.293z" />
-    <path stroke-linecap="round" stroke-linejoin="round" d="M12 8.25a3.75 3.75 0 100 7.5 3.75 3.75 0 000-7.5z" />
-  </svg>
-  <span class="sr-only">DM Tools</span>
-</button>
 <div class="overlay hidden" id="dm-login-modal" aria-hidden="true">
   <section class="modal">
     <button id="dm-login-close" class="x" aria-label="Close">

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -1006,15 +1006,47 @@ function initDMLogin(){
     }
   });
 
-  if (dmToggleBtn) dmToggleBtn.addEventListener('click', () => {
+  let pointerToggleActivated = false;
+  function clearPointerToggleFlag() {
+    pointerToggleActivated = false;
+  }
+
+  function handleToggleActivation(event) {
     if (!isLoggedIn()) {
       requireLogin().catch(() => {});
       return;
     }
-    toggleMenu();
-  });
+    if (event.type === 'pointerdown' && event.pointerType && event.pointerType !== 'mouse') {
+      pointerToggleActivated = true;
+      event.preventDefault();
+      toggleMenu();
+      return;
+    }
+    if (event.type === 'click') {
+      if (pointerToggleActivated) {
+        clearPointerToggleFlag();
+        return;
+      }
+      toggleMenu();
+    }
+  }
+
+  if (dmToggleBtn) {
+    dmToggleBtn.addEventListener('pointerdown', handleToggleActivation);
+    dmToggleBtn.addEventListener('pointerup', clearPointerToggleFlag);
+    dmToggleBtn.addEventListener('pointercancel', clearPointerToggleFlag);
+    dmToggleBtn.addEventListener('click', handleToggleActivation);
+  }
 
   document.addEventListener('click', e => {
+    if (menu && !menu.hidden && !menu.contains(e.target) && !dmBtn?.contains(e.target) && !dmToggleBtn?.contains(e.target)) {
+      menu.hidden = true;
+      if (dmToggleBtn) dmToggleBtn.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  document.addEventListener('pointerdown', e => {
+    if (e.pointerType === 'mouse') return;
     if (menu && !menu.hidden && !menu.contains(e.target) && !dmBtn?.contains(e.target) && !dmToggleBtn?.contains(e.target)) {
       menu.hidden = true;
       if (dmToggleBtn) dmToggleBtn.setAttribute('aria-expanded', 'false');

--- a/styles/main.css
+++ b/styles/main.css
@@ -1751,22 +1751,23 @@ select[required]:valid{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  width:56px;
-  height:56px;
+  width:60px;
+  height:60px;
   padding:0;
-  border-radius:999px;
-  border:1px solid rgba(255,255,255,.14);
-  background:rgba(10,13,18,.92);
+  border-radius:16px;
+  border:1px solid rgba(255,255,255,.18);
+  background:rgba(10,13,18,.94);
   color:var(--text);
   box-shadow:0 16px 36px rgba(0,0,0,.55),0 0 0 1px rgba(59,130,246,.12) inset;
   backdrop-filter:blur(8px);
   cursor:pointer;
   z-index:2100;
   transition:var(--transition),transform .2s ease;
+  touch-action:manipulation;
 }
 .dm-tools-toggle:hover,
 .dm-tools-toggle:focus-visible{
-  background:rgba(15,21,30,.95);
+  background:rgba(15,21,30,.97);
   color:var(--accent);
   border-color:rgba(59,130,246,.6);
   transform:translateY(-2px);
@@ -1781,13 +1782,16 @@ select[required]:valid{
 }
 .dm-tools-toggle[hidden]{display:none}
 .dm-tools-toggle__icon{
-  width:26px;
-  height:26px;
+  width:28px;
+  height:28px;
   transition:transform .3s ease;
 }
 .dm-tools-toggle:hover .dm-tools-toggle__icon,
 .dm-tools-toggle:focus-visible .dm-tools-toggle__icon{
   transform:rotate(25deg);
+}
+.dm-tools-menu button{
+  touch-action:manipulation;
 }
 
 /* DM Tool (Shards of Many Fates) */


### PR DESCRIPTION
## Summary
- restyle the DM tools floating toggle as a rounded square gear button and keep the supporting markup within the footer
- improve touch interactions by handling pointer events when opening and closing the DM tools menu
- add touch-action hints to DM menu controls so taps feel more responsive

## Testing
- npm test -- --runTestsByPath __tests__/dm_login.test.js


------
https://chatgpt.com/codex/tasks/task_e_68de7b6baa8c832eac6e6d0be69b56a1