### PR TITLE
Fix SOMF reveal overlay interaction

### DIFF
--- a/scripts/modal.js
+++ b/scripts/modal.js
@@ -5,7 +5,7 @@ function getInertTargets() {
   qsa('body > :not(.overlay):not([data-launch-shell])').forEach(el => targets.add(el));
   const shell = document.querySelector('[data-launch-shell]');
   if (shell) {
-    qsa(':scope > :not(.overlay)', shell).forEach(el => targets.add(el));
+    qsa(':scope > :not(.overlay):not(#somf-reveal-alert)', shell).forEach(el => targets.add(el));
   }
   return Array.from(targets);
 }

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -1176,6 +1176,22 @@
     const card = overlay?.querySelector('.somf-reveal-alert__card');
     if (!overlay || !dismiss) return Promise.resolve();
 
+    const body = document.body;
+    const suppressedBodyClasses = [];
+    if (body?.classList?.contains('modal-open')) {
+      try { body.classList.remove('modal-open'); } catch {}
+      suppressedBodyClasses.push('modal-open');
+    }
+    if (body?.classList?.contains('touch-controls-disabled')) {
+      try { body.classList.remove('touch-controls-disabled'); } catch {}
+      suppressedBodyClasses.push('touch-controls-disabled');
+    }
+
+    const overlayWasInert = overlay.hasAttribute('inert');
+    if (overlayWasInert) {
+      try { overlay.removeAttribute('inert'); } catch {}
+    }
+
     const previouslyFocused = document.activeElement;
     overlay.hidden = false;
     overlay.setAttribute('aria-hidden', 'false');
@@ -1195,7 +1211,18 @@
         overlay.classList.remove('is-visible');
         document.body?.classList?.remove('somf-reveal-active');
 
+        if (body && suppressedBodyClasses.length) {
+          suppressedBodyClasses.forEach(cls => {
+            if (cls && !body.classList.contains(cls)) {
+              try { body.classList.add(cls); } catch {}
+            }
+          });
+        }
+
         const finalize = () => {
+          if (overlayWasInert) {
+            try { overlay.setAttribute('inert', ''); } catch {}
+          }
           overlay.hidden = true;
           overlay.setAttribute('aria-hidden', 'true');
           if (previouslyFocused && typeof previouslyFocused.focus === 'function') {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1347,7 +1347,7 @@ progress::-moz-progress-bar{
 .overlay.hidden .modal{transform:scale(.95);opacity:0}
 body.modal-open{overflow:hidden}
 body.modal-open> :not(.overlay):not([data-launch-shell]){pointer-events:none;user-select:none}
-body.modal-open [data-launch-shell]> :not(.overlay){pointer-events:none;user-select:none}
+body.modal-open [data-launch-shell]> :not(.overlay):not(.somf-reveal-alert){pointer-events:none;user-select:none}
 body.touch-controls-disabled{touch-action:none}
 body.touch-controls-disabled .app-shell{pointer-events:none}
 .modal h3{margin:0 0 4px;color:var(--accent);font-size:.9rem;line-height:1.2;font-weight:600}
@@ -1906,7 +1906,7 @@ body.app-alert-active{overflow:hidden}
   .app-alert__button{transition:none}
 }
 
-.somf-reveal-alert{position:fixed;inset:0;display:grid;place-items:center;padding:24px;background:rgba(4,6,12,.92);z-index:5000;opacity:0;pointer-events:none;transition:opacity .4s ease}
+.somf-reveal-alert{position:fixed;inset:0;display:grid;place-items:center;padding:24px;background:rgba(4,6,12,.92);z-index:12000;opacity:0;pointer-events:none;transition:opacity .4s ease}
 .somf-reveal-alert[hidden]{display:none}
 .somf-reveal-alert.is-visible{opacity:1;pointer-events:auto}
 .somf-reveal-alert__card{background:var(--surface);color:var(--text);border-radius:24px;border:1px solid rgba(255,255,255,.12);box-shadow:0 32px 60px rgba(0,0,0,.6);width:100%;max-width:var(--content-width);padding:32px 28px;text-align:center;display:flex;flex-direction:column;gap:18px;transform:translateY(12px) scale(.98);transition:transform .35s ease,box-shadow .35s ease}
@@ -1917,6 +1917,11 @@ body.app-alert-active{overflow:hidden}
 .somf-reveal-alert__btn:hover{transform:translateY(-2px);box-shadow:0 22px 54px rgba(59,130,246,.55)}
 .somf-reveal-alert__btn:focus-visible{outline:2px solid var(--text-on-accent);outline-offset:4px}
 body.somf-reveal-active{overflow:hidden}
+body.somf-reveal-active .overlay{pointer-events:none}
+body.somf-reveal-active .app-alert{pointer-events:none}
+body.modal-open [data-launch-shell]>.somf-reveal-alert{pointer-events:auto;user-select:auto}
+body.touch-controls-disabled.somf-reveal-active .app-shell{pointer-events:auto}
+body.touch-controls-disabled.somf-reveal-active .app-shell> :not(.somf-reveal-alert){pointer-events:none}
 @media (prefers-reduced-motion:reduce){
   .somf-reveal-alert{transition:none}
   .somf-reveal-alert__card{transition:none}


### PR DESCRIPTION
## Summary
- ensure the Shards reveal overlay stays interactive by releasing body touch locks and restoring them after dismiss
- boost the reveal overlay stacking order and suppress other overlays while it is active
- prevent modal infrastructure from marking the reveal overlay inert so its button remains clickable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68debbd146e0832ea0b51ac1afcfbf05