### PR TITLE
Prevent hidden tabs from extending layout

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -652,6 +652,15 @@ main.is-animating-tabs{
   overflow:hidden;
 }
 fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:10px;margin-bottom:0;box-shadow:var(--shadow);display:flex;flex-direction:column;opacity:0;transform:translate3d(0,0,0);cursor:default;pointer-events:none;will-change:opacity,filter;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);background-color:color-mix(in srgb,var(--surface) 5%,transparent);position:absolute;inset:0;width:100%;max-width:100%;visibility:hidden;filter:blur(18px) saturate(1.2)}
+fieldset[data-tab].card:not(.active):not(.animating){
+  height:0;
+  max-height:0;
+  min-height:0;
+  padding:0;
+  margin:0;
+  border-width:0;
+  overflow:hidden;
+}
 fieldset[data-tab].card.animating{visibility:visible;pointer-events:none;position:absolute;inset:0;margin-bottom:0;width:100%;max-width:100%;z-index:2}
 main.is-animating-tabs fieldset[data-tab].card.animating{will-change:opacity,filter}
 fieldset[data-tab="combat"].card{


### PR DESCRIPTION
## Summary
- collapse inactive tab panels so their content no longer stretches the page below the footer
- keep animation support by excluding currently animating panels from the collapse rules

## Testing
- Manual verification in headless browser

------
https://chatgpt.com/codex/tasks/task_e_68debcac4cf8832e94344244e019d71a