### PR TITLE
Replace DM Tools button icon with skull

### DIFF
--- a/index.html
+++ b/index.html
@@ -1176,7 +1176,14 @@
 <footer>
   <p>When the whole world tells you to move, it's your job to plant yourself like a tree by the river of truth and tell the whole world - no, YOU move.</p>
   <button id="dm-login" class="dm-login-btn" type="button" aria-label="DM Tools">
-    <img class="dm-login-logo" src="images/XoVrom.png" alt="XoVrom Industries logo">
+    <svg class="dm-login-logo" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M24 9C31 9 36.5 14.5 36.5 21.5V24c0 3.3 -1.866 6.39 -4.907 8.356l-.464 4.046a1.5 1.5 0 0 1 -1.484 1.242H17.88a1.5 1.5 0 0 1 -1.484-1.242l-.464-4.046C12.866 30.39 11 27.3 11 24v-2.5C11 14.5 16.5 9 24 9Z" />
+      <circle cx="19" cy="23" r="2.6" fill="currentColor" />
+      <circle cx="29" cy="23" r="2.6" fill="currentColor" />
+      <path stroke-linecap="round" stroke-linejoin="round" d="M22.5 27.5l1.5-1.5 1.5 1.5" />
+      <path stroke-linecap="round" stroke-linejoin="round" d="M21.5 31h5" />
+      <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 36.8h9" />
+    </svg>
   </button>
   <div class="dm-tools-portal">
     <div id="dm-tools-menu" class="dm-tools-menu" hidden>
@@ -1188,8 +1195,12 @@
     </div>
     <button id="dm-tools-toggle" class="dm-tools-toggle" type="button" hidden aria-haspopup="true" aria-controls="dm-tools-menu" aria-expanded="false" aria-label="DM tools menu">
       <svg class="dm-tools-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M11.079 2.25c-.267 0-.525.105-.714.293l-1.08 1.08a1.125 1.125 0 01-.53.296l-1.527.305a1.125 1.125 0 00-.876.918l-.211 1.298a1.125 1.125 0 01-.466.748l-1.12.706a1.125 1.125 0 00-.39.93v1.51c0 .376.196.725.39.93l1.12.706c.21.133.356.352.4.6l.21 1.299c.08.51.484.893.99.993l1.526.305c.246.049.472.177.642.363l1.08 1.08c.188.188.447.293.714.293s.525-.105.714-.293l1.08-1.08c.17-.186.396-.314.642-.363l1.526-.305a1.125 1.125 0 00.99-.993l.21-1.299c.044-.248.19-.467.4-.6l1.12-.706c.194-.205.39-.554.39-.93v-1.51c0-.376-.196-.725-.39-.93l-1.12-.706a1.125 1.125 0 01-.4-.6l-.21-1.299a1.125 1.125 0 00-.99-.993l-1.526-.305a1.125 1.125 0 01-.642-.363l-1.08-1.08a1.012 1.012 0 00-.714-.293z" />
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 8.25a3.75 3.75 0 100 7.5 3.75 3.75 0 000-7.5z" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5C15.5 4.5 18.25 7.25 18.25 10.75V12c0 1.65 -.84 3.23 -2.22 4.18l-.23 2a.75.75 0 0 1 -.74.64H8.94a.75.75 0 0 1 -.74-.64l-.23-2C6.59 15.23 5.75 13.65 5.75 12v-1.25C5.75 7.25 8.5 4.5 12 4.5Z" />
+        <circle cx="9.5" cy="11.5" r="1.3" fill="currentColor" />
+        <circle cx="14.5" cy="11.5" r="1.3" fill="currentColor" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 13.75l.75-.75.75.75" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M10.75 15.5h2.5" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 18.4h4.5" />
       </svg>
       <span class="sr-only">DM Tools</span>
     </button>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1740,7 +1740,7 @@ select[required]:valid{
   filter:none;
   transform:none;
 }
-.dm-login-btn img{
+.dm-login-btn svg{
   display:block;
   max-width:160px;
   width:100%;


### PR DESCRIPTION
## Summary
- replace the DM Tools login and toggle buttons' inline SVG art with a skull motif

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deeb52b8ac832e86ec75ae759067e1