### PR TITLE
Replace DM Tools toggle icon with text label

### DIFF
--- a/index.html
+++ b/index.html
@@ -1187,10 +1187,7 @@
       <button id="dm-tools-logout" class="btn-sm">Logout</button>
     </div>
     <button id="dm-tools-toggle" class="dm-tools-toggle" type="button" hidden aria-haspopup="true" aria-controls="dm-tools-menu" aria-expanded="false" aria-label="DM tools menu">
-      <svg class="dm-tools-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M11.079 2.25c-.267 0-.525.105-.714.293l-1.08 1.08a1.125 1.125 0 01-.53.296l-1.527.305a1.125 1.125 0 00-.876.918l-.211 1.298a1.125 1.125 0 01-.466.748l-1.12.706a1.125 1.125 0 00-.39.93v1.51c0 .376.196.725.39.93l1.12.706c.21.133.356.352.4.6l.21 1.299c.08.51.484.893.99.993l1.526.305c.246.049.472.177.642.363l1.08 1.08c.188.188.447.293.714.293s.525-.105.714-.293l1.08-1.08c.17-.186.396-.314.642-.363l1.526-.305a1.125 1.125 0 00.99-.993l.21-1.299c.044-.248.19-.467.4-.6l1.12-.706c.194-.205.39-.554.39-.93v-1.51c0-.376-.196-.725-.39-.93l-1.12-.706a1.125 1.125 0 01-.4-.6l-.21-1.299a1.125 1.125 0 00-.99-.993l-1.526-.305a1.125 1.125 0 01-.642-.363l-1.08-1.08a1.012 1.012 0 00-.714-.293z" />
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 8.25a3.75 3.75 0 100 7.5 3.75 3.75 0 000-7.5z" />
-      </svg>
+      <span class="dm-tools-toggle__label" aria-hidden="true">D.M.</span>
       <span class="sr-only">DM Tools</span>
     </button>
   </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1826,14 +1826,17 @@ select[required]:valid{
   box-shadow:0 10px 24px rgba(0,0,0,.45),0 0 0 1px rgba(59,130,246,.2) inset;
 }
 .dm-tools-toggle[hidden]{display:none}
-.dm-tools-toggle__icon{
-  width:28px;
-  height:28px;
+.dm-tools-toggle__label{
+  display:inline-block;
+  font-size:18px;
+  font-weight:700;
+  letter-spacing:0.18em;
+  text-transform:uppercase;
   transition:transform .3s ease;
 }
-.dm-tools-toggle:hover .dm-tools-toggle__icon,
-.dm-tools-toggle:focus-visible .dm-tools-toggle__icon{
-  transform:rotate(25deg);
+.dm-tools-toggle:hover .dm-tools-toggle__label,
+.dm-tools-toggle:focus-visible .dm-tools-toggle__label{
+  transform:scale(1.08);
 }
 
 /* DM Tool (Shards of Many Fates) */


### PR DESCRIPTION
## Summary
- replace the DM Tools toggle gear icon with a D.M. text label for better clarity
- add styling for the new label and hover scaling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df9bf8c910832ebb652f1fd28dd932