### PR TITLE
Fix mini-game pages to load shared runner shell

### DIFF
--- a/SuperheroMiniGames/ClueTracker/ClueTracker.html
+++ b/SuperheroMiniGames/ClueTracker/ClueTracker.html
@@ -1,14 +1,54 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-mini-game-id="clue-tracker">
   <head>
     <meta charset="utf-8" />
-    <title>Clue Tracker</title>
-    <meta http-equiv="refresh" content="0; url=../play.html?game=clue-tracker" />
-    <script>
-      window.location.replace('../play.html?game=clue-tracker');
-    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="mini-game-id" content="clue-tracker" />
+    <title>Clue Tracker – Superhero Mini-Game</title>
+    <link rel="stylesheet" href="../play.css" />
   </head>
-  <body>
-    <p>Redirecting to the updated Clue Tracker experience… <a href="../play.html?game=clue-tracker">Continue</a></p>
+  <body data-mini-game-id="clue-tracker">
+    <noscript>This app requires JavaScript to run properly.</noscript>
+    <main id="mini-game-shell" class="mini-game-shell" hidden>
+      <header class="mini-game-shell__header">
+        <div class="mini-game-shell__heading">
+          <h1 id="mini-game-title" class="mini-game-shell__title"></h1>
+          <p id="mini-game-tagline" class="mini-game-shell__tagline"></p>
+        </div>
+        <aside class="mini-game-shell__meta">
+          <dl>
+            <div>
+              <dt>Player</dt>
+              <dd id="mini-game-player">Unknown Operative</dd>
+            </div>
+            <div>
+              <dt>Issued By</dt>
+              <dd id="mini-game-issued"></dd>
+            </div>
+            <div id="mini-game-deployment-row" hidden>
+              <dt>Deployment</dt>
+              <dd id="mini-game-deployment"></dd>
+            </div>
+          </dl>
+        </aside>
+      </header>
+      <section class="mini-game-shell__briefing">
+        <div class="mini-game-shell__brief-text">
+          <h2>Mission Briefing</h2>
+          <p id="mini-game-brief"></p>
+        </div>
+        <div class="mini-game-shell__config" id="mini-game-config"></div>
+        <div class="mini-game-shell__notes" id="mini-game-notes" hidden>
+          <h3>DM Notes</h3>
+          <p id="mini-game-notes-text"></p>
+        </div>
+        <p id="mini-game-preview-banner" class="mini-game-shell__preview" hidden>
+          Running in preview mode with default parameters.
+        </p>
+      </section>
+      <section class="mini-game-shell__content" id="mini-game-root"></section>
+    </main>
+    <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
+    <script type="module" src="../play.js"></script>
   </body>
 </html>

--- a/SuperheroMiniGames/CodeBreaker/CodeBreaker.html
+++ b/SuperheroMiniGames/CodeBreaker/CodeBreaker.html
@@ -1,14 +1,54 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-mini-game-id="code-breaker">
   <head>
     <meta charset="utf-8" />
-    <title>Code Breaker</title>
-    <meta http-equiv="refresh" content="0; url=../play.html?game=code-breaker" />
-    <script>
-      window.location.replace('../play.html?game=code-breaker');
-    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="mini-game-id" content="code-breaker" />
+    <title>Code Breaker – Superhero Mini-Game</title>
+    <link rel="stylesheet" href="../play.css" />
   </head>
-  <body>
-    <p>Redirecting to the updated Code Breaker experience… <a href="../play.html?game=code-breaker">Continue</a></p>
+  <body data-mini-game-id="code-breaker">
+    <noscript>This app requires JavaScript to run properly.</noscript>
+    <main id="mini-game-shell" class="mini-game-shell" hidden>
+      <header class="mini-game-shell__header">
+        <div class="mini-game-shell__heading">
+          <h1 id="mini-game-title" class="mini-game-shell__title"></h1>
+          <p id="mini-game-tagline" class="mini-game-shell__tagline"></p>
+        </div>
+        <aside class="mini-game-shell__meta">
+          <dl>
+            <div>
+              <dt>Player</dt>
+              <dd id="mini-game-player">Unknown Operative</dd>
+            </div>
+            <div>
+              <dt>Issued By</dt>
+              <dd id="mini-game-issued"></dd>
+            </div>
+            <div id="mini-game-deployment-row" hidden>
+              <dt>Deployment</dt>
+              <dd id="mini-game-deployment"></dd>
+            </div>
+          </dl>
+        </aside>
+      </header>
+      <section class="mini-game-shell__briefing">
+        <div class="mini-game-shell__brief-text">
+          <h2>Mission Briefing</h2>
+          <p id="mini-game-brief"></p>
+        </div>
+        <div class="mini-game-shell__config" id="mini-game-config"></div>
+        <div class="mini-game-shell__notes" id="mini-game-notes" hidden>
+          <h3>DM Notes</h3>
+          <p id="mini-game-notes-text"></p>
+        </div>
+        <p id="mini-game-preview-banner" class="mini-game-shell__preview" hidden>
+          Running in preview mode with default parameters.
+        </p>
+      </section>
+      <section class="mini-game-shell__content" id="mini-game-root"></section>
+    </main>
+    <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
+    <script type="module" src="../play.js"></script>
   </body>
 </html>

--- a/SuperheroMiniGames/LockdownOverride/LockdownOverride.html
+++ b/SuperheroMiniGames/LockdownOverride/LockdownOverride.html
@@ -1,14 +1,54 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-mini-game-id="lockdown-override">
   <head>
     <meta charset="utf-8" />
-    <title>Lockdown Override</title>
-    <meta http-equiv="refresh" content="0; url=../play.html?game=lockdown-override" />
-    <script>
-      window.location.replace('../play.html?game=lockdown-override');
-    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="mini-game-id" content="lockdown-override" />
+    <title>Lockdown Override – Superhero Mini-Game</title>
+    <link rel="stylesheet" href="../play.css" />
   </head>
-  <body>
-    <p>Redirecting to the updated Lockdown Override experience… <a href="../play.html?game=lockdown-override">Continue</a></p>
+  <body data-mini-game-id="lockdown-override">
+    <noscript>This app requires JavaScript to run properly.</noscript>
+    <main id="mini-game-shell" class="mini-game-shell" hidden>
+      <header class="mini-game-shell__header">
+        <div class="mini-game-shell__heading">
+          <h1 id="mini-game-title" class="mini-game-shell__title"></h1>
+          <p id="mini-game-tagline" class="mini-game-shell__tagline"></p>
+        </div>
+        <aside class="mini-game-shell__meta">
+          <dl>
+            <div>
+              <dt>Player</dt>
+              <dd id="mini-game-player">Unknown Operative</dd>
+            </div>
+            <div>
+              <dt>Issued By</dt>
+              <dd id="mini-game-issued"></dd>
+            </div>
+            <div id="mini-game-deployment-row" hidden>
+              <dt>Deployment</dt>
+              <dd id="mini-game-deployment"></dd>
+            </div>
+          </dl>
+        </aside>
+      </header>
+      <section class="mini-game-shell__briefing">
+        <div class="mini-game-shell__brief-text">
+          <h2>Mission Briefing</h2>
+          <p id="mini-game-brief"></p>
+        </div>
+        <div class="mini-game-shell__config" id="mini-game-config"></div>
+        <div class="mini-game-shell__notes" id="mini-game-notes" hidden>
+          <h3>DM Notes</h3>
+          <p id="mini-game-notes-text"></p>
+        </div>
+        <p id="mini-game-preview-banner" class="mini-game-shell__preview" hidden>
+          Running in preview mode with default parameters.
+        </p>
+      </section>
+      <section class="mini-game-shell__content" id="mini-game-root"></section>
+    </main>
+    <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
+    <script type="module" src="../play.js"></script>
   </body>
 </html>

--- a/SuperheroMiniGames/PowerSurge/PowerSurge.html
+++ b/SuperheroMiniGames/PowerSurge/PowerSurge.html
@@ -1,14 +1,54 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-mini-game-id="power-surge">
   <head>
     <meta charset="utf-8" />
-    <title>Power Surge</title>
-    <meta http-equiv="refresh" content="0; url=../play.html?game=power-surge" />
-    <script>
-      window.location.replace('../play.html?game=power-surge');
-    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="mini-game-id" content="power-surge" />
+    <title>Power Surge – Superhero Mini-Game</title>
+    <link rel="stylesheet" href="../play.css" />
   </head>
-  <body>
-    <p>Redirecting to the updated Power Surge experience… <a href="../play.html?game=power-surge">Continue</a></p>
+  <body data-mini-game-id="power-surge">
+    <noscript>This app requires JavaScript to run properly.</noscript>
+    <main id="mini-game-shell" class="mini-game-shell" hidden>
+      <header class="mini-game-shell__header">
+        <div class="mini-game-shell__heading">
+          <h1 id="mini-game-title" class="mini-game-shell__title"></h1>
+          <p id="mini-game-tagline" class="mini-game-shell__tagline"></p>
+        </div>
+        <aside class="mini-game-shell__meta">
+          <dl>
+            <div>
+              <dt>Player</dt>
+              <dd id="mini-game-player">Unknown Operative</dd>
+            </div>
+            <div>
+              <dt>Issued By</dt>
+              <dd id="mini-game-issued"></dd>
+            </div>
+            <div id="mini-game-deployment-row" hidden>
+              <dt>Deployment</dt>
+              <dd id="mini-game-deployment"></dd>
+            </div>
+          </dl>
+        </aside>
+      </header>
+      <section class="mini-game-shell__briefing">
+        <div class="mini-game-shell__brief-text">
+          <h2>Mission Briefing</h2>
+          <p id="mini-game-brief"></p>
+        </div>
+        <div class="mini-game-shell__config" id="mini-game-config"></div>
+        <div class="mini-game-shell__notes" id="mini-game-notes" hidden>
+          <h3>DM Notes</h3>
+          <p id="mini-game-notes-text"></p>
+        </div>
+        <p id="mini-game-preview-banner" class="mini-game-shell__preview" hidden>
+          Running in preview mode with default parameters.
+        </p>
+      </section>
+      <section class="mini-game-shell__content" id="mini-game-root"></section>
+    </main>
+    <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
+    <script type="module" src="../play.js"></script>
   </body>
 </html>

--- a/SuperheroMiniGames/StratagemHero/StratagemHero.html
+++ b/SuperheroMiniGames/StratagemHero/StratagemHero.html
@@ -1,14 +1,54 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-mini-game-id="stratagem-hero">
   <head>
     <meta charset="utf-8" />
-    <title>Stratagem Hero</title>
-    <meta http-equiv="refresh" content="0; url=../play.html?game=stratagem-hero" />
-    <script>
-      window.location.replace('../play.html?game=stratagem-hero');
-    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="mini-game-id" content="stratagem-hero" />
+    <title>Stratagem Hero – Superhero Mini-Game</title>
+    <link rel="stylesheet" href="../play.css" />
   </head>
-  <body>
-    <p>Redirecting to the updated Stratagem Hero experience… <a href="../play.html?game=stratagem-hero">Continue</a></p>
+  <body data-mini-game-id="stratagem-hero">
+    <noscript>This app requires JavaScript to run properly.</noscript>
+    <main id="mini-game-shell" class="mini-game-shell" hidden>
+      <header class="mini-game-shell__header">
+        <div class="mini-game-shell__heading">
+          <h1 id="mini-game-title" class="mini-game-shell__title"></h1>
+          <p id="mini-game-tagline" class="mini-game-shell__tagline"></p>
+        </div>
+        <aside class="mini-game-shell__meta">
+          <dl>
+            <div>
+              <dt>Player</dt>
+              <dd id="mini-game-player">Unknown Operative</dd>
+            </div>
+            <div>
+              <dt>Issued By</dt>
+              <dd id="mini-game-issued"></dd>
+            </div>
+            <div id="mini-game-deployment-row" hidden>
+              <dt>Deployment</dt>
+              <dd id="mini-game-deployment"></dd>
+            </div>
+          </dl>
+        </aside>
+      </header>
+      <section class="mini-game-shell__briefing">
+        <div class="mini-game-shell__brief-text">
+          <h2>Mission Briefing</h2>
+          <p id="mini-game-brief"></p>
+        </div>
+        <div class="mini-game-shell__config" id="mini-game-config"></div>
+        <div class="mini-game-shell__notes" id="mini-game-notes" hidden>
+          <h3>DM Notes</h3>
+          <p id="mini-game-notes-text"></p>
+        </div>
+        <p id="mini-game-preview-banner" class="mini-game-shell__preview" hidden>
+          Running in preview mode with default parameters.
+        </p>
+      </section>
+      <section class="mini-game-shell__content" id="mini-game-root"></section>
+    </main>
+    <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
+    <script type="module" src="../play.js"></script>
   </body>
 </html>

--- a/SuperheroMiniGames/TechLockpick/TechLockpick.html
+++ b/SuperheroMiniGames/TechLockpick/TechLockpick.html
@@ -1,14 +1,54 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-mini-game-id="tech-lockpick">
   <head>
     <meta charset="utf-8" />
-    <title>Tech Lockpick</title>
-    <meta http-equiv="refresh" content="0; url=../play.html?game=tech-lockpick" />
-    <script>
-      window.location.replace('../play.html?game=tech-lockpick');
-    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="mini-game-id" content="tech-lockpick" />
+    <title>Tech Lockpick – Superhero Mini-Game</title>
+    <link rel="stylesheet" href="../play.css" />
   </head>
-  <body>
-    <p>Redirecting to the updated Tech Lockpick experience… <a href="../play.html?game=tech-lockpick">Continue</a></p>
+  <body data-mini-game-id="tech-lockpick">
+    <noscript>This app requires JavaScript to run properly.</noscript>
+    <main id="mini-game-shell" class="mini-game-shell" hidden>
+      <header class="mini-game-shell__header">
+        <div class="mini-game-shell__heading">
+          <h1 id="mini-game-title" class="mini-game-shell__title"></h1>
+          <p id="mini-game-tagline" class="mini-game-shell__tagline"></p>
+        </div>
+        <aside class="mini-game-shell__meta">
+          <dl>
+            <div>
+              <dt>Player</dt>
+              <dd id="mini-game-player">Unknown Operative</dd>
+            </div>
+            <div>
+              <dt>Issued By</dt>
+              <dd id="mini-game-issued"></dd>
+            </div>
+            <div id="mini-game-deployment-row" hidden>
+              <dt>Deployment</dt>
+              <dd id="mini-game-deployment"></dd>
+            </div>
+          </dl>
+        </aside>
+      </header>
+      <section class="mini-game-shell__briefing">
+        <div class="mini-game-shell__brief-text">
+          <h2>Mission Briefing</h2>
+          <p id="mini-game-brief"></p>
+        </div>
+        <div class="mini-game-shell__config" id="mini-game-config"></div>
+        <div class="mini-game-shell__notes" id="mini-game-notes" hidden>
+          <h3>DM Notes</h3>
+          <p id="mini-game-notes-text"></p>
+        </div>
+        <p id="mini-game-preview-banner" class="mini-game-shell__preview" hidden>
+          Running in preview mode with default parameters.
+        </p>
+      </section>
+      <section class="mini-game-shell__content" id="mini-game-root"></section>
+    </main>
+    <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
+    <script type="module" src="../play.js"></script>
   </body>
 </html>

--- a/SuperheroMiniGames/play.css
+++ b/SuperheroMiniGames/play.css
@@ -316,6 +316,7 @@ body {
   margin: 0;
   font-size: 0.95rem;
   line-height: 1.4;
+  word-break: break-word;
 }
 
 .clue-card__tags {
@@ -353,6 +354,77 @@ body {
 .clue-card--red {
   border-color: rgba(248, 113, 113, 0.65);
   background: rgba(127, 29, 29, 0.35);
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 16px 12px 28px;
+  }
+
+  .mini-game-shell {
+    padding: 22px clamp(14px, 6vw, 22px) 28px;
+    gap: 20px;
+  }
+
+  .mini-game-shell__header {
+    gap: 12px;
+  }
+
+  .mini-game-shell__meta dl {
+    gap: 4px 12px;
+    font-size: 0.85rem;
+  }
+
+  .mini-game-shell__briefing {
+    gap: 14px;
+  }
+
+  .clue-tracker__summary {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .clue-grid {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .clue-card {
+    padding: 14px;
+    min-height: 0;
+  }
+
+  .clue-card__body {
+    font-size: 0.92rem;
+  }
+
+  .clue-card__tags {
+    gap: 4px;
+  }
+}
+
+@media (max-width: 420px) {
+  .mini-game-shell__title {
+    font-size: clamp(1.5rem, 8vw, 1.9rem);
+  }
+
+  .mini-game-shell__tagline {
+    font-size: 0.95rem;
+  }
+
+  .clue-card {
+    border-radius: 14px;
+  }
+
+  .clue-card__body {
+    line-height: 1.45;
+  }
+
+  .clue-card__tag {
+    font-size: 0.7rem;
+    padding: 3px 8px;
+  }
 }
 
 /* Code Breaker */


### PR DESCRIPTION
## Summary
- allow the mini-game runner to resolve game, deployment, and player details from metadata or data attributes when query params are missing
- replace each per-game HTML stub with the shared runner shell so legacy links open the interactive experience instead of placeholders

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df9eb5aac0832ebc861a83d3affee6