### PR TITLE
Refine DM and player mini-game modals

### DIFF
--- a/SuperheroMiniGames/play.css
+++ b/SuperheroMiniGames/play.css
@@ -110,7 +110,7 @@ body {
   color: rgba(226, 232, 240, 0.9);
 }
 
-.mini-game-shell__config {
+.mini-game-shell__config { 
   border: 1px solid var(--border);
   border-radius: 14px;
   padding: 14px 16px;
@@ -120,6 +120,13 @@ body {
 .mini-game-shell__config h3 {
   margin: 0 0 8px;
   font-size: 1.05rem;
+}
+
+.mini-game-shell__configHint {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.85);
 }
 
 .mini-game-shell__config dl {

--- a/SuperheroMiniGames/play.js
+++ b/SuperheroMiniGames/play.js
@@ -129,25 +129,29 @@ function getDefaultConfig(game) {
 function renderConfigSummary(game, config) {
   if (!configEl) return;
   configEl.innerHTML = '';
-  const knobs = game.knobs || [];
+  const knobs = (game.knobs || []).filter(knob => knob && knob.playerFacing === true);
   if (!knobs.length) {
     const p = document.createElement('p');
-    p.textContent = 'This assignment uses default parameters.';
+    p.className = 'mini-game-shell__configHint';
+    p.textContent = 'Your DM already set the mission parameters. Focus on the briefing and tap “Start Mission” when you are ready.';
     configEl.appendChild(p);
     return;
   }
   const heading = document.createElement('h3');
-  heading.textContent = 'Fast Edit Parameters';
+  heading.textContent = 'Mission Parameters';
   configEl.appendChild(heading);
   const dl = document.createElement('dl');
   knobs.forEach(knob => {
     const dt = document.createElement('dt');
-    dt.textContent = knob.label;
+    dt.textContent = knob.playerLabel || knob.label;
     const dd = document.createElement('dd');
     const raw = Object.prototype.hasOwnProperty.call(config, knob.key)
       ? config[knob.key]
       : knob.default;
-    dd.textContent = formatKnobValue(knob, raw);
+    const displayValue = typeof knob.playerFormat === 'function'
+      ? knob.playerFormat(raw, config)
+      : formatKnobValue(knob, raw);
+    dd.textContent = displayValue;
     dl.appendChild(dt);
     dl.appendChild(dd);
   });

--- a/__tests__/dm_mini_games.test.js
+++ b/__tests__/dm_mini_games.test.js
@@ -32,9 +32,10 @@ function setupDom() {
     <div id="dm-mini-games-modal" class="overlay hidden" aria-hidden="true">
       <section class="modal dm-mini-games">
         <button id="dm-mini-games-close"></button>
+        <p id="dm-mini-games-steps" class="dm-mini-games__intro"></p>
         <div class="dm-mini-games__layout">
           <aside class="dm-mini-games__sidebar">
-            <h4 class="dm-mini-games__section-title">Library</h4>
+            <h4 class="dm-mini-games__section-title">Mini-Game Library</h4>
             <ul id="dm-mini-games-list" class="dm-mini-games__list"></ul>
           </aside>
           <div class="dm-mini-games__content">
@@ -46,9 +47,13 @@ function setupDom() {
               <a id="dm-mini-games-launch" hidden></a>
             </header>
             <section class="dm-mini-games__section">
+              <h5 class="dm-mini-games__section-heading">Step 2 · Tune the Mission (DM only)</h5>
+              <p id="dm-mini-games-knobs-hint" class="dm-mini-games__hint"></p>
               <div id="dm-mini-games-knobs" class="dm-mini-games__knobs"></div>
             </section>
             <section class="dm-mini-games__section">
+              <h5 class="dm-mini-games__section-heading">Step 3 · Send to a Player</h5>
+              <p id="dm-mini-games-player-hint" class="dm-mini-games__hint"></p>
               <div class="dm-mini-games__deploy-form">
                 <label class="dm-mini-games__field">
                   <span>Target</span>
@@ -69,11 +74,12 @@ function setupDom() {
               </div>
             </section>
             <section class="dm-mini-games__section dm-mini-games__section--scroll">
+              <h5 class="dm-mini-games__section-heading">Mission Briefing (Player View)</h5>
               <pre id="dm-mini-games-readme" class="dm-mini-games__readme"></pre>
             </section>
             <section class="dm-mini-games__section dm-mini-games__section--scroll">
               <div class="dm-mini-games__section-header">
-                <h5>Deployments</h5>
+                <h5 class="dm-mini-games__section-heading">Deployments</h5>
                 <div class="dm-mini-games__section-actions">
                   <button id="dm-mini-games-refresh" type="button"></button>
                 </div>

--- a/index.html
+++ b/index.html
@@ -1244,9 +1244,10 @@
       </svg>
     </button>
     <h3>Deploy Mini-Games</h3>
+    <p id="dm-mini-games-steps" class="dm-mini-games__intro">Step 1: Choose a mini-game from the library to get started.</p>
     <div class="dm-mini-games__layout">
       <aside class="dm-mini-games__sidebar">
-        <h4 class="dm-mini-games__section-title">Library</h4>
+        <h4 class="dm-mini-games__section-title">Mini-Game Library</h4>
         <ul id="dm-mini-games-list" class="dm-mini-games__list" role="listbox" aria-label="Mini-game library"></ul>
       </aside>
       <div class="dm-mini-games__content">
@@ -1258,11 +1259,13 @@
           <a id="dm-mini-games-launch" class="dm-mini-games__launch" href="#" target="_blank" rel="noopener" hidden>Open Player View</a>
         </header>
         <section class="dm-mini-games__section">
-          <h5>Fast Edit Controls</h5>
+          <h5 class="dm-mini-games__section-heading">Step 2 · Tune the Mission (DM only)</h5>
+          <p id="dm-mini-games-knobs-hint" class="dm-mini-games__hint">Choose a mini-game to unlock DM-only tuning controls.</p>
           <div id="dm-mini-games-knobs" class="dm-mini-games__knobs"></div>
         </section>
         <section class="dm-mini-games__section">
-          <h5>Deployment Target</h5>
+          <h5 class="dm-mini-games__section-heading">Step 3 · Send to a Player</h5>
+          <p id="dm-mini-games-player-hint" class="dm-mini-games__hint">Pick who should receive the mission and add any quick instructions.</p>
           <div class="dm-mini-games__deploy-form">
             <label class="dm-mini-games__field">
               <span>Select character</span>
@@ -1285,12 +1288,12 @@
           </div>
         </section>
         <section class="dm-mini-games__section dm-mini-games__section--scroll">
-          <h5>Mini-Game Briefing</h5>
+          <h5 class="dm-mini-games__section-heading">Mission Briefing (Player View)</h5>
           <pre id="dm-mini-games-readme" class="dm-mini-games__readme" tabindex="0">Select a mini-game to view its briefing.</pre>
         </section>
         <section class="dm-mini-games__section dm-mini-games__section--scroll">
           <div class="dm-mini-games__section-header">
-            <h5>Active Deployments</h5>
+            <h5 class="dm-mini-games__section-heading">Active Deployments</h5>
             <div class="dm-mini-games__section-actions">
               <button id="dm-mini-games-refresh" type="button" class="btn-sm">Refresh</button>
             </div>
@@ -1318,8 +1321,8 @@
       <p id="mini-game-invite-notes-text" class="mini-game-invite__notes-text"></p>
     </div>
     <footer class="mini-game-invite__actions">
-      <button id="mini-game-invite-decline" type="button" class="btn-sm mini-game-invite__decline">Decline</button>
-      <button id="mini-game-invite-accept" type="button" class="somf-btn somf-primary mini-game-invite__accept">Accept &amp; Launch</button>
+      <button id="mini-game-invite-decline" type="button" class="btn-sm mini-game-invite__decline">Not Now</button>
+      <button id="mini-game-invite-accept" type="button" class="somf-btn somf-primary mini-game-invite__accept">Start Mission</button>
     </footer>
   </section>
 </div>

--- a/scripts/dm.js
+++ b/scripts/dm.js
@@ -160,7 +160,10 @@ function initDMLogin(){
   const miniGamesTitle = document.getElementById('dm-mini-games-title');
   const miniGamesTagline = document.getElementById('dm-mini-games-tagline');
   const miniGamesLaunch = document.getElementById('dm-mini-games-launch');
+  const miniGamesIntro = document.getElementById('dm-mini-games-steps');
+  const miniGamesKnobsHint = document.getElementById('dm-mini-games-knobs-hint');
   const miniGamesKnobs = document.getElementById('dm-mini-games-knobs');
+  const miniGamesPlayerHint = document.getElementById('dm-mini-games-player-hint');
   const miniGamesPlayerSelect = document.getElementById('dm-mini-games-player');
   const miniGamesPlayerCustom = document.getElementById('dm-mini-games-player-custom');
   const miniGamesNotes = document.getElementById('dm-mini-games-notes');
@@ -216,6 +219,27 @@ function initDMLogin(){
     knobStateByGame.set(gameId, { ...state });
   }
 
+  function updateMiniGameGuidance(game) {
+    const hasKnobs = Array.isArray(game?.knobs) && game.knobs.length > 0;
+    if (miniGamesIntro) {
+      miniGamesIntro.textContent = game
+        ? `Step 1 complete: ${game.name} is loaded and ready to deploy.`
+        : 'Step 1: Choose a mini-game from the library to get started.';
+    }
+    if (miniGamesKnobsHint) {
+      miniGamesKnobsHint.textContent = game
+        ? hasKnobs
+          ? 'Adjust these DM-only controls to fit the moment. Players will never see them.'
+          : 'This mission has no optional tuning—skip straight to sending it to a player.'
+        : 'Choose a mini-game to unlock DM-only tuning controls.';
+    }
+    if (miniGamesPlayerHint) {
+      miniGamesPlayerHint.textContent = game
+        ? 'Choose the hero to receive this mission and add any quick instructions before deploying.'
+        : 'Pick who should receive the mission once you have it tuned.';
+    }
+  }
+
   function buildMiniGamesList() {
     if (!miniGamesList || miniGamesInitialized) return;
     miniGamesList.innerHTML = '';
@@ -254,11 +278,12 @@ function initDMLogin(){
     if (miniGamesTagline) miniGamesTagline.textContent = '';
     if (miniGamesLaunch) miniGamesLaunch.hidden = true;
     if (miniGamesKnobs) {
-      miniGamesKnobs.innerHTML = '<p class="dm-mini-games__empty">No mini-game selected.</p>';
+      miniGamesKnobs.innerHTML = '<p class="dm-mini-games__empty">Pick a mini-game to unlock DM tools.</p>';
     }
     if (miniGamesReadme) {
-      miniGamesReadme.textContent = 'Select a mini-game to view its briefing.';
+      miniGamesReadme.textContent = 'Select a mini-game to review the player-facing briefing.';
     }
+    updateMiniGameGuidance(null);
   }
 
   function renderMiniGameKnobs(game) {
@@ -266,7 +291,7 @@ function initDMLogin(){
     const state = ensureKnobState(game.id);
     miniGamesKnobs.innerHTML = '';
     if (!Array.isArray(game.knobs) || game.knobs.length === 0) {
-      miniGamesKnobs.innerHTML = '<p class="dm-mini-games__empty">No fast edit controls defined.</p>';
+      miniGamesKnobs.innerHTML = '<p class="dm-mini-games__empty">This mission has no DM tuning controls.</p>';
       return;
     }
     game.knobs.forEach(knob => {
@@ -377,6 +402,7 @@ function initDMLogin(){
       }
     }
     renderMiniGameKnobs(game);
+    updateMiniGameGuidance(game);
     if (miniGamesReadme) {
       miniGamesReadme.textContent = 'Loading briefing…';
       loadMiniGameReadme(game.id)
@@ -405,7 +431,7 @@ function initDMLogin(){
   function renderMiniGameDeployments(entries = []) {
     if (!miniGamesDeployments) return;
     if (!Array.isArray(entries) || entries.length === 0) {
-      miniGamesDeployments.innerHTML = '<li class="dm-mini-games__empty">No active deployments.</li>';
+      miniGamesDeployments.innerHTML = '<li class="dm-mini-games__empty">Launched missions will appear here for quick status updates.</li>';
       return;
     }
     miniGamesDeployments.innerHTML = '';

--- a/styles/main.css
+++ b/styles/main.css
@@ -1389,8 +1389,10 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
 .dm-mini-games__tagline{margin:0;font-size:.9rem;color:var(--muted)}
 .dm-mini-games__launch{align-self:flex-start;text-decoration:none;font-size:.85rem;border:1px solid var(--accent);padding:6px 10px;border-radius:var(--radius);color:var(--accent);transition:var(--transition)}
 .dm-mini-games__launch:hover{background:var(--accent);color:var(--text-on-accent)}
+.dm-mini-games__intro{margin:0 0 12px;font-size:.9rem;color:var(--muted);line-height:1.5}
 .dm-mini-games__section{display:flex;flex-direction:column;gap:12px}
-.dm-mini-games__section>h5{margin:0;font-size:.85rem;font-weight:600;color:var(--muted)}
+.dm-mini-games__section-heading{margin:0;font-size:.85rem;font-weight:600;color:var(--muted);text-transform:none;letter-spacing:.02em}
+.dm-mini-games__hint{margin:0;font-size:.8rem;color:var(--muted);line-height:1.4}
 .dm-mini-games__knobs{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
 .dm-mini-games__knob{border:1px solid var(--line);border-radius:var(--radius);padding:10px;display:flex;flex-direction:column;gap:8px;background:rgba(0,0,0,.1)}
 .theme-light .dm-mini-games__knob{background:rgba(255,255,255,.04)}


### PR DESCRIPTION
## Summary
- add guided copy and hints to the DM mini-game modal so each step is clear
- simplify player invitations by hiding fast-edit configs and updating mission messaging
- streamline the mini-game player view with mission-focused copy and styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfce812fc8832e8dd029da502d8297