### PR TITLE
Add interactive clue tagging to the Clue Tracker mini-game

### DIFF
--- a/SuperheroMiniGames/ClueTracker/README.txt
+++ b/SuperheroMiniGames/ClueTracker/README.txt
@@ -8,4 +8,5 @@ Clue Tracker tasks a hero with connecting scattered intel before the trail goes 
 ## Deployment Tips
 1. Brief the player on the scene and drop the corresponding clue card set.
 2. Adjust the fast edit knobs in the DM tools and deploy the mini-game to the target hero.
-3. During play, use the deployment tracker to escalate the situation if the timer runs out or if too many red herrings are accepted.
+3. During play, the hero can tag each dossier card as a connected lead or flag it as a red herring to track their deductions.
+4. Use the deployment tracker to escalate the situation if the timer runs out or if too many red herrings are accepted.

--- a/SuperheroMiniGames/ClueTracker/README.txt
+++ b/SuperheroMiniGames/ClueTracker/README.txt
@@ -4,9 +4,11 @@ Clue Tracker tasks a hero with connecting scattered intel before the trail goes 
 - **Clues to Reveal** *(number, default 3)* – Controls how many verified clues are available at the start of play.
 - **Time per Clue (seconds)** *(number, default 90)* – Sets the window the player has to respond before the system automatically exposes the next clue.
 - **Include Red Herrings** *(toggle, default off)* – Adds misleading hints that must be disproved before they contaminate the evidence chain.
+- **Connections to Solve** *(number, default 3)* – Sets how many verified leads the player must confirm to close the case.
 
 ## Deployment Tips
 1. Brief the player on the scene and drop the corresponding clue card set.
 2. Adjust the fast edit knobs in the DM tools and deploy the mini-game to the target hero.
 3. During play, the hero can tag each dossier card as a connected lead or flag it as a red herring to track their deductions.
-4. Use the deployment tracker to escalate the situation if the timer runs out or if too many red herrings are accepted.
+4. The case closes automatically once the required number of genuine leads are confirmed; locking in a planted red herring or exhausting the intel without enough connections ends the investigation in failure.
+5. Use the deployment tracker to escalate the situation if the timer runs out or if too many red herrings are accepted.

--- a/SuperheroMiniGames/play.css
+++ b/SuperheroMiniGames/play.css
@@ -332,6 +332,32 @@ body {
   flex-wrap: wrap;
 }
 
+.clue-card__status {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  background: rgba(148, 163, 184, 0.22);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.clue-card__status--confirmed {
+  background: rgba(34, 197, 94, 0.25);
+  color: rgba(240, 253, 244, 0.95);
+}
+
+.clue-card__status--disproved {
+  background: rgba(248, 113, 113, 0.25);
+  color: rgba(254, 226, 226, 0.95);
+}
+
 .clue-card__tag {
   font-size: 0.75rem;
   text-transform: uppercase;
@@ -361,6 +387,17 @@ body {
 .clue-card--red {
   border-color: rgba(248, 113, 113, 0.65);
   background: rgba(127, 29, 29, 0.35);
+}
+
+.clue-card--confirmed {
+  border-color: rgba(74, 222, 128, 0.85);
+  background: linear-gradient(135deg, rgba(21, 128, 61, 0.22), rgba(13, 148, 136, 0.1));
+}
+
+.clue-card--disproved {
+  border-color: rgba(248, 113, 113, 0.75);
+  background: rgba(127, 29, 29, 0.4);
+  box-shadow: 0 12px 22px rgba(127, 29, 29, 0.2);
 }
 
 @media (max-width: 720px) {

--- a/SuperheroMiniGames/play.css
+++ b/SuperheroMiniGames/play.css
@@ -285,6 +285,45 @@ body {
   color: var(--warning);
 }
 
+.clue-tracker__objective {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.clue-tracker__instruction {
+  margin: 6px 0 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.clue-tracker__outcome {
+  margin: 12px 0 0;
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.45;
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.clue-tracker__outcome--success {
+  background: rgba(34, 197, 94, 0.22);
+  border-color: rgba(34, 197, 94, 0.4);
+  color: rgba(240, 253, 244, 0.95);
+}
+
+.clue-tracker__outcome--failure {
+  background: rgba(248, 113, 113, 0.25);
+  border-color: rgba(248, 113, 113, 0.45);
+  color: rgba(254, 226, 226, 0.95);
+}
+
 .clue-grid {
   display: grid;
   gap: 12px;

--- a/SuperheroMiniGames/play.js
+++ b/SuperheroMiniGames/play.js
@@ -279,8 +279,13 @@ function setupClueTracker(root, context) {
   intro.appendChild(timer);
   card.appendChild(intro);
 
+  const objective = document.createElement('p');
+  objective.className = 'clue-tracker__objective';
+  card.appendChild(objective);
+
   const body = document.createElement('p');
-  body.textContent = 'Reveal clues, mark which ones connect, and watch for planted misinformation.';
+  body.className = 'clue-tracker__instruction';
+  body.textContent = 'Reveal clues, prove which ones connect, and quarantine misinformation before it derails the case.';
   card.appendChild(body);
 
   const actions = document.createElement('div');
@@ -292,6 +297,11 @@ function setupClueTracker(root, context) {
   actions.appendChild(revealBtn);
   card.appendChild(actions);
 
+  const outcome = document.createElement('div');
+  outcome.className = 'clue-tracker__outcome';
+  outcome.hidden = true;
+  card.appendChild(outcome);
+
   const grid = document.createElement('div');
   grid.className = 'clue-grid';
 
@@ -301,7 +311,16 @@ function setupClueTracker(root, context) {
   const config = context.config || {};
   const initialReveal = clamp(Number(config.cluesToReveal ?? 3), 1, 8);
   const includeRed = Boolean(config.includeRedHerrings);
+  const requiredConnections = clamp(Number(config.connectionsRequired ?? 3), 1, CLUE_POOL.length);
   const timePerClue = clamp(Number(config.timePerClue ?? 90), 15, 900);
+
+  const objectiveText = `Objective: Confirm ${requiredConnections} connected lead${requiredConnections === 1 ? '' : 's'} before intel runs dry.`;
+  objective.textContent = includeRed
+    ? `${objectiveText} Flag planted red herrings so they can't poison the evidence chain.`
+    : objectiveText;
+
+  const successMessage = 'You triangulated the villain\'s route. Relay the confirmed sequence to HQ.';
+  const exhaustionMessage = 'All intel exhausted before you could confirm the full sequence.';
 
   const pool = shuffle([...CLUE_POOL]);
   const redDeck = includeRed ? shuffle([...RED_HERRINGS]) : [];
@@ -314,33 +333,70 @@ function setupClueTracker(root, context) {
     disproved: 0,
     timer: timePerClue,
     interval: null,
+    required: requiredConnections,
+    solved: false,
+    success: false,
   };
 
   const cards = [];
 
+  function completeCase(success, message) {
+    if (state.solved) return;
+    state.solved = true;
+    state.success = success;
+    stopTimer();
+    revealBtn.disabled = true;
+    revealBtn.textContent = success ? 'Case closed' : 'Investigation failed';
+    timer.textContent = success ? 'Case closed' : 'Intel compromised';
+    outcome.hidden = false;
+    outcome.textContent = message;
+    outcome.className = success
+      ? 'clue-tracker__outcome clue-tracker__outcome--success'
+      : 'clue-tracker__outcome clue-tracker__outcome--failure';
+    cards.forEach(entry => {
+      entry.data.confirmBtn.disabled = true;
+      entry.data.disproveBtn.disabled = true;
+    });
+    updateProgress();
+  }
+
   function updateProgress() {
     const segments = [`Revealed ${state.revealed} clue${state.revealed === 1 ? '' : 's'}`];
-    segments.push(`Connected ${state.confirmed}`);
-    segments.push(`Flagged ${state.disproved}`);
+    segments.push(`Connections ${Math.min(state.confirmed, state.required)}/${state.required}`);
+    if (includeRed) {
+      segments.push(`Red herrings flagged ${state.disproved}`);
+    }
+    if (state.solved) {
+      segments.push(state.success ? 'Case closed' : 'Case compromised');
+    }
     progress.textContent = segments.join(' · ');
-    if (!hiddenDeck.length) {
+    if (!hiddenDeck.length && !state.solved) {
       revealBtn.disabled = true;
       revealBtn.textContent = 'All clues revealed';
     }
   }
 
   function updateTimerDisplay() {
+    if (state.solved) {
+      timer.textContent = state.success ? 'Case closed' : 'Intel compromised';
+      return;
+    }
     timer.textContent = hiddenDeck.length
       ? `Auto reveal in ${secondsToClock(state.timer)}`
       : 'All intel deployed';
   }
 
   function resetTimer() {
+    if (state.solved) return;
     state.timer = timePerClue;
     updateTimerDisplay();
   }
 
   function tickTimer() {
+    if (state.solved) {
+      stopTimer();
+      return;
+    }
     if (!hiddenDeck.length) {
       timer.textContent = 'All intel deployed';
       return;
@@ -353,6 +409,7 @@ function setupClueTracker(root, context) {
   }
 
   function ensureTimer() {
+    if (state.solved) return;
     if (state.interval) return;
     state.interval = window.setInterval(tickTimer, 1000);
   }
@@ -405,6 +462,7 @@ function setupClueTracker(root, context) {
       revealed: false,
       confirmed: false,
       disproved: false,
+      compromised: false,
       index,
       confirmBtn,
       disproveBtn,
@@ -420,6 +478,14 @@ function setupClueTracker(root, context) {
         status.textContent = '';
         status.className = 'clue-card__status';
         el.classList.remove('clue-card--confirmed', 'clue-card--disproved');
+        return;
+      }
+      if (data.compromised) {
+        status.hidden = false;
+        status.textContent = 'Red herring locked in';
+        status.className = 'clue-card__status clue-card__status--disproved';
+        el.classList.add('clue-card--disproved');
+        el.classList.remove('clue-card--confirmed');
         return;
       }
       if (data.confirmed) {
@@ -465,25 +531,39 @@ function setupClueTracker(root, context) {
     }
 
     function setConfirmed(value) {
-      if (!data.revealed || value === data.confirmed) return;
+      if (state.solved || !data.revealed || value === data.confirmed) return;
       if (value) {
+        if (data.clue?.redHerring) {
+          data.confirmed = true;
+          data.compromised = true;
+          state.confirmed += 1;
+          updateButtons();
+          updateStatus();
+          completeCase(false, 'A planted red herring poisoned the intel. Debrief with HQ and reset the trace.');
+          return;
+        }
         state.confirmed += 1;
         if (data.disproved) {
           data.disproved = false;
           state.disproved = Math.max(0, state.disproved - 1);
         }
         data.confirmed = true;
+        data.compromised = false;
       } else {
         data.confirmed = false;
         state.confirmed = Math.max(0, state.confirmed - 1);
+        data.compromised = false;
       }
       updateButtons();
       updateStatus();
       updateProgress();
+      if (value && state.confirmed >= state.required) {
+        completeCase(true, successMessage);
+      }
     }
 
     function setDisproved(value) {
-      if (!data.revealed || value === data.disproved) return;
+      if (state.solved || !data.revealed || value === data.disproved) return;
       if (value) {
         state.disproved += 1;
         if (data.confirmed) {
@@ -491,8 +571,10 @@ function setupClueTracker(root, context) {
           state.confirmed = Math.max(0, state.confirmed - 1);
         }
         data.disproved = true;
+        data.compromised = false;
       } else {
         data.disproved = false;
+        data.compromised = false;
         state.disproved = Math.max(0, state.disproved - 1);
       }
       updateButtons();
@@ -563,17 +645,28 @@ function setupClueTracker(root, context) {
   });
 
   function revealNext() {
+    if (state.solved) return;
     const hidden = cards.find(entry => !entry.data.revealed);
     if (!hidden) {
       stopTimer();
-      updateProgress();
+      if (!state.solved) {
+        if (state.confirmed >= state.required) {
+          completeCase(true, successMessage);
+        } else {
+          completeCase(false, exhaustionMessage);
+        }
+      }
       return;
     }
     hiddenDeck.shift();
     hidden.reveal();
-    if (!cards.some(entry => !entry.data.revealed)) {
+    if (!cards.some(entry => !entry.data.revealed) && !state.solved) {
       stopTimer();
-      timer.textContent = 'All intel deployed';
+      if (state.confirmed >= state.required) {
+        completeCase(true, successMessage);
+      } else {
+        timer.textContent = 'All intel deployed';
+      }
     }
   }
 
@@ -1311,6 +1404,7 @@ const GAMES = {
       { key: 'cluesToReveal', label: 'Clues to reveal', type: 'number', min: 1, max: 12, default: 3 },
       { key: 'timePerClue', label: 'Time per clue (seconds)', type: 'number', min: 15, max: 600, default: 90 },
       { key: 'includeRedHerrings', label: 'Include red herrings', type: 'toggle', default: false },
+      { key: 'connectionsRequired', label: 'Connections to solve', type: 'number', min: 1, max: 10, default: 3, playerFacing: true },
     ],
     setup: setupClueTracker,
   },


### PR DESCRIPTION
## Summary
- add dedicated controls for confirming leads or flagging red herrings on each clue card
- provide visual status indicators and updated progress totals for confirmed and flagged clues
- update the Clue Tracker documentation to cover the new deduction workflow

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dffdac58bc832e95114c05b76d57b4