### PR TITLE
Allow DM mini-games modal inputs in view mode

### DIFF
--- a/__tests__/dm_mini_games.test.js
+++ b/__tests__/dm_mini_games.test.js
@@ -30,7 +30,7 @@ function setupDom() {
       <button id="dm-character-close"></button>
     </div>
     <div id="dm-mini-games-modal" class="overlay hidden" aria-hidden="true">
-      <section class="modal dm-mini-games">
+      <section class="modal dm-mini-games" data-view-allow>
         <button id="dm-mini-games-close"></button>
         <p id="dm-mini-games-steps" class="dm-mini-games__intro"></p>
         <div class="dm-mini-games__layout">

--- a/__tests__/mini_games_system.test.js
+++ b/__tests__/mini_games_system.test.js
@@ -18,7 +18,7 @@ function setupDom() {
       <button id="dm-login-close"></button>
     </div>
     <div id="dm-mini-games-modal" class="overlay hidden" aria-hidden="true">
-      <section class="modal dm-mini-games">
+      <section class="modal dm-mini-games" data-view-allow>
         <button id="dm-mini-games-close"></button>
         <p id="dm-mini-games-steps" class="dm-mini-games__intro"></p>
         <div class="dm-mini-games__layout">

--- a/index.html
+++ b/index.html
@@ -1237,7 +1237,7 @@
   </section>
 </div>
 <div class="overlay hidden" id="dm-mini-games-modal" aria-hidden="true">
-  <section class="modal dm-mini-games">
+  <section class="modal dm-mini-games" data-view-allow>
     <button id="dm-mini-games-close" class="x" aria-label="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>


### PR DESCRIPTION
## Summary
- allow the DM mini-games modal to bypass view-mode locking so text inputs remain editable
- update related tests to mirror the new modal markup

## Testing
- npm test -- dm_mini_games mini_games_system

------
https://chatgpt.com/codex/tasks/task_e_68dffdc56ca0832e9022f76a21f36460