### PR TITLE
Add player-controlled start flow for mini-game deployments

### DIFF
--- a/SuperheroMiniGames/ClueTracker/ClueTracker.html
+++ b/SuperheroMiniGames/ClueTracker/ClueTracker.html
@@ -46,7 +46,15 @@
           Running in preview mode with default parameters.
         </p>
       </section>
-      <section class="mini-game-shell__content" id="mini-game-root"></section>
+      <div id="mini-game-launch" class="mini-game-shell__launch" hidden>
+        <p id="mini-game-launch-text" class="mini-game-shell__launch-text">
+          Review the mission briefing and parameters. When you're ready, begin the deployment to load the interactive console.
+        </p>
+        <button id="mini-game-start" type="button" class="mg-button mini-game-shell__launch-button">
+          Start Mission
+        </button>
+      </div>
+      <section class="mini-game-shell__content" id="mini-game-root" hidden></section>
     </main>
     <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
     <script type="module" src="../play.js"></script>

--- a/SuperheroMiniGames/CodeBreaker/CodeBreaker.html
+++ b/SuperheroMiniGames/CodeBreaker/CodeBreaker.html
@@ -46,7 +46,15 @@
           Running in preview mode with default parameters.
         </p>
       </section>
-      <section class="mini-game-shell__content" id="mini-game-root"></section>
+      <div id="mini-game-launch" class="mini-game-shell__launch" hidden>
+        <p id="mini-game-launch-text" class="mini-game-shell__launch-text">
+          Review the mission briefing and parameters. When you're ready, begin the deployment to load the interactive console.
+        </p>
+        <button id="mini-game-start" type="button" class="mg-button mini-game-shell__launch-button">
+          Start Mission
+        </button>
+      </div>
+      <section class="mini-game-shell__content" id="mini-game-root" hidden></section>
     </main>
     <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
     <script type="module" src="../play.js"></script>

--- a/SuperheroMiniGames/LockdownOverride/LockdownOverride.html
+++ b/SuperheroMiniGames/LockdownOverride/LockdownOverride.html
@@ -46,7 +46,15 @@
           Running in preview mode with default parameters.
         </p>
       </section>
-      <section class="mini-game-shell__content" id="mini-game-root"></section>
+      <div id="mini-game-launch" class="mini-game-shell__launch" hidden>
+        <p id="mini-game-launch-text" class="mini-game-shell__launch-text">
+          Review the mission briefing and parameters. When you're ready, begin the deployment to load the interactive console.
+        </p>
+        <button id="mini-game-start" type="button" class="mg-button mini-game-shell__launch-button">
+          Start Mission
+        </button>
+      </div>
+      <section class="mini-game-shell__content" id="mini-game-root" hidden></section>
     </main>
     <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
     <script type="module" src="../play.js"></script>

--- a/SuperheroMiniGames/PowerSurge/PowerSurge.html
+++ b/SuperheroMiniGames/PowerSurge/PowerSurge.html
@@ -46,7 +46,15 @@
           Running in preview mode with default parameters.
         </p>
       </section>
-      <section class="mini-game-shell__content" id="mini-game-root"></section>
+      <div id="mini-game-launch" class="mini-game-shell__launch" hidden>
+        <p id="mini-game-launch-text" class="mini-game-shell__launch-text">
+          Review the mission briefing and parameters. When you're ready, begin the deployment to load the interactive console.
+        </p>
+        <button id="mini-game-start" type="button" class="mg-button mini-game-shell__launch-button">
+          Start Mission
+        </button>
+      </div>
+      <section class="mini-game-shell__content" id="mini-game-root" hidden></section>
     </main>
     <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
     <script type="module" src="../play.js"></script>

--- a/SuperheroMiniGames/StratagemHero/StratagemHero.html
+++ b/SuperheroMiniGames/StratagemHero/StratagemHero.html
@@ -46,7 +46,15 @@
           Running in preview mode with default parameters.
         </p>
       </section>
-      <section class="mini-game-shell__content" id="mini-game-root"></section>
+      <div id="mini-game-launch" class="mini-game-shell__launch" hidden>
+        <p id="mini-game-launch-text" class="mini-game-shell__launch-text">
+          Review the mission briefing and parameters. When you're ready, begin the deployment to load the interactive console.
+        </p>
+        <button id="mini-game-start" type="button" class="mg-button mini-game-shell__launch-button">
+          Start Mission
+        </button>
+      </div>
+      <section class="mini-game-shell__content" id="mini-game-root" hidden></section>
     </main>
     <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
     <script type="module" src="../play.js"></script>

--- a/SuperheroMiniGames/TechLockpick/TechLockpick.html
+++ b/SuperheroMiniGames/TechLockpick/TechLockpick.html
@@ -46,7 +46,15 @@
           Running in preview mode with default parameters.
         </p>
       </section>
-      <section class="mini-game-shell__content" id="mini-game-root"></section>
+      <div id="mini-game-launch" class="mini-game-shell__launch" hidden>
+        <p id="mini-game-launch-text" class="mini-game-shell__launch-text">
+          Review the mission briefing and parameters. When you're ready, begin the deployment to load the interactive console.
+        </p>
+        <button id="mini-game-start" type="button" class="mg-button mini-game-shell__launch-button">
+          Start Mission
+        </button>
+      </div>
+      <section class="mini-game-shell__content" id="mini-game-root" hidden></section>
     </main>
     <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
     <script type="module" src="../play.js"></script>

--- a/SuperheroMiniGames/play.css
+++ b/SuperheroMiniGames/play.css
@@ -178,6 +178,28 @@ body {
   letter-spacing: 0.08em;
 }
 
+.mini-game-shell__launch {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 18px 20px;
+  background: rgba(15, 23, 42, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+  box-shadow: 0 16px 26px rgba(15, 23, 42, 0.28);
+}
+
+.mini-game-shell__launch-text {
+  margin: 0;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.mini-game-shell__launch-button {
+  align-self: flex-start;
+}
+
 .mini-game-shell__content {
   display: flex;
   flex-direction: column;

--- a/SuperheroMiniGames/play.html
+++ b/SuperheroMiniGames/play.html
@@ -44,7 +44,15 @@
           Running in preview mode with default parameters.
         </p>
       </section>
-      <section class="mini-game-shell__content" id="mini-game-root"></section>
+      <div id="mini-game-launch" class="mini-game-shell__launch" hidden>
+        <p id="mini-game-launch-text" class="mini-game-shell__launch-text">
+          Review the mission briefing and parameters. When you're ready, begin the deployment to load the interactive console.
+        </p>
+        <button id="mini-game-start" type="button" class="mg-button mini-game-shell__launch-button">
+          Start Mission
+        </button>
+      </div>
+      <section class="mini-game-shell__content" id="mini-game-root" hidden></section>
     </main>
     <div id="mini-game-error" class="mini-game-shell__error" hidden></div>
     <script type="module" src="play.js"></script>

--- a/SuperheroMiniGames/play.js
+++ b/SuperheroMiniGames/play.js
@@ -14,9 +14,9 @@ const configEl = document.getElementById('mini-game-config');
 const notesEl = document.getElementById('mini-game-notes');
 const notesTextEl = document.getElementById('mini-game-notes-text');
 const previewBannerEl = document.getElementById('mini-game-preview-banner');
-const launchEl = document.getElementById('mini-game-launch');
-const launchTextEl = document.getElementById('mini-game-launch-text');
-const startButtonEl = document.getElementById('mini-game-start');
+let launchEl = document.getElementById('mini-game-launch');
+let launchTextEl = document.getElementById('mini-game-launch-text');
+let startButtonEl = document.getElementById('mini-game-start');
 const rootEl = document.getElementById('mini-game-root');
 
 const CLOUD_MINI_GAMES_URL = 'https://ccccg-7d6b6-default-rtdb.firebaseio.com/miniGames';
@@ -159,6 +159,64 @@ function renderConfigSummary(game, config) {
     dl.appendChild(dd);
   });
   configEl.appendChild(dl);
+}
+
+function ensureLaunchPanel() {
+  if (!shell) {
+    launchEl = null;
+    startButtonEl = null;
+    launchTextEl = null;
+    return { launch: null, start: null, text: null };
+  }
+
+  if (!launchEl) {
+    launchEl = document.createElement('div');
+    launchEl.id = 'mini-game-launch';
+    launchEl.className = 'mini-game-shell__launch';
+  }
+
+  if (!launchTextEl) {
+    launchTextEl = document.createElement('p');
+    launchTextEl.id = 'mini-game-launch-text';
+    launchTextEl.className = 'mini-game-shell__launch-text';
+  }
+
+  if (!startButtonEl) {
+    startButtonEl = document.createElement('button');
+    startButtonEl.id = 'mini-game-start';
+    startButtonEl.type = 'button';
+    startButtonEl.className = 'mg-button mini-game-shell__launch-button';
+    startButtonEl.textContent = 'Start Mission';
+  }
+
+  if (!launchTextEl.parentElement || launchTextEl.parentElement !== launchEl) {
+    if (launchTextEl.parentElement) {
+      launchTextEl.parentElement.removeChild(launchTextEl);
+    }
+    launchEl.appendChild(launchTextEl);
+  }
+
+  if (!startButtonEl.parentElement || startButtonEl.parentElement !== launchEl) {
+    if (startButtonEl.parentElement) {
+      startButtonEl.parentElement.removeChild(startButtonEl);
+    }
+    launchEl.appendChild(startButtonEl);
+  }
+
+  if (!launchEl.parentElement) {
+    const briefingSection = document.querySelector('.mini-game-shell__briefing');
+    if (briefingSection && briefingSection.parentElement === shell) {
+      briefingSection.insertAdjacentElement('afterend', launchEl);
+    } else if (rootEl && rootEl.parentElement === shell) {
+      shell.insertBefore(launchEl, rootEl);
+    } else {
+      shell.appendChild(launchEl);
+    }
+  }
+
+  launchEl.hidden = true;
+
+  return { launch: launchEl, start: startButtonEl, text: launchTextEl };
 }
 
 function readMetaContent(name) {
@@ -1420,6 +1478,8 @@ async function init() {
     }
   }
 
+  const ensuredLaunch = ensureLaunchPanel();
+
   if (launchTextEl) {
     const baseMessage = 'Review the mission briefing and parameters. When you\'re ready, begin the deployment to load the interactive console.';
     launchTextEl.textContent = context.warning
@@ -1455,20 +1515,22 @@ async function init() {
     }
   };
 
-  if (launchEl && startButtonEl) {
-    launchEl.hidden = false;
-    startButtonEl.disabled = false;
-    startButtonEl.addEventListener('click', () => {
-      startButtonEl.disabled = true;
+  if (ensuredLaunch.start) {
+    if (ensuredLaunch.launch) {
+      ensuredLaunch.launch.hidden = false;
+    }
+    ensuredLaunch.start.disabled = false;
+    ensuredLaunch.start.addEventListener('click', () => {
+      ensuredLaunch.start.disabled = true;
       const success = startMission();
       if (!success) {
-        startButtonEl.disabled = false;
-        try { startButtonEl.focus(); } catch {}
+        ensuredLaunch.start.disabled = false;
+        try { ensuredLaunch.start.focus(); } catch {}
       }
     });
-    try { startButtonEl.focus(); } catch {}
+    try { ensuredLaunch.start.focus(); } catch {}
   } else {
-    startMission();
+    showError('Launch controls failed to load. Refresh the page or contact your DM.');
   }
 }
 

--- a/SuperheroMiniGames/play.js
+++ b/SuperheroMiniGames/play.js
@@ -14,6 +14,9 @@ const configEl = document.getElementById('mini-game-config');
 const notesEl = document.getElementById('mini-game-notes');
 const notesTextEl = document.getElementById('mini-game-notes-text');
 const previewBannerEl = document.getElementById('mini-game-preview-banner');
+const launchEl = document.getElementById('mini-game-launch');
+const launchTextEl = document.getElementById('mini-game-launch-text');
+const startButtonEl = document.getElementById('mini-game-start');
 const rootEl = document.getElementById('mini-game-root');
 
 const CLOUD_MINI_GAMES_URL = 'https://ccccg-7d6b6-default-rtdb.firebaseio.com/miniGames';
@@ -1417,10 +1420,56 @@ async function init() {
     }
   }
 
-  rootEl.innerHTML = '';
-  game.setup(rootEl, context);
+  if (launchTextEl) {
+    const baseMessage = 'Review the mission briefing and parameters. When you\'re ready, begin the deployment to load the interactive console.';
+    launchTextEl.textContent = context.warning
+      ? `${context.warning} ${baseMessage}`
+      : baseMessage;
+  }
 
+  rootEl.innerHTML = '';
+  rootEl.hidden = true;
   shell.hidden = false;
+
+  let missionStarted = false;
+
+  const startMission = () => {
+    if (missionStarted) return true;
+    missionStarted = true;
+    if (launchEl) {
+      launchEl.hidden = true;
+    }
+    hideError();
+    try {
+      game.setup(rootEl, context);
+      rootEl.hidden = false;
+      return true;
+    } catch (err) {
+      console.error('Failed to initialise mission content', err);
+      showError('Failed to load the mini-game deployment. Please refresh or request a new link.');
+      missionStarted = false;
+      if (launchEl) {
+        launchEl.hidden = false;
+      }
+      return false;
+    }
+  };
+
+  if (launchEl && startButtonEl) {
+    launchEl.hidden = false;
+    startButtonEl.disabled = false;
+    startButtonEl.addEventListener('click', () => {
+      startButtonEl.disabled = true;
+      const success = startMission();
+      if (!success) {
+        startButtonEl.disabled = false;
+        try { startButtonEl.focus(); } catch {}
+      }
+    });
+    try { startButtonEl.focus(); } catch {}
+  } else {
+    startMission();
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- add a launch panel with a Start Mission button so mini-game content no longer appears active on load
- style the new launch controls to match the existing mission shell presentation
- only initialise mini-game logic after the player starts the mission and handle setup failures gracefully

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dffe5d0034832eaa8e43a31d031df1