### PR TITLE
Use DM tools icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -1187,7 +1187,7 @@
       <button id="dm-tools-logout" class="btn-sm">Logout</button>
     </div>
     <button id="dm-tools-toggle" class="dm-tools-toggle" type="button" hidden aria-haspopup="true" aria-controls="dm-tools-menu" aria-expanded="false" aria-label="DM tools menu">
-      <span class="dm-tools-toggle__label" aria-hidden="true">D.M.</span>
+      <img class="dm-tools-toggle__icon" src="images/set-up-svgrepo-com.svg" alt="" aria-hidden="true" />
       <span class="sr-only">DM Tools</span>
     </button>
   </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1836,16 +1836,15 @@ select[required]:valid{
   box-shadow:0 10px 24px rgba(0,0,0,.45),0 0 0 1px rgba(59,130,246,.2) inset;
 }
 .dm-tools-toggle[hidden]{display:none}
-.dm-tools-toggle__label{
-  display:inline-block;
-  font-size:18px;
-  font-weight:700;
-  letter-spacing:0.18em;
-  text-transform:uppercase;
+.dm-tools-toggle__icon{
+  display:block;
+  width:28px;
+  height:28px;
+  pointer-events:none;
   transition:transform .3s ease;
 }
-.dm-tools-toggle:hover .dm-tools-toggle__label,
-.dm-tools-toggle:focus-visible .dm-tools-toggle__label{
+.dm-tools-toggle:hover .dm-tools-toggle__icon,
+.dm-tools-toggle:focus-visible .dm-tools-toggle__icon{
   transform:scale(1.08);
 }
 


### PR DESCRIPTION
## Summary
- replace the DM tools floating button label text with the existing set-up-svgrepo-com.svg icon
- style the toggle icon for centered display and hover scaling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e00351ece4832e93db04c86d975777