### PR TITLE
Double main menu popup scale

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -52,8 +52,8 @@ header::before{content:none}
 .actions{display:flex;gap:calc(6px * 1.15);flex-wrap:wrap}
 .actions.actions--center{justify-content:center}
 .dropdown{position:relative;display:flex;align-items:center;justify-content:flex-end;flex:0 0 auto;justify-self:end;grid-area:menu}
-.menu{position:absolute;top:calc(100% + 4px);right:0;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50;opacity:0;transform:translateY(-10px) scale(.96);visibility:hidden;transition:opacity .24s cubic-bezier(.22,1,.36,1),transform .24s cubic-bezier(.22,1,.36,1);pointer-events:none;transform-origin:top right;will-change:opacity,transform}
-.menu.show{opacity:1;transform:translateY(0) scale(1);visibility:visible;pointer-events:auto}
+.menu{position:absolute;top:calc(100% + 4px);right:0;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50;opacity:0;transform:translateY(-10px) scale(1.92);visibility:hidden;transition:opacity .24s cubic-bezier(.22,1,.36,1),transform .24s cubic-bezier(.22,1,.36,1);pointer-events:none;transform-origin:top right;will-change:opacity,transform}
+.menu.show{opacity:1;transform:translateY(0) scale(2);visibility:visible;pointer-events:auto}
 .menu button{background:transparent;color:var(--text);border:none;padding:8px 12px;text-align:left;font-weight:400;min-height:auto;white-space:nowrap}
 .menu button:hover{background:var(--accent);color:var(--text-on-accent)}
 .menu .btn-sm{justify-content:flex-start}


### PR DESCRIPTION
## Summary
- double the expanded header menu scale so the touch targets are easier to hit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e003a4f34c832eb89e7cb3e4d28867