### PR TITLE
Clarify stakes of Lockdown Override mini-game

### DIFF
--- a/SuperheroMiniGames/LockdownOverride/README.txt
+++ b/SuperheroMiniGames/LockdownOverride/README.txt
@@ -1,11 +1,16 @@
 Lockdown Override challenges a hero to stabilise a base security system before automated defences escalate. The player must reroute power, silence alarms, and reset locks while the timer counts down.
 
+## Narrative Stakes
+- **Why it matters:** The base is moments away from sealing into a hardened killbox. If the override fails, automated turrets and gas floods fire up while allies and civilians are trapped inside.
+- **Why the heroes act:** They are buying time for an evacuation team evacuating civilians from the lower decks. Each stabilised subsystem delays the lockdown long enough for people to escape.
+- **Failure consequences:** When the timer hits zero without a successful override, security countermeasures engage at full force, cutting the team off from objectives or forcing a costly breakout scene.
+
 ## Fast Edit Knobs
 - **Security Level** *(select, default Amber)* – Sets the number of subsystems that must be cleared (Green is easiest, Crimson is the full gauntlet).
 - **Override Timer (seconds)** *(number, default 300)* – Controls how long the hero has before the lockdown seals permanently.
 - **Hazard Suppression Enabled** *(toggle, default on)* – When on, traps pause during the mini-game; when off, narrate stray lasers, gas jets, or drones interfering with the hero.
 
 ## Deployment Tips
-1. Pair the security level with the current scene stakes—Crimson works well for major set pieces.
-2. Use the hazard toggle to inject dynamic complications if other players want to assist.
-3. If the timer expires, trigger a narrative twist such as a rival faction breaking through or the base sealing the heroes inside.
+1. Pair the security level with the current scene stakes—Crimson works well for major set pieces where a disaster is minutes away.
+2. Use the hazard toggle to inject dynamic complications if other players want to assist or when the defence grid is actively fighting back.
+3. If the timer expires, trigger a narrative twist such as a rival faction breaking through, the base sealing the heroes inside, or civilians suffering casualties that escalate the campaign stakes.

--- a/SuperheroMiniGames/play.js
+++ b/SuperheroMiniGames/play.js
@@ -946,7 +946,7 @@ function setupLockdownOverride(root, context) {
   const card = document.createElement('section');
   card.className = 'mg-card';
   const intro = document.createElement('p');
-  intro.textContent = 'Balance the base subsystems before lockdown finalises. Stabilise each system while the clock counts down.';
+  intro.textContent = 'Balance the base subsystems before the base seals and lethal countermeasures trigger. Stabilise each system while the evacuation clock counts down.';
   card.appendChild(intro);
 
   const timerLabel = document.createElement('div');


### PR DESCRIPTION
## Summary
- add narrative stakes guidance to the Lockdown Override reference so facilitators know what is at risk
- update the in-game introduction text to call out the lethal consequences of failure and the evacuation clock

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00a8204d8832e9627503c840ab034