### PR TITLE
Auto-dismiss mini-games with toast notifications

### DIFF
--- a/SuperheroMiniGames/play.css
+++ b/SuperheroMiniGames/play.css
@@ -782,6 +782,62 @@ body {
   }
 }
 
+.mini-game-toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  max-width: clamp(240px, 40vw, 360px);
+  padding: 14px 18px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.45);
+  font-size: 0.95rem;
+  line-height: 1.4;
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 200ms ease, transform 200ms ease;
+  pointer-events: none;
+  z-index: 2000;
+  cursor: default;
+  outline: none;
+}
+
+.mini-game-toast--visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.mini-game-toast--success {
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.mini-game-toast--error {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.mini-game-toast:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+@media (max-width: 600px) {
+  .mini-game-toast {
+    left: 50%;
+    right: auto;
+    transform: translate(-50%, 12px);
+  }
+
+  .mini-game-toast--visible {
+    transform: translate(-50%, 0);
+  }
+}
+
 @media (max-width: 420px) {
   .mini-game-shell {
     padding: 16px 12px 22px;

--- a/SuperheroMiniGames/play.css
+++ b/SuperheroMiniGames/play.css
@@ -11,6 +11,7 @@
   --warning: #facc15;
   --card-bg: rgba(15, 23, 42, 0.82);
   --shadow: 0 22px 45px rgba(2, 6, 23, 0.5);
+  --mini-game-vh: 1vh;
 }
 
 * {
@@ -19,14 +20,15 @@
 
 body {
   margin: 0;
-  min-height: 100vh;
+  min-height: calc(var(--mini-game-vh, 1vh) * 100);
   background: radial-gradient(circle at top, rgba(14, 165, 233, 0.25), transparent 55%),
     linear-gradient(160deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.95));
   color: #f8fafc;
   display: flex;
   align-items: stretch;
   justify-content: center;
-  padding: 24px 16px 40px;
+  padding: clamp(22px, 6vh, 36px) clamp(16px, 5vw, 32px);
+  padding-bottom: calc(clamp(28px, 8vh, 44px) + env(safe-area-inset-bottom, 0px));
 }
 
 .mini-game-shell {
@@ -40,6 +42,9 @@ body {
   padding: 28px clamp(18px, 4vw, 32px) 36px;
   box-shadow: var(--shadow);
   backdrop-filter: blur(14px);
+  max-height: calc(var(--mini-game-vh, 1vh) * 100 - clamp(56px, 12vh, 96px));
+  overflow-y: auto;
+  overscroll-behavior: contain;
   animation: shell-fade-in 280ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -240,7 +245,7 @@ body {
 .mini-game-shell__dismissed {
   width: min(640px, 100%);
   margin: 24px auto 0;
-  padding: 24px 20px;
+  padding: 24px clamp(16px, 4vw, 24px);
   border-radius: 18px;
   border: 1px solid rgba(148, 163, 184, 0.4);
   background: rgba(15, 23, 42, 0.7);
@@ -255,6 +260,20 @@ body {
   margin: 0;
   line-height: 1.6;
   color: rgba(226, 232, 240, 0.92);
+}
+
+@media (max-width: 540px) {
+  .mini-game-shell__dismissed {
+    width: 100%;
+    margin: 20px 0 0;
+    padding: 18px 14px;
+    border-radius: 16px;
+  }
+
+  .mini-game-shell__dismissed-text {
+    font-size: 0.95rem;
+    line-height: 1.55;
+  }
 }
 
 .mini-game-shell__content {
@@ -719,7 +738,8 @@ body {
 
 @media (max-width: 720px) {
   body {
-    padding: 16px 12px 28px;
+    padding: clamp(18px, 6vh, 28px) clamp(12px, 6vw, 20px);
+    padding-bottom: calc(clamp(22px, 7vh, 32px) + env(safe-area-inset-bottom, 0px));
   }
 
   .mini-game-shell {
@@ -784,10 +804,10 @@ body {
 
 .mini-game-toast {
   position: fixed;
-  bottom: 24px;
-  right: 24px;
-  max-width: clamp(240px, 40vw, 360px);
-  padding: 14px 18px;
+  bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+  right: clamp(16px, 6vw, 28px);
+  max-width: min(360px, calc(100vw - 32px));
+  padding: 14px clamp(16px, 4vw, 20px);
   border-radius: 14px;
   border: 1px solid var(--border);
   background: rgba(15, 23, 42, 0.92);
@@ -828,9 +848,11 @@ body {
 
 @media (max-width: 600px) {
   .mini-game-toast {
+    width: min(90vw, 440px);
     left: 50%;
     right: auto;
     transform: translate(-50%, 12px);
+    text-align: center;
   }
 
   .mini-game-toast--visible {
@@ -1318,10 +1340,6 @@ body {
 }
 
 @media (max-width: 720px) {
-  body {
-    padding: 16px;
-  }
-
   .mini-game-shell {
     border-radius: 18px;
     padding: 22px 16px 28px;
@@ -1340,13 +1358,16 @@ body {
 @media (max-width: 540px) {
   body {
     display: block;
-    padding: 14px 10px 22px;
+    padding: 16px 10px;
+    padding-bottom: calc(20px + env(safe-area-inset-bottom, 0px));
   }
 
   .mini-game-shell {
     width: 100%;
     padding: 18px 12px 24px;
     gap: 16px;
+    max-height: none;
+    overflow: visible;
   }
 
   .mini-game-shell__header {
@@ -1510,7 +1531,8 @@ body {
 
 @media (max-width: 360px) {
   body {
-    padding: 12px 8px 18px;
+    padding: 14px 8px;
+    padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px));
   }
 
   .mini-game-shell {

--- a/SuperheroMiniGames/play.js
+++ b/SuperheroMiniGames/play.js
@@ -26,6 +26,74 @@ const dismissedEl = document.getElementById('mini-game-dismissed');
 const dismissedTextEl = document.getElementById('mini-game-dismissed-text');
 const dismissedReopenBtn = document.getElementById('mini-game-dismissed-reopen');
 
+const MINI_GAME_TOAST_ID = 'mini-game-toast';
+let toastHideTimer = null;
+
+function getToastElement() {
+  return document.getElementById(MINI_GAME_TOAST_ID);
+}
+
+function ensureToastElement() {
+  let el = getToastElement();
+  if (!el) {
+    el = document.createElement('div');
+    el.id = MINI_GAME_TOAST_ID;
+    el.className = 'mini-game-toast';
+    el.setAttribute('role', 'status');
+    el.setAttribute('aria-live', 'polite');
+    el.tabIndex = -1;
+    el.addEventListener('click', () => hideToastMessage());
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
+function hideToastMessage() {
+  const el = getToastElement();
+  if (!el) return;
+  el.classList.remove('mini-game-toast--visible');
+  el.classList.remove('mini-game-toast--success');
+  el.classList.remove('mini-game-toast--error');
+  if (toastHideTimer) {
+    clearTimeout(toastHideTimer);
+    toastHideTimer = null;
+  }
+}
+
+function showToastMessage(message, { type = 'info', duration = 4000 } = {}) {
+  const text = typeof message === 'string' ? message.trim() : '';
+  if (!text) return;
+  const el = ensureToastElement();
+  if (toastHideTimer) {
+    clearTimeout(toastHideTimer);
+    toastHideTimer = null;
+  }
+  const normalizedType = type === 'success'
+    ? 'success'
+    : type === 'error' || type === 'danger' || type === 'failure'
+      ? 'error'
+      : 'info';
+  const classNames = ['mini-game-toast', 'mini-game-toast--visible'];
+  if (normalizedType === 'success') {
+    classNames.push('mini-game-toast--success');
+  } else if (normalizedType === 'error') {
+    classNames.push('mini-game-toast--error');
+  }
+  el.className = classNames.join(' ');
+  el.textContent = text;
+  try {
+    el.focus({ preventScroll: true });
+  } catch {
+    /* ignore focus errors */
+  }
+  const timeout = typeof duration === 'number' && duration > 0 ? duration : 0;
+  if (timeout > 0) {
+    toastHideTimer = setTimeout(() => {
+      hideToastMessage();
+    }, timeout);
+  }
+}
+
 const CLOUD_MINI_GAMES_URL = 'https://ccccg-7d6b6-default-rtdb.firebaseio.com/miniGames';
 
 function showError(message) {
@@ -50,23 +118,32 @@ function hideOutcome() {
   if (outcomeBodyEl) outcomeBodyEl.textContent = '';
 }
 
+function getOutcomeCopy({ success, heading, body } = {}) {
+  const headingText = typeof heading === 'string' && heading.trim()
+    ? heading.trim()
+    : success === true
+      ? 'Mission accomplished'
+      : success === false
+        ? 'Mission concluded'
+        : 'Mission update';
+  const bodyText = typeof body === 'string' && body.trim()
+    ? body.trim()
+    : success === true
+      ? 'Great work. You can replay the mission or dismiss this console.'
+      : success === false
+        ? 'The mission failed. Debrief with your DM before trying again.'
+        : 'Mission status updated.';
+  return { headingText, bodyText };
+}
+
 function showOutcome({ success, heading, body } = {}) {
   if (!outcomeEl) return;
+  const { headingText, bodyText } = getOutcomeCopy({ success, heading, body });
   if (outcomeHeadingEl) {
-    outcomeHeadingEl.textContent = heading
-      || (success === true
-        ? 'Mission accomplished'
-        : success === false
-          ? 'Mission concluded'
-          : 'Mission update');
+    outcomeHeadingEl.textContent = headingText;
   }
   if (outcomeBodyEl) {
-    outcomeBodyEl.textContent = body
-      || (success === true
-        ? 'Great work. You can replay the mission or dismiss this console.'
-        : success === false
-          ? 'The mission failed. Debrief with your DM before trying again.'
-          : 'Mission status updated.');
+    outcomeBodyEl.textContent = bodyText;
   }
   if (success === true) {
     outcomeEl.dataset.state = 'success';
@@ -90,6 +167,30 @@ function showDismissedNotice(message) {
     dismissedTextEl.textContent = message.trim();
   }
   dismissedEl.hidden = false;
+}
+
+function autoDismissMission({ dismissMessage = '', toastMessage = '', toastType = 'info' } = {}) {
+  hideOutcome();
+  if (launchEl) {
+    launchEl.hidden = true;
+  }
+  if (shell) {
+    shell.hidden = true;
+  }
+  if (typeof dismissMessage === 'string' && dismissMessage.trim()) {
+    showDismissedNotice(dismissMessage);
+  } else {
+    hideDismissedNotice();
+  }
+  if (dismissedReopenBtn) {
+    try { dismissedReopenBtn.focus(); } catch {}
+  }
+  if (typeof toastMessage === 'string' && toastMessage.trim()) {
+    showToastMessage(toastMessage, {
+      type: toastType,
+      duration: 5000,
+    });
+  }
 }
 
 function safeLocalStorage() {
@@ -2239,13 +2340,17 @@ async function init() {
     rootEl.hidden = true;
     hideError();
     const { success = null, heading = '', body = '', dismissMessage } = result;
-    showOutcome({ success, heading, body });
-    if (launchEl) {
-      launchEl.hidden = false;
+    const { headingText, bodyText } = getOutcomeCopy({ success, heading, body });
+    const shouldAutoDismiss = success === true || success === false;
+    if (!shouldAutoDismiss) {
+      showOutcome({ success, heading: headingText, body: bodyText });
+      if (launchEl) {
+        launchEl.hidden = false;
+      }
     }
     if (launchTextEl) {
       const base = 'You can replay the mission or dismiss this console.';
-      const prefix = heading
+      const prefix = headingText
         || (success === true
           ? 'Mission accomplished.'
           : success === false
@@ -2264,7 +2369,17 @@ async function init() {
         : success === false
           ? 'Mission dismissed. Coordinate with your DM before attempting again.'
           : 'Mission dismissed. You may close this window.');
-    if (dismissButtonEl) {
+    const toastMessage = result.toastMessage && typeof result.toastMessage === 'string' && result.toastMessage.trim()
+      ? result.toastMessage.trim()
+      : `${title}: ${success === true ? 'Mission accomplished' : success === false ? 'Mission failed' : headingText}`;
+    const toastType = success === true ? 'success' : success === false ? 'error' : 'info';
+    if (shouldAutoDismiss) {
+      autoDismissMission({
+        dismissMessage: lastDismissMessage,
+        toastMessage,
+        toastType,
+      });
+    } else if (dismissButtonEl) {
       dismissButtonEl.disabled = false;
     }
   };


### PR DESCRIPTION
## Summary
- add a lightweight toast system to the standalone mini-game runner
- automatically dismiss missions and announce victories or failures via toast
- reuse the outcome copy defaults for both UI text and toast messaging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e12a2a7738832e8888ec6a7480662b