### PR TITLE
Hide DM tools launcher while modals are open

### DIFF
--- a/scripts/floating-launcher.js
+++ b/scripts/floating-launcher.js
@@ -1,0 +1,37 @@
+const CLASS_NAME = 'dm-floating-covered';
+const ATTRIBUTE_NAME = 'data-floating-covered';
+let coverCount = 0;
+
+function applyState() {
+  const body = document.body;
+  if (!body) return;
+  if (coverCount > 0) {
+    body.classList.add(CLASS_NAME);
+    body.setAttribute(ATTRIBUTE_NAME, 'true');
+  } else {
+    body.classList.remove(CLASS_NAME);
+    body.removeAttribute(ATTRIBUTE_NAME);
+  }
+}
+
+export function coverFloatingLauncher() {
+  coverCount += 1;
+  applyState();
+  return coverCount;
+}
+
+export function releaseFloatingLauncher() {
+  coverCount = Math.max(0, coverCount - 1);
+  applyState();
+  return coverCount;
+}
+
+export function isFloatingLauncherCovered() {
+  return coverCount > 0;
+}
+
+if (typeof window !== 'undefined') {
+  window.coverFloatingLauncher = coverFloatingLauncher;
+  window.releaseFloatingLauncher = releaseFloatingLauncher;
+  window.isFloatingLauncherCovered = isFloatingLauncherCovered;
+}

--- a/scripts/modal.js
+++ b/scripts/modal.js
@@ -1,4 +1,5 @@
 import { $, qsa } from './helpers.js';
+import { coverFloatingLauncher, releaseFloatingLauncher } from './floating-launcher.js';
 
 function getInertTargets() {
   const targets = new Set();
@@ -68,6 +69,7 @@ export function show(id) {
   if (!el || !el.classList.contains('hidden')) return;
   lastFocus = document.activeElement;
   if (openModals === 0) {
+    coverFloatingLauncher();
     document.body.classList.add('modal-open');
     getInertTargets().forEach(e => e.setAttribute('inert', ''));
   }
@@ -100,6 +102,7 @@ export function hide(id) {
   }
   openModals = Math.max(0, openModals - 1);
   if (openModals === 0) {
+    releaseFloatingLauncher();
     document.body.classList.remove('modal-open');
     getInertTargets().forEach(e => e.removeAttribute('inert'));
   }

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -2365,6 +2365,7 @@
       this.toastEventsBound = false;
       this.toastShownHandler = evt => this.onGlobalToastShown(evt);
       this.toastDismissHandler = () => this.onGlobalToastDismissed();
+      this.modalIsOpen = false;
     }
 
     attach() {
@@ -2790,10 +2791,22 @@
     openModal() {
       this.render();
       if (this.dom.modal) this.dom.modal.hidden = false;
+      if (!this.modalIsOpen) {
+        this.modalIsOpen = true;
+        if (typeof window?.coverFloatingLauncher === 'function') {
+          window.coverFloatingLauncher();
+        }
+      }
     }
 
     closeModal() {
       if (this.dom.modal) this.dom.modal.hidden = true;
+      if (this.modalIsOpen) {
+        this.modalIsOpen = false;
+        if (typeof window?.releaseFloatingLauncher === 'function') {
+          window.releaseFloatingLauncher();
+        }
+      }
       this.tempArtwork = null;
     }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -1856,6 +1856,14 @@ select[required]:valid{
   --dm-tools-icon-scale:1.08;
 }
 
+body.modal-open .dm-login-btn,
+body.modal-open .dm-tools-toggle,
+body.modal-open .dm-tools-menu{
+  opacity:0;
+  visibility:hidden;
+  pointer-events:none;
+}
+
 /* DM Tool (Shards of Many Fates) */
 .somf-dm{background:var(--surface);color:var(--text);border:1px solid var(--line);border-radius:var(--radius);padding:12px;margin:0 auto;width:100%;max-width:var(--content-width);max-height:calc(var(--vh,1vh)*100 - 32px);overflow:auto;-webkit-overflow-scrolling:touch}
 .somf-dm__hdr{display:flex;flex-direction:column;align-items:stretch;gap:8px;margin-bottom:8px}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1856,9 +1856,9 @@ select[required]:valid{
   --dm-tools-icon-scale:1.08;
 }
 
-body.modal-open .dm-login-btn,
-body.modal-open .dm-tools-toggle,
-body.modal-open .dm-tools-menu{
+body:is(.modal-open, .dm-floating-covered) .dm-login-btn,
+body:is(.modal-open, .dm-floating-covered) .dm-tools-toggle,
+body:is(.modal-open, .dm-floating-covered) .dm-tools-menu{
   opacity:0;
   visibility:hidden;
   pointer-events:none;


### PR DESCRIPTION
## Summary
- hide the DM Tools launcher and menu whenever a modal is active so the overlay is unobstructed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1408b051c832e863163e3b5c429b8