### PR TITLE
Apply bonus registry data to roll calculations

### DIFF
--- a/scripts/faction.js
+++ b/scripts/faction.js
@@ -232,6 +232,7 @@ export function updateFactionRep(handlePerkEffects = () => {}) {
     const tierEl = $(`${id}-rep-tier`);
     const perkEl = $(`${id}-rep-perk`);
     if (!input || !bar || !tierEl || !perkEl) return;
+    handlePerkEffects(perkEl, '', `faction:${id}`);
     const rawValue = input.value === '' ? config.defaultValue : input.value;
     const clamped = config.clamp(rawValue);
     input.value = String(clamped);
@@ -268,7 +269,8 @@ export function updateFactionRep(handlePerkEffects = () => {}) {
       } else {
         perkEl.textContent = text;
       }
-      handlePerkEffects(perkEl, text);
+      const tierKey = tierName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'tier';
+      handlePerkEffects(perkEl, text, `faction:${config.id}:${tierKey}`);
       perkEl.style.display = 'block';
     } else {
       perkEl.style.display = 'none';


### PR DESCRIPTION
## Summary
- add a resolver that lets `rollWithBonus` pull registered modifiers automatically based on the supplied roll metadata
- update save, skill, attack, and death save roll flows to pass base modifiers and rely on the resolver for bonus aggregation
- keep faction reputation rendering invoking the perk handler so faction perks continue registering their bonuses

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e1f1b4145c832ea005687c463dad85