### PR TITLE
Centralize roll bonus resolution for player rolls

### DIFF
--- a/scripts/faction.js
+++ b/scripts/faction.js
@@ -271,6 +271,7 @@ export function updateFactionRep(handlePerkEffects = () => {}) {
       handlePerkEffects(perkEl, text);
       perkEl.style.display = 'block';
     } else {
+      handlePerkEffects(perkEl, '');
       perkEl.style.display = 'none';
     }
   });


### PR DESCRIPTION
## Summary
- introduce a roll bonus registry and resolver so rollWithBonus automatically aggregates modifiers and surfaces breakdowns for logs
- update save, skill, initiative, attack, and death save rolls to pass base modifiers/metadata and take advantage of the shared resolver
- re-trigger perk effect handling when rendering faction reputation so perk-driven bonuses stay synchronized

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1f9407ef4832e8e45cf125835da4b