### PR TITLE
Rework combat controls layout and supporting menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,29 +231,42 @@
 
     <h2 class="card-title">Combat</h2>
 
-    <div class="grid grid-2 roll-flip-grid">
-      <fieldset class="card">
-        <legend data-animate-title>Dice Roll</legend>
-        <span class="pill result" id="dice-out" data-placeholder="000"></span>
-        <div class="inline">
-          <label for="dice-sides" class="sr-only">Sides</label>
-          <select id="dice-sides" data-view-allow>
-            <option value="4">d4</option><option value="6">d6</option><option value="8">d8</option><option value="10">d10</option><option value="12">d12</option><option value="20" selected>d20</option><option value="100">d100</option>
-          </select>
-          <label for="dice-count" class="sr-only">Count</label>
-          <input id="dice-count" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" min="1" value="1"/>
-          <button id="roll-dice" class="btn-sm">Roll</button>
+    <fieldset class="card roll-tools-card">
+      <legend data-animate-title>Dice, Coin &amp; Initiative</legend>
+      <div class="roll-tools">
+        <div class="roll-tools__panel">
+          <h3 class="roll-tools__heading">Dice Roll</h3>
+          <span class="pill result" id="dice-out" data-placeholder="000"></span>
+          <div class="inline">
+            <label for="dice-sides" class="sr-only">Sides</label>
+            <select id="dice-sides" data-view-allow>
+              <option value="4">d4</option><option value="6">d6</option><option value="8">d8</option><option value="10">d10</option><option value="12">d12</option><option value="20" selected>d20</option><option value="100">d100</option>
+            </select>
+            <label for="dice-count" class="sr-only">Count</label>
+            <input id="dice-count" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" min="1" value="1"/>
+            <button id="roll-dice" class="btn-sm">Roll</button>
+          </div>
         </div>
-      </fieldset>
-      <fieldset class="card">
-        <legend data-animate-title>Coin Flip</legend>
-        <span class="pill result" id="flip-out" data-placeholder="Heads"></span>
-        <div class="inline">
-          <button id="flip" class="btn-sm">Flip</button>
+        <div class="roll-tools__panel">
+          <h3 class="roll-tools__heading">Coin Flip</h3>
+          <span class="pill result" id="flip-out" data-placeholder="Heads"></span>
+          <div class="inline">
+            <button id="flip" class="btn-sm">Flip</button>
+          </div>
         </div>
-      </fieldset>
-    </div>
-    <fieldset id="death-saves" class="card" disabled>
+      </div>
+      <div class="roll-tools__initiative">
+        <div class="initiative-field">
+          <label for="initiative">Initiative</label>
+          <div class="initiative-controls">
+            <input id="initiative" type="text" inputmode="numeric" pattern="[0-9]*" placeholder="auto from DEX + bonuses" readonly/>
+            <button type="button" id="roll-initiative" class="btn-sm" aria-label="Roll Initiative">Roll</button>
+          </div>
+          <span id="initiative-roll-result" class="pill result" data-placeholder="Roll"></span>
+        </div>
+      </div>
+    </fieldset>
+    <fieldset id="death-saves" class="card" hidden disabled>
       <legend data-animate-title>Death Saves</legend>
       <div class="death-saves-grid">
         <div class="death-save-tracks">
@@ -286,32 +299,36 @@
     <div class="grid grid-1">
       <fieldset class="card hp-field">
         <legend data-animate-title>HP</legend>
-          <input id="hp-roll" type="hidden" value="0"/>
-          <div class="inline">
-            <div class="bar-label">
-              <progress id="hp-bar" max="30" value="30"></progress>
-              <span id="hp-pill">30/30</span>
-            </div>
+        <button type="button" class="card-caret" id="hp-settings-toggle" aria-haspopup="dialog" aria-expanded="false" aria-controls="modal-hp-settings">
+          <span class="sr-only">Open HP options</span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4"/>
+          </svg>
+        </button>
+        <input id="hp-roll" type="hidden" value="0"/>
+        <div class="inline">
+          <div class="bar-label">
+            <progress id="hp-bar" max="30" value="30"></progress>
+            <span id="hp-pill">30/30</span>
           </div>
-          <div class="inline">
-            <label for="hp-temp" class="sr-only">Temp HP</label>
-            <input id="hp-temp" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Temp HP"/>
-            <button id="hp-roll-add" class="btn-sm" type="button">Tier HP</button>
-          </div>
-          <div class="inline">
-            <label for="hp-amt" class="sr-only">Amount</label>
-            <input id="hp-amt" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Amount"/>
-          </div>
-          <div class="inline">
-            <button id="hp-dmg" class="btn-sm">Damage</button>
-            <button id="hp-heal" class="btn-sm">Heal</button>
-          </div>
-          <div class="inline">
-            <button id="hp-full" class="btn-sm">Reset HP</button>
-          </div>
+        </div>
+        <div class="inline">
+          <label for="hp-amt" class="sr-only">Amount</label>
+          <input id="hp-amt" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Amount"/>
+        </div>
+        <div class="inline">
+          <button id="hp-dmg" class="btn-sm">Damage</button>
+          <button id="hp-heal" class="btn-sm">Heal</button>
+        </div>
       </fieldset>
       <fieldset class="card sp-field">
         <legend data-animate-title>SP</legend>
+        <button type="button" class="card-caret" id="sp-menu-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="sp-menu">
+          <span class="sr-only">Open SP options</span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4"/>
+          </svg>
+        </button>
         <div class="inline">
           <div class="bar-label">
             <progress id="sp-bar" max="5" value="5"></progress>
@@ -328,7 +345,9 @@
           <button class="btn-sm" data-sp="-5">-5 SP</button>
           <button id="sp-full" class="btn-sm">Reset SP</button>
         </div>
-        <button id="long-rest" class="btn-sm">Long Rest</button>
+        <div id="sp-menu" class="card-menu" role="menu" hidden>
+          <button id="long-rest" class="card-menu__item" role="menuitem" type="button">Long Rest</button>
+        </div>
       </fieldset>
       <fieldset class="card cap-field">
         <legend data-animate-title>Cinematic Action Point</legend>
@@ -346,24 +365,16 @@
     <div class="grid grid-1">
       <fieldset class="card">
         <legend data-animate-title>Stats and Effects</legend>
-        <div class="stats-grid">
-          <div class="initiative-field">
-            <label for="initiative">Initiative</label>
-            <div class="initiative-controls">
-              <input id="initiative" type="text" inputmode="numeric" pattern="[0-9]*" placeholder="auto from DEX + bonuses" readonly/>
-              <button type="button" id="roll-initiative" class="btn-sm" aria-label="Roll Initiative">Roll</button>
-            </div>
-            <span id="initiative-roll-result" class="pill result" data-placeholder="Roll"></span>
-          </div>
-          <div>
+        <div class="stat-trio">
+          <div class="stat-trio__item">
             <label for="speed">Speed (ft)</label>
             <input id="speed" type="number" inputmode="numeric" pattern="[0-9]*" placeholder="30"/>
           </div>
-          <div>
+          <div class="stat-trio__item">
             <label for="pp">Passive Perception</label>
             <input id="pp" type="number" inputmode="numeric" pattern="[0-9]*" readonly/>
           </div>
-          <div>
+          <div class="stat-trio__item">
             <label for="tc">TC</label>
             <input id="tc" type="number" inputmode="numeric" pattern="[0-9]*" readonly/>
           </div>
@@ -440,60 +451,52 @@
     <div id="abil-grid" class="grid ability-grid"></div>
     <fieldset class="card">
       <legend data-animate-title>Proficiency and Power</legend>
-      <div class="inline" style="flex-wrap:wrap;gap:12px">
-        <div style="flex:1;min-width:160px">
+      <div class="proficiency-card__grid">
+        <div class="proficiency-card__field">
           <label for="prof-bonus">Proficiency Bonus</label>
           <input id="prof-bonus" type="number" inputmode="numeric" pattern="[0-9]*" value="2" readonly/>
         </div>
-        <div style="flex:1;min-width:200px">
-          <label data-animate-title>Save DC Formula</label>
-          <div class="inline" style="gap:8px">
-            <label class="inline" style="gap:4px">
-              <input type="radio" name="power-dc-mode" id="power-dc-mode-simple" value="Simple"/>
-              <span>Simple</span>
-            </label>
-            <label class="inline" style="gap:4px">
-              <input type="radio" name="power-dc-mode" id="power-dc-mode-proficiency" value="Proficiency" checked/>
-              <span>Proficiency</span>
-            </label>
-          </div>
-          <input id="power-dc-formula" type="hidden" value="Proficiency"/>
-        </div>
-        <div style="flex:1;min-width:160px">
+        <div class="proficiency-card__field">
           <label for="power-save-ability">Power Save Ability</label>
           <select id="power-save-ability">
             <option value="str">STR</option><option value="dex">DEX</option><option value="con">CON</option>
             <option value="int">INT</option><option value="wis" selected>WIS</option><option value="cha">CHA</option>
           </select>
         </div>
-        <div style="flex:1;min-width:160px">
-          <label for="power-save-dc">Power Save DC</label>
+      </div>
+      <div class="proficiency-card__hidden" aria-hidden="true">
+        <input id="power-dc-formula" type="hidden" value="Proficiency"/>
+        <div hidden>
+          <label data-animate-title class="sr-only" for="power-save-dc">Power Save DC</label>
           <input id="power-save-dc" type="number" inputmode="numeric" pattern="[0-9]*" readonly/>
         </div>
-        <div style="flex:1;min-width:160px">
-          <label for="power-range-unit">Default Range Unit</label>
+        <div hidden>
+          <label class="sr-only" for="power-range-unit">Default Range Unit</label>
           <select id="power-range-unit">
             <option value="feet" selected>Feet</option>
             <option value="narrative">Narrative</option>
           </select>
         </div>
-        <div style="flex:1;min-width:200px">
-          <label for="power-suggestion-strength">Auto-Suggestion Strength</label>
+        <div hidden>
+          <label class="sr-only" for="power-suggestion-strength">Auto-Suggestion Strength</label>
           <select id="power-suggestion-strength">
             <option value="off">Off</option>
             <option value="conservative" selected>Conservative</option>
             <option value="assertive">Assertive</option>
           </select>
         </div>
-        <div style="flex:1;min-width:200px;display:flex;flex-direction:column;gap:6px">
-          <label class="inline" style="gap:6px">
-            <input type="checkbox" id="power-range-metric"/>
-            <span>Show metric ranges</span>
-          </label>
-          <label class="inline" style="gap:6px">
-            <input type="checkbox" id="power-text-compact"/>
-            <span>Use compact rules text</span>
-          </label>
+        <div hidden>
+          <label class="sr-only" for="power-range-metric">Show metric ranges</label>
+          <input type="checkbox" id="power-range-metric"/>
+        </div>
+        <div hidden>
+          <label class="sr-only" for="power-text-compact">Use compact rules text</label>
+          <input type="checkbox" id="power-text-compact"/>
+        </div>
+        <div hidden>
+          <label class="sr-only" for="power-dc-mode-simple">Save DC Formula</label>
+          <input type="radio" name="power-dc-mode" id="power-dc-mode-simple" value="Simple"/>
+          <input type="radio" name="power-dc-mode" id="power-dc-mode-proficiency" value="Proficiency" checked/>
         </div>
       </div>
     </fieldset>
@@ -1056,20 +1059,29 @@
   </div>
 </div>
 
-<div class="overlay hidden" id="modal-hp-roll" aria-hidden="true">
+<div class="overlay hidden" id="modal-hp-settings" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
     <button class="x" data-close aria-label="Close">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
-    <h3>Tier HP</h3>
-    <label for="hp-roll-input" class="sr-only">Tier HP Bonus</label>
-    <input id="hp-roll-input" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Tier HP Bonus"/>
-    <ul id="hp-roll-list"></ul>
-    <div class="actions">
-      <button id="hp-roll-save" class="btn-sm">Add</button>
-      <button class="btn-sm" data-close>Cancel</button>
+    <h3>HP Options</h3>
+    <div class="hp-settings__section">
+      <label for="hp-temp">Temporary HP</label>
+      <input id="hp-temp" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Temp HP"/>
+    </div>
+    <div class="hp-settings__section">
+      <label for="hp-roll-input">Tier HP Bonus</label>
+      <div class="hp-settings__row">
+        <input id="hp-roll-input" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Tier HP Bonus"/>
+        <button id="hp-roll-save" class="btn-sm" type="button">Add</button>
+      </div>
+      <ul id="hp-roll-list"></ul>
+    </div>
+    <div class="actions hp-settings__actions">
+      <button id="hp-full" class="btn-sm">Reset HP</button>
+      <button class="btn-sm" data-close>Close</button>
     </div>
   </div>
 </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -707,6 +707,15 @@ fieldset[data-tab="combat"] .card{
 main>:last-child{margin-bottom:0}
 fieldset[data-tab].card.active{opacity:1;transform:translate3d(0,0,0);pointer-events:auto;visibility:visible;filter:blur(0)saturate(1);position:relative;inset:auto;margin-bottom:14px}
 fieldset[data-tab].card>legend{font-size:clamp(1.1rem,3.4vw,1.5rem);font-weight:600;color:var(--accent);margin:0 0 6px;font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;letter-spacing:var(--title-letter-spacing);word-spacing:var(--title-word-spacing)}
+.card{position:relative}
+.card .card-caret{position:absolute;top:10px;right:10px;width:clamp(28px,6vw,34px);height:clamp(28px,6vw,34px);border-radius:8px;border:1px solid transparent;display:inline-flex;align-items:center;justify-content:center;background:var(--surface-2);color:var(--text);cursor:pointer;padding:0;transition:background .2s ease,border-color .2s ease,transform .2s ease}
+.card .card-caret svg{width:clamp(14px,4vw,18px);height:clamp(14px,4vw,18px)}
+.card .card-caret:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.card .card-caret:hover{background:color-mix(in srgb,var(--surface-2) 80%,var(--accent) 20%);border-color:color-mix(in srgb,var(--accent) 35%,transparent)}
+.card-menu{position:absolute;top:calc(10px + clamp(28px,6vw,34px));right:10px;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:6px;display:flex;flex-direction:column;gap:6px;min-width:clamp(140px,40vw,180px);z-index:5}
+.card-menu__item{width:100%;min-height:var(--control-compact-min-height);padding:clamp(6px,2.2vw,10px);font-size:clamp(.8rem,2.5vw,.95rem);background:var(--surface-2);border:1px solid transparent;border-radius:var(--radius);cursor:pointer;text-align:left}
+.card-menu__item:hover,.card-menu__item:focus-visible{background:color-mix(in srgb,var(--accent) 18%,var(--surface-2));border-color:color-mix(in srgb,var(--accent) 35%,transparent);outline:none}
+.card-menu[hidden]{display:none}
 .card-title{font-size:clamp(1.1rem,3.4vw,1.5rem);font-weight:600;color:var(--accent);margin:0 0 10px;font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;letter-spacing:var(--title-letter-spacing);word-spacing:var(--title-word-spacing)}
 p{max-width:var(--shell-width)}
 footer{
@@ -769,14 +778,21 @@ margin:0
 }
 #statuses .status-option span{flex:1}
 .status-effects{font-size:90%}
-.stats-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px}
 label{display:block;font-weight:700;margin-bottom:6px;font-size:clamp(.9rem,2.4vw,1rem)}
-.stats-grid label{min-height:3.2em;display:flex;align-items:flex-end}
+.stat-trio{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
+.stat-trio__item{display:flex;flex-direction:column;gap:6px}
+.stat-trio__item label{min-height:auto}
 .initiative-field{display:flex;flex-direction:column}
 .initiative-controls{display:flex;gap:var(--control-gap);align-items:center}
 .initiative-controls input{flex:1 1 auto}
 .initiative-controls button{flex:0 0 auto;white-space:nowrap}
 .initiative-field .pill.result{margin-top:4px;display:flex;align-items:center;justify-content:center;min-height:var(--control-compact-min-height);width:100%}
+.hp-settings__section{display:flex;flex-direction:column;gap:8px;margin-top:12px}
+.hp-settings__section:first-of-type{margin-top:0}
+.hp-settings__row{display:flex;gap:8px;align-items:center}
+.hp-settings__row input{flex:1}
+.hp-settings__row button{flex:0 0 auto}
+.hp-settings__actions{justify-content:flex-end;gap:8px}
 input:not([type="checkbox"]),select,textarea,button{-webkit-appearance:none;-moz-appearance:none;appearance:none;width:auto;max-width:100%;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:var(--control-padding-y) var(--control-padding-x);min-height:var(--control-min-height);font-size:var(--control-font-size);line-height:1.35;transition:var(--transition)}
 input:not([type="checkbox"]),select,textarea{width:100%}
 body.is-view-mode input[data-view-locked],
@@ -944,24 +960,6 @@ progress::-moz-progress-bar{
   0%{transform:scale(0);opacity:0;}
   50%{transform:scale(1.2);opacity:1;}
   100%{transform:scale(1);opacity:1;}
-}
-.roll-flip-grid{grid-template-columns:repeat(2,1fr);gap:var(--control-gap);}
-.roll-flip-grid .inline{flex-wrap:nowrap;gap:calc(var(--control-gap)*.6);}
-.roll-flip-grid select,
-.roll-flip-grid input,
-.roll-flip-grid button,
-.roll-flip-grid .pill{padding:calc(var(--pill-padding-y)*.7) calc(var(--pill-padding-x)*.7);min-height:var(--control-compact-min-height);}
-.roll-flip-grid .inline>select{flex:0 0 auto;width:clamp(64px,22vw,88px);min-height:var(--control-compact-min-height);height:var(--control-compact-min-height);}
-.roll-flip-grid .inline>input:not([type="checkbox"]){flex:1;width:auto;min-height:var(--control-compact-min-height);height:var(--control-compact-min-height);line-height:var(--control-compact-min-height);padding-top:0;padding-bottom:0;}
-.roll-flip-grid fieldset>legend{font-size:clamp(0.95rem,2.5vw,1.2rem);}
-.roll-flip-grid .pill.result{font-size:clamp(.75rem,2.4vw,.9rem);min-width:clamp(40px,12vw,56px);width:100%;display:flex;align-items:center;justify-content:center;text-align:center;margin-bottom:4px;}
-#dice-count{flex:0 0 clamp(30px,9vw,44px);width:clamp(30px,9vw,44px);}
-@media(max-width:600px){
-  .roll-flip-grid{grid-template-columns:repeat(2,1fr);}
-  .roll-flip-grid .inline{flex-direction:row;}
-  .roll-flip-grid .inline>select,
-  .roll-flip-grid .inline>input:not([type="checkbox"]){flex:1;width:auto;}
-  .roll-flip-grid .inline>button{flex:0 0 auto;width:auto;}
 }
 #flip{flex:1;width:100%;display:block;}
 #credits-total-pill{
@@ -1578,7 +1576,8 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
 
 
 /* ability grid */
-.ability-grid{grid-template-columns:repeat(2,1fr)}
+.ability-grid{grid-template-columns:repeat(2,1fr);gap:12px}
+#abil-grid{grid-template-columns:repeat(3,1fr);gap:clamp(10px,3vw,16px)}
 
 .ability-box{
   border:1px solid var(--line);
@@ -1596,10 +1595,13 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
 }
 
 /* Ensure skill names like "Sleight of Hand" fit on one line */
+#skills{grid-template-columns:repeat(3,1fr);gap:clamp(10px,3vw,16px)}
 #skills .ability-box label,
 #skills .ability-box .ability-label{
-  font-size:0.85rem;
-  white-space:nowrap;
+  font-size:0.8rem;
+  text-align:center;
+  white-space:normal;
+  line-height:1.2;
 }
 
 .ability-box .score{
@@ -1619,11 +1621,14 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
   align-items:center;
   justify-content:center;
   width:100%;
-  height:72px;
-  font-size:1.8rem;
+  height:64px;
+  font-size:1.6rem;
   border:1px solid var(--line);
   border-radius:var(--radius);
 }
+.proficiency-card__grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:var(--control-gap);margin-top:8px}
+.proficiency-card__field{display:flex;flex-direction:column;gap:6px}
+.proficiency-card__hidden{display:none}
 
 .ability-box .mod{
   position:absolute;
@@ -2145,4 +2150,15 @@ body.is-view-mode .power-card__body{display:none}
 @media (max-width:480px){
   .power-card__summary-roll-btn,.power-card__quick-btn{min-height:26px;font-size:.78rem}
   .power-card__roll-output{min-height:26px;font-size:.78rem}
+}
+#dice-count{flex:0 0 clamp(30px,9vw,44px);width:clamp(30px,9vw,44px);}
+.roll-tools-card{display:flex;flex-direction:column;gap:clamp(10px,3vw,16px)}
+.roll-tools{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--control-gap)}
+.roll-tools__panel{display:flex;flex-direction:column;gap:calc(var(--control-gap)*.6)}
+.roll-tools__heading{margin:0;font-size:clamp(.95rem,2.4vw,1.1rem);color:var(--muted);text-transform:uppercase;letter-spacing:.08em}
+.roll-tools__panel .pill.result{margin-bottom:4px}
+.roll-tools__initiative{margin-top:4px;padding-top:8px;border-top:1px solid var(--line)}
+@media(max-width:700px){
+  .roll-tools{grid-template-columns:1fr}
+  .roll-tools__initiative{border-top:1px solid var(--line);padding-top:12px;margin-top:8px}
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -712,7 +712,7 @@ fieldset[data-tab].card>legend{font-size:clamp(1.1rem,3.4vw,1.5rem);font-weight:
 .card .card-caret svg{width:clamp(14px,4vw,18px);height:clamp(14px,4vw,18px)}
 .card .card-caret:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .card .card-caret:hover{background:color-mix(in srgb,var(--surface-2) 80%,var(--accent) 20%);border-color:color-mix(in srgb,var(--accent) 35%,transparent)}
-.card-menu{position:absolute;top:calc(10px + clamp(28px,6vw,34px));right:10px;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:6px;display:flex;flex-direction:column;gap:6px;min-width:clamp(140px,40vw,180px);z-index:5}
+.card-menu{position:absolute;top:calc(10px + clamp(28px,6vw,34px));right:10px;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:6px;display:flex;flex-direction:column;gap:6px;min-width:clamp(140px,48vw,200px);max-width:calc(100vw - 24px);width:max-content;max-height:var(--card-menu-max-height, none);overflow-x:hidden;overflow-y:auto;transform:translateX(calc(var(--card-menu-offset-x, 0px) * -1));z-index:5}
 .card-menu__item{width:100%;min-height:var(--control-compact-min-height);padding:clamp(6px,2.2vw,10px);font-size:clamp(.8rem,2.5vw,.95rem);background:var(--surface-2);border:1px solid transparent;border-radius:var(--radius);cursor:pointer;text-align:left}
 .card-menu__item:hover,.card-menu__item:focus-visible{background:color-mix(in srgb,var(--accent) 18%,var(--surface-2));border-color:color-mix(in srgb,var(--accent) 35%,transparent);outline:none}
 .card-menu[hidden]{display:none}
@@ -782,6 +782,9 @@ label{display:block;font-weight:700;margin-bottom:6px;font-size:clamp(.9rem,2.4v
 .stat-trio{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
 .stat-trio__item{display:flex;flex-direction:column;gap:6px}
 .stat-trio__item label{min-height:auto}
+@media(max-width:480px){
+  .stat-trio{grid-template-columns:repeat(auto-fit,minmax(105px,1fr));gap:10px}
+}
 .initiative-field{display:flex;flex-direction:column}
 .initiative-controls{display:flex;gap:var(--control-gap);align-items:center}
 .initiative-controls input{flex:1 1 auto}
@@ -789,10 +792,14 @@ label{display:block;font-weight:700;margin-bottom:6px;font-size:clamp(.9rem,2.4v
 .initiative-field .pill.result{margin-top:4px;display:flex;align-items:center;justify-content:center;min-height:var(--control-compact-min-height);width:100%}
 .hp-settings__section{display:flex;flex-direction:column;gap:8px;margin-top:12px}
 .hp-settings__section:first-of-type{margin-top:0}
-.hp-settings__row{display:flex;gap:8px;align-items:center}
-.hp-settings__row input{flex:1}
+.hp-settings__row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.hp-settings__row input{flex:1 1 140px;min-width:0}
 .hp-settings__row button{flex:0 0 auto}
 .hp-settings__actions{justify-content:flex-end;gap:8px}
+@media(max-width:520px){
+  .hp-settings__row{flex-direction:column;align-items:stretch}
+  .hp-settings__row button{width:100%}
+}
 input:not([type="checkbox"]),select,textarea,button{-webkit-appearance:none;-moz-appearance:none;appearance:none;width:auto;max-width:100%;border-radius:var(--radius);border:1px solid var(--accent);background:var(--surface-2);color:var(--text);padding:var(--control-padding-y) var(--control-padding-x);min-height:var(--control-min-height);font-size:var(--control-font-size);line-height:1.35;transition:var(--transition)}
 input:not([type="checkbox"]),select,textarea{width:100%}
 body.is-view-mode input[data-view-locked],
@@ -1310,7 +1317,7 @@ progress::-moz-progress-bar{
   90%{opacity:1;}
   100%{opacity:0;}
 }
-.sp-grid{display:grid;width:100%;grid-template-columns:repeat(3,1fr);gap:8px;}
+.sp-grid{display:grid;width:100%;grid-template-columns:repeat(auto-fit,minmax(90px,1fr));gap:8px;}
 .sp-grid .btn-sm{width:100%;}
 .custom-type-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:10px;margin:12px 0;}
 .custom-type-grid .btn-sm{width:100%;}
@@ -1576,8 +1583,8 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
 
 
 /* ability grid */
-.ability-grid{grid-template-columns:repeat(2,1fr);gap:12px}
-#abil-grid{grid-template-columns:repeat(3,1fr);gap:clamp(10px,3vw,16px)}
+.ability-grid{display:grid;gap:clamp(10px,3vw,16px);grid-template-columns:repeat(auto-fit,minmax(clamp(140px,36vw,200px),1fr))}
+#abil-grid{grid-template-columns:repeat(auto-fit,minmax(clamp(96px,26vw,140px),1fr))}
 
 .ability-box{
   border:1px solid var(--line);
@@ -1595,7 +1602,7 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
 }
 
 /* Ensure skill names like "Sleight of Hand" fit on one line */
-#skills{grid-template-columns:repeat(3,1fr);gap:clamp(10px,3vw,16px)}
+#skills{grid-template-columns:repeat(auto-fit,minmax(clamp(96px,28vw,150px),1fr))}
 #skills .ability-box label,
 #skills .ability-box .ability-label{
   font-size:0.8rem;


### PR DESCRIPTION
## Summary
- combine the dice, coin, and initiative controls into a single card and keep death saves hidden until HP hits zero
- move HP temp/tier/reset actions into a dedicated modal, add SP options to a caret menu, and reorganize the stat trio layout
- resize ability and skill grids and streamline the proficiency & power card to surface only the key fields

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e372152c40832e8eadfaa07c2eb08d