### PR TITLE
Default character loads to view mode

### DIFF
--- a/__tests__/new_character.test.js
+++ b/__tests__/new_character.test.js
@@ -1,25 +1,16 @@
 import { jest } from '@jest/globals';
 
-describe('new character reset', () => {
-  test('starting a new character resets ability scores and story fields', async () => {
-    global.fetch = jest.fn().mockResolvedValue({ text: async () => '' });
+const originalGetElementById = document.getElementById;
+const originalConsoleError = console.error;
+const originalConfirm = window.confirm;
+const originalPrompt = window.prompt;
 
-    document.body.innerHTML = `
-      <div id="abil-grid"></div>
-      <div id="saves"></div>
-      <div id="skills"></div>
-      <div id="powers"></div>
-      <div id="sigs"></div>
-      <div id="weapons"></div>
-      <div id="armors"></div>
-      <div id="items"></div>
-      <div id="campaign-log"></div>
-      <button id="create-character"></button>
-      <input id="superhero" />
-    `;
-
-    const realGet = document.getElementById.bind(document);
-    document.getElementById = (id) => realGet(id) || {
+function stubMissingElements(){
+  const realGet = originalGetElementById.bind(document);
+  document.getElementById = (id) => {
+    const found = realGet(id);
+    if(found) return found;
+    return {
       innerHTML: '',
       value: '',
       style: { setProperty: () => {}, getPropertyValue: () => '' },
@@ -38,8 +29,47 @@ describe('new character reset', () => {
       textContent: '',
       disabled: false,
       checked: false,
-      hidden: false
+      hidden: false,
+      dataset: {},
+      closest: () => null,
     };
+  };
+}
+
+describe('new character reset', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '';
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    document.getElementById = originalGetElementById;
+    console.error = originalConsoleError;
+    window.confirm = originalConfirm;
+    window.prompt = originalPrompt;
+    jest.clearAllMocks();
+    delete global.fetch;
+  });
+
+  test('starting a new character resets ability scores and story fields', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ text: async () => '' });
+
+    document.body.innerHTML = `
+      <div id="abil-grid"></div>
+      <div id="saves"></div>
+      <div id="skills"></div>
+      <div id="powers"></div>
+      <div id="sigs"></div>
+      <div id="weapons"></div>
+      <div id="armors"></div>
+      <div id="items"></div>
+      <div id="campaign-log"></div>
+      <button id="create-character"></button>
+      <input id="superhero" />
+    `;
+
+    stubMissingElements();
 
     console.error = jest.fn();
 
@@ -56,5 +86,42 @@ describe('new character reset', () => {
 
     expect(document.getElementById('str').value).toBe('10');
     expect(document.getElementById('superhero').value).toBe('');
+  });
+
+  test('creating a new character exits view mode for editing', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ text: async () => '' });
+    localStorage.setItem('view-mode', '1');
+
+    document.body.innerHTML = `
+      <div id="abil-grid"></div>
+      <div id="saves"></div>
+      <div id="skills"></div>
+      <div id="powers"></div>
+      <div id="sigs"></div>
+      <div id="weapons"></div>
+      <div id="armors"></div>
+      <div id="items"></div>
+      <div id="campaign-log"></div>
+      <button id="create-character"></button>
+      <button id="btn-view-mode"></button>
+      <input id="superhero" />
+    `;
+
+    stubMissingElements();
+
+    console.error = jest.fn();
+
+    await import('../scripts/main.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(document.body.classList.contains('is-view-mode')).toBe(true);
+
+    window.confirm = jest.fn().mockReturnValue(true);
+    window.prompt = jest.fn().mockReturnValue('New Hero');
+
+    document.getElementById('create-character').click();
+
+    expect(document.body.classList.contains('is-view-mode')).toBe(false);
+    expect(localStorage.getItem('view-mode')).toBe('0');
   });
 });

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5307,6 +5307,7 @@ if(newCharBtn){
     setCurrentCharacter(clean);
     syncMiniGamePlayerName();
     deserialize(DEFAULT_STATE);
+    setViewMode(false);
     hide('modal-load-list');
     toast(`Switched to ${clean}`,'success');
   });
@@ -5341,6 +5342,7 @@ async function doLoad(){
       ? await loadBackup(pendingLoad.name, pendingLoad.ts, pendingLoad.type)
       : await loadCharacter(pendingLoad.name);
     deserialize(data);
+    setViewMode(true);
     setCurrentCharacter(pendingLoad.name);
     syncMiniGamePlayerName();
     hide('modal-load');
@@ -5375,6 +5377,7 @@ if (autoChar) {
       syncMiniGamePlayerName();
       const data = await loadCharacter(autoChar);
       deserialize(data);
+      setViewMode(true);
     } catch (e) {
       console.error('Failed to load character from URL', e);
     } finally {


### PR DESCRIPTION
## Summary
- force the character sheet into view mode whenever a character is loaded from saves or URL parameters so editing requires an explicit toggle
- ensure new characters created from the load list or welcome modal automatically switch back to edit mode so players can fill out details immediately

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e39a996380832e9d1819dfe0f538df