### PR TITLE
Add card toolbar utility for card action layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,14 +513,24 @@
   <!-- POWERS -->
   <fieldset data-tab="powers" class="card">
     <h2 class="card-title">Powers</h2>
-    <div style="display:flex;justify-content:flex-end;margin-bottom:16px">
-      <button id="add-power" style="max-width:180px">Add Power</button>
+    <div class="card-toolbar">
+      <div class="card-toolbar__actions">
+        <button id="add-power" style="max-width:180px">
+          <span class="btn-icon" aria-hidden="true">➕</span>
+          <span class="btn-label">Add Power</span>
+        </button>
+      </div>
     </div>
     <div class="grid grid-2" id="powers"></div>
 
     <h3 style="margin:16px 0 8px">Signature Moves</h3>
-    <div style="display:flex;justify-content:flex-end;margin-bottom:16px">
-      <button id="add-sig" style="max-width:200px">Add Signature Move</button>
+    <div class="card-toolbar">
+      <div class="card-toolbar__actions">
+        <button id="add-sig" style="max-width:200px">
+          <span class="btn-icon" aria-hidden="true">➕</span>
+          <span class="btn-label">Add Signature Move</span>
+        </button>
+      </div>
     </div>
     <div class="grid grid-2" id="sigs"></div>
   </fieldset>
@@ -530,21 +540,41 @@
     <h2 class="card-title">Gear</h2>
     <div class="grid grid-2">
       <div class="card gear-card">
-        <h3 class="gear-card-title">Weapons</h3>
-        <button id="add-weapon" class="btn-sm gear-card-action" style="max-width:140px">Add Weapon</button>
+        <div class="card-toolbar">
+          <h3 class="gear-card-title card-toolbar__title">Weapons</h3>
+          <div class="card-toolbar__actions">
+            <button id="add-weapon" class="btn-sm gear-card-action" style="max-width:140px">
+              <span class="btn-icon" aria-hidden="true">➕</span>
+              <span class="btn-label">Add Weapon</span>
+            </button>
+          </div>
+        </div>
         <div id="weapons" class="grid grid-1"></div>
       </div>
       <div class="card gear-card">
-        <h3 class="gear-card-title">Armor and Protection</h3>
-        <button id="add-armor" class="btn-sm gear-card-action" style="max-width:160px">Add Armor</button>
+        <div class="card-toolbar">
+          <h3 class="gear-card-title card-toolbar__title">Armor and Protection</h3>
+          <div class="card-toolbar__actions">
+            <button id="add-armor" class="btn-sm gear-card-action" style="max-width:160px">
+              <span class="btn-icon" aria-hidden="true">➕</span>
+              <span class="btn-label">Add Armor</span>
+            </button>
+          </div>
+        </div>
         <div id="armors" class="grid grid-1"></div>
       </div>
       <div class="card" style="grid-column:1/-1">
-        <div class="inline" style="justify-content:space-between">
-          <h3 style="margin:0">Gear and Items</h3>
-          <div class="inline">
-            <button id="add-item" class="btn-sm" style="max-width:140px">Add Item</button>
-            <button id="open-catalog" class="btn-sm" style="max-width:160px">Open Gear Catalog</button>
+        <div class="card-toolbar">
+          <h3 class="card-toolbar__title">Gear and Items</h3>
+          <div class="card-toolbar__actions">
+            <button id="add-item" class="btn-sm" style="max-width:140px">
+              <span class="btn-icon" aria-hidden="true">➕</span>
+              <span class="btn-label">Add Item</span>
+            </button>
+            <button id="open-catalog" class="btn-sm" style="max-width:160px">
+              <span class="btn-icon" aria-hidden="true">📚</span>
+              <span class="btn-label">Open Gear Catalog</span>
+            </button>
           </div>
         </div>
         <div id="items" class="grid grid-1"></div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -882,6 +882,53 @@ button:focus-visible,
 .btn-sm:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .btn-sm:disabled{opacity:.5;cursor:not-allowed}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+.card-toolbar{
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+  gap:var(--control-gap);
+  flex-wrap:wrap;
+  width:100%;
+  margin-bottom:clamp(12px,3vw,18px);
+}
+
+.card-toolbar__title,
+.card-toolbar__label{
+  margin:0;
+  margin-inline-end:auto;
+  flex:1 1 auto;
+  min-width:min(220px,100%);
+}
+
+.card-toolbar__actions{
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+  gap:var(--control-gap);
+  flex-wrap:wrap;
+  margin-inline-start:auto;
+}
+
+.card-toolbar__actions>*{flex:0 0 auto}
+
+@media(max-width:600px){
+  .card-toolbar{justify-content:flex-start}
+  .card-toolbar__title,
+  .card-toolbar__label{min-width:100%}
+  .card-toolbar__actions{width:100%;justify-content:flex-start}
+}
+
+.btn-icon{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  font-size:1.05em;
+  line-height:1;
+  margin-inline-end:clamp(4px,1.2vw,8px);
+}
+
+button .btn-label{display:inline-flex;align-items:center}
+
 .inline{display:flex;align-items:center;gap:var(--control-gap);flex-wrap:wrap}
 .inline>input:not([type="checkbox"]),
 .inline>select,


### PR DESCRIPTION
## Summary
- add a reusable `.card-toolbar` utility with icon helpers to handle alignment and responsive wrapping of card actions
- update the powers and gear sections to consume the toolbar and provide icon-labeled buttons for clearer hierarchy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e39f51b610832e8194a7c17c421791