### PR TITLE
Adjust saving throws grid layout

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1623,6 +1623,15 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
   line-height:1.2;
 }
 
+#saves{grid-template-columns:repeat(auto-fit,minmax(clamp(96px,28vw,150px),1fr))}
+#saves .ability-box label,
+#saves .ability-box .ability-label{
+  font-size:0.8rem;
+  text-align:center;
+  white-space:normal;
+  line-height:1.2;
+}
+
 .ability-box .score{
   position:relative;
   width:100%;


### PR DESCRIPTION
## Summary
- align the Saving Throws grid columns with the Ability Scores and Skills layouts for consistent three-column rendering
- apply the same label styling tweaks used for Skills to keep Saving Throws labels readable at narrower widths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e39fd2136c832ea494c8bb0b96e0ad