### PR TITLE
Adjust HP card layout for settings button

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -949,6 +949,14 @@ button .btn-label{display:inline-flex;align-items:center}
   .inline>progress{flex:none;width:100%}
 }
 
+.hp-field{
+  --hp-settings-button-size:clamp(28px,6vw,34px);
+}
+
+.hp-field .card-caret{z-index:2}
+
+.hp-field .inline:first-of-type{padding-right:calc(var(--hp-settings-button-size) + var(--card-padding,8px))}
+
 @media(max-width:600px){
   .hp-field .inline,
   .sp-field .inline{


### PR DESCRIPTION
## Summary
- reserve space around the HP progress display so the HP settings button stays visible
- raise the HP settings toggle above nearby elements to keep it clickable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3a32dd178832ea0d5cfd5d643871b