### PR TITLE
Fix SP caret overlap on the SP card

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,7 +297,7 @@
       </div>
     </fieldset>
     <div class="grid grid-1">
-      <fieldset class="card hp-field">
+      <fieldset class="card hp-field card--has-caret">
         <legend data-animate-title>HP</legend>
         <button type="button" class="card-caret" id="hp-settings-toggle" aria-haspopup="dialog" aria-expanded="false" aria-controls="modal-hp-settings">
           <span class="sr-only">Open HP options</span>
@@ -321,7 +321,7 @@
           <button id="hp-heal" class="btn-sm">Heal</button>
         </div>
       </fieldset>
-      <fieldset class="card sp-field">
+      <fieldset class="card sp-field card--has-caret">
         <legend data-animate-title>SP</legend>
         <button type="button" class="card-caret" id="sp-menu-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="sp-menu">
           <span class="sr-only">Open SP options</span>

--- a/styles/main.css
+++ b/styles/main.css
@@ -721,10 +721,13 @@ fieldset[data-tab].card.active{opacity:1;transform:translate3d(0,0,0);pointer-ev
 fieldset[data-tab].card>legend{font-size:clamp(1.1rem,3.4vw,1.5rem);font-weight:600;color:var(--accent);margin:0 0 6px;font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;letter-spacing:var(--title-letter-spacing);word-spacing:var(--title-word-spacing)}
 .card{position:relative}
 .card .card-caret{position:absolute;top:10px;right:10px;width:clamp(28px,6vw,34px);height:clamp(28px,6vw,34px);border-radius:8px;border:1px solid transparent;display:inline-flex;align-items:center;justify-content:center;background:var(--surface-2);color:var(--text);cursor:pointer;padding:0;transition:background .2s ease,border-color .2s ease,transform .2s ease}
+.card--has-caret{padding-right:calc(var(--card-padding, 8px) + clamp(28px, 6vw, 34px) + 8px)}
+.card--has-caret>legend{padding-right:calc(clamp(28px, 6vw, 34px) + 8px)}
+.card--has-caret .card-caret{top:var(--card-padding, 8px);right:var(--card-padding, 8px)}
 .card .card-caret svg{width:clamp(14px,4vw,18px);height:clamp(14px,4vw,18px)}
 .card .card-caret:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .card .card-caret:hover{background:color-mix(in srgb,var(--surface-2) 80%,var(--accent) 20%);border-color:color-mix(in srgb,var(--accent) 35%,transparent)}
-.card-menu{position:absolute;top:calc(10px + clamp(28px,6vw,34px));right:10px;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:6px;display:flex;flex-direction:column;gap:6px;min-width:clamp(140px,48vw,200px);max-width:calc(100vw - 24px);width:max-content;max-height:var(--card-menu-max-height, none);overflow-x:hidden;overflow-y:auto;transform:translateX(calc(var(--card-menu-offset-x, 0px) * -1));z-index:5}
+.card-menu{position:absolute;top:calc(var(--card-padding, 8px) + clamp(28px,6vw,34px));right:var(--card-padding, 8px);background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:6px;display:flex;flex-direction:column;gap:6px;min-width:clamp(140px,48vw,200px);max-width:calc(100vw - 24px);width:max-content;max-height:var(--card-menu-max-height, none);overflow-x:hidden;overflow-y:auto;transform:translateX(calc(var(--card-menu-offset-x, 0px) * -1));z-index:5}
 .card-menu__item{width:100%;min-height:var(--control-compact-min-height);padding:clamp(6px,2.2vw,10px);font-size:clamp(.8rem,2.5vw,.95rem);background:var(--surface-2);border:1px solid transparent;border-radius:var(--radius);cursor:pointer;text-align:left}
 .card-menu__item:hover,.card-menu__item:focus-visible{background:color-mix(in srgb,var(--accent) 18%,var(--surface-2));border-color:color-mix(in srgb,var(--accent) 35%,transparent);outline:none}
 .card-menu[hidden]{display:none}


### PR DESCRIPTION
## Summary
- add a helper class to cards that include a caret button so their content respects the caret space
- update the HP and SP cards to use the helper and keep the long-rest menu away from other controls

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e3a3851000832e94d8032d2be2d933