### PR TITLE
Add text labels to navigation tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,34 +168,49 @@
   </div>
   <nav class="tabs" role="tablist" aria-label="Primary">
     <button class="tab active" data-go="combat" aria-label="Combat" title="Combat" role="tab" aria-current="page" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <polyline stroke-linecap="round" stroke-linejoin="round" points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/>
-        <line stroke-linecap="round" stroke-linejoin="round" x1="13" y1="19" x2="19" y2="13"/>
-        <line stroke-linecap="round" stroke-linejoin="round" x1="16" y1="16" x2="20" y2="20"/>
-        <line stroke-linecap="round" stroke-linejoin="round" x1="19" y1="21" x2="21" y2="19"/>
-      </svg>
+      <span class="tab__icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <polyline stroke-linecap="round" stroke-linejoin="round" points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/>
+          <line stroke-linecap="round" stroke-linejoin="round" x1="13" y1="19" x2="19" y2="13"/>
+          <line stroke-linecap="round" stroke-linejoin="round" x1="16" y1="16" x2="20" y2="20"/>
+          <line stroke-linecap="round" stroke-linejoin="round" x1="19" y1="21" x2="21" y2="19"/>
+        </svg>
+      </span>
+      <span class="tab__label">Combat</span>
     </button>
     <button class="tab" data-go="abilities" aria-label="Abilities" title="Abilities" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9.8132 15.9038L9 18.75L8.1868 15.9038C7.75968 14.4089 6.59112 13.2403 5.09619 12.8132L2.25 12L5.09619 11.1868C6.59113 10.7597 7.75968 9.59112 8.1868 8.09619L9 5.25L9.8132 8.09619C10.2403 9.59113 11.4089 10.7597 12.9038 11.1868L15.75 12L12.9038 12.8132C11.4089 13.2403 10.2403 14.4089 9.8132 15.9038Z"/>
-        <path stroke-linecap="round" stroke-linejoin="round" d="M18.2589 8.71454L18 9.75L17.7411 8.71454C17.4388 7.50533 16.4947 6.56117 15.2855 6.25887L14.25 6L15.2855 5.74113C16.4947 5.43883 17.4388 4.49467 17.7411 3.28546L18 2.25L18.2589 3.28546C18.5612 4.49467 19.5053 5.43883 20.7145 5.74113L21.75 6L20.7145 6.25887C19.5053 6.56117 18.5612 7.50533 18.2589 8.71454Z"/>
-        <path stroke-linecap="round" stroke-linejoin="round" d="M16.8942 20.5673L16.5 21.75L16.1058 20.5673C15.8818 19.8954 15.3546 19.3682 14.6827 19.1442L13.5 18.75L14.6827 18.3558C15.3546 18.1318 15.8818 17.6046 16.1058 16.9327L16.5 15.75L16.8942 16.9327C17.1182 17.6046 17.6454 18.1318 18.3173 18.3558L19.5 18.75L18.3173 19.1442C17.6454 19.3682 17.1182 19.8954 16.8942 20.5673Z"/>
-      </svg>
+      <span class="tab__icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9.8132 15.9038L9 18.75L8.1868 15.9038C7.75968 14.4089 6.59112 13.2403 5.09619 12.8132L2.25 12L5.09619 11.1868C6.59113 10.7597 7.75968 9.59112 8.1868 8.09619L9 5.25L9.8132 8.09619C10.2403 9.59113 11.4089 10.7597 12.9038 11.1868L15.75 12L12.9038 12.8132C11.4089 13.2403 10.2403 14.4089 9.8132 15.9038Z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M18.2589 8.71454L18 9.75L17.7411 8.71454C17.4388 7.50533 16.4947 6.56117 15.2855 6.25887L14.25 6L15.2855 5.74113C16.4947 5.43883 17.4388 4.49467 17.7411 3.28546L18 2.25L18.2589 3.28546C18.5612 4.49467 19.5053 5.43883 20.7145 5.74113L21.75 6L20.7145 6.25887C19.5053 6.56117 18.5612 7.50533 18.2589 8.71454Z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M16.8942 20.5673L16.5 21.75L16.1058 20.5673C15.8818 19.8954 15.3546 19.3682 14.6827 19.1442L13.5 18.75L14.6827 18.3558C15.3546 18.1318 15.8818 17.6046 16.1058 16.9327L16.5 15.75L16.8942 16.9327C17.1182 17.6046 17.6454 18.1318 18.3173 18.3558L19.5 18.75L18.3173 19.1442C17.6454 19.3682 17.1182 19.8954 16.8942 20.5673Z"/>
+        </svg>
+      </span>
+      <span class="tab__label">Abilities</span>
     </button>
     <button class="tab" data-go="powers" aria-label="Powers" title="Powers" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5L14.25 2.25L12 10.5H20.25L9.75 21.75L12 13.5H3.75Z"/>
-      </svg>
+      <span class="tab__icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5L14.25 2.25L12 10.5H20.25L9.75 21.75L12 13.5H3.75Z"/>
+        </svg>
+      </span>
+      <span class="tab__label">Powers</span>
     </button>
     <button class="tab" data-go="gear" aria-label="Gear" title="Gear" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M20.38 3.46 16 2a4 4 0 0 1-8 0L3.62 3.46a2 2 0 0 0-1.34 2.23l.58 3.47a1 1 0 0 0 .99.84H6v10c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V10h2.15a1 1 0 0 0 .99-.84l.58-3.47a2 2 0 0 0-1.34-2.23z"/>
-      </svg>
+      <span class="tab__icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M20.38 3.46 16 2a4 4 0 0 1-8 0L3.62 3.46a2 2 0 0 0-1.34 2.23l.58 3.47a1 1 0 0 0 .99.84H6v10c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V10h2.15a1 1 0 0 0 .99-.84l.58-3.47a2 2 0 0 0-1.34-2.23z"/>
+        </svg>
+      </span>
+      <span class="tab__label">Gear</span>
     </button>
     <button class="tab" data-go="story" aria-label="Story" title="Story" role="tab" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
-      </svg>
+      <span class="tab__icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"/>
+        </svg>
+      </span>
+      <span class="tab__label">Story</span>
     </button>
   </nav>
   <div class="news-ticker" role="status" aria-live="polite" aria-labelledby="news-ticker-label" data-expand-edge>

--- a/styles/main.css
+++ b/styles/main.css
@@ -389,7 +389,38 @@ label[data-animate-title]{
   color:var(--muted);
 }
 
-.tabs .tab{justify-self:center}
+.tabs .tab{
+  justify-self:center;
+  flex-direction:column;
+  justify-content:center;
+  align-items:center;
+  gap:calc(4px * 1.15);
+  padding:clamp(6px,2.4vw,12px) clamp(10px,4vw,18px);
+  min-width:calc(var(--icon-size) * 2.6);
+  min-height:calc(var(--icon-size) * 2.8);
+  height:auto;
+  text-align:center;
+  line-height:1.2;
+  font-size:clamp(.7rem,2.8vw,.9rem);
+  font-weight:600;
+}
+
+.tabs .tab .tab__icon{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+
+.tabs .tab .tab__icon svg{
+  width:var(--icon-size);
+  height:var(--icon-size);
+}
+
+.tabs .tab .tab__label{
+  display:block;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+}
 
 .tab.active{background:var(--accent);color:var(--text-on-accent)}
 .news-ticker{


### PR DESCRIPTION
## Summary
- add visible labels beneath each primary navigation icon
- update tab styling to support stacked icon and text layout on all viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3aa968b10832ea52f30756e37f55f