### PR TITLE
Ensure hidden cards collapse when toggled

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1536,6 +1536,7 @@ progress::-moz-progress-bar{
 .sp-field #long-rest{width:100%;margin-top:8px;}
 .cap-field .cap-box{margin-top:8px;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:var(--card-padding,8px);display:flex;flex-direction:column;gap:var(--card-gap,10px);transition:box-shadow .3s ease-in-out;background:color-mix(in srgb,var(--surface) 5%,transparent);background-color:color-mix(in srgb,var(--surface) 5%,transparent);-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);margin-left:auto;margin-right:auto;width:100%;max-width:var(--content-width);font-size:1.1rem}
+.card[hidden]{display:none !important}
 .gear-card .gear-card-title{margin:0}
 .gear-card .gear-card-action{align-self:flex-start}
 .card[draggable]{cursor:grab}


### PR DESCRIPTION
## Summary
- ensure elements using the card style collapse visually when the hidden attribute is present so death saves stays hidden above 0 HP

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3aca622d0832e822d689d9dae139b