### PR TITLE
Adjust theme toggle logo sizing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -212,9 +212,10 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 
 .theme-toggle__face--front::after{
   background-image:url("../images/LOGO.PNG");
-  border-radius:14%;
-  width:68%;
-  height:68%;
+  border-radius:50%;
+  width:100%;
+  height:100%;
+  background-size:cover;
   box-shadow:0 0 12px rgba(0,0,0,.35);
 }
 
@@ -225,6 +226,8 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 
 .theme-toggle__face--back::after{
   background-image:var(--theme-toggle-icon);
+  width:60%;
+  height:60%;
 }
 
 .theme-toggle__spinner--spinning{


### PR DESCRIPTION
## Summary
- update the theme toggle front face so the Catalyst Core logo spans the full circular button
- maintain the size of the rotating theme glyphs on the back face

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3ad3e67d4832eb299b7bfe60e7ae7