### PR TITLE
Fix SP temp input overlap with caret button on small screens

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1622,6 +1622,12 @@ progress::-moz-progress-bar{
   .sp-field .inline>.bar-label{
     max-width:none;
   }
+
+  .sp-field #sp-temp{
+    flex:1 0 100%;
+    max-width:100%;
+    margin-top:var(--control-gap);
+  }
 }
 .sp-field #long-rest{width:100%;margin-top:8px;}
 .cap-field .cap-box{margin-top:8px;}


### PR DESCRIPTION
## Summary
- ensure the SP temporary input stretches to a full-width row on small screens so the caret menu button no longer overlaps it

## Testing
- not run (CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68e3d6d06fe4832e989bb6cd016f74ec