### PR TITLE
Align stat trio inputs

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -980,7 +980,7 @@ margin:0
 #statuses .status-option span{flex:1}
 .status-effects{font-size:90%}
 label{display:block;font-weight:700;margin-bottom:6px;font-size:clamp(.9rem,2.4vw,1rem)}
-.stat-trio{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
+.stat-trio{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;align-items:end}
 .stat-trio__item{display:flex;flex-direction:column;gap:6px}
 .stat-trio__item label{
   min-height:2.5em;


### PR DESCRIPTION
## Summary
- align the stat trio grid items to the bottom so the inputs share a consistent baseline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d7604e3c832e853006c6581e1d2b