### PR TITLE
Adjust initiative tool layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,11 +279,9 @@
       <div class="roll-tools__initiative">
         <div class="initiative-field">
           <label for="initiative">Initiative</label>
-          <div class="initiative-controls">
-            <input id="initiative" type="text" inputmode="numeric" pattern="[0-9]*" placeholder="auto from DEX + bonuses" readonly/>
-            <button type="button" id="roll-initiative" class="btn-sm" aria-label="Roll Initiative">Roll</button>
-          </div>
           <span id="initiative-roll-result" class="pill result" data-placeholder="Roll"></span>
+          <input id="initiative" type="text" inputmode="numeric" pattern="[0-9]*" placeholder="auto from DEX + bonuses" readonly/>
+          <button type="button" id="roll-initiative" class="btn-sm" aria-label="Roll Initiative">Roll</button>
         </div>
       </div>
     </fieldset>

--- a/styles/main.css
+++ b/styles/main.css
@@ -990,11 +990,12 @@ label{display:block;font-weight:700;margin-bottom:6px;font-size:clamp(.9rem,2.4v
 @media(max-width:480px){
   .stat-trio{grid-template-columns:repeat(auto-fit,minmax(105px,1fr));gap:10px}
 }
-.initiative-field{display:grid;grid-template-columns:auto minmax(0,1fr) auto auto;align-items:center;gap:calc(var(--roll-tools-gap,var(--control-gap))*.6)}
-.initiative-controls{display:contents}
-.initiative-controls input{min-width:0}
-.initiative-controls button{white-space:nowrap}
-.initiative-field .pill.result{margin:0;display:flex;align-items:center;justify-content:center;min-height:var(--roll-tools-pill-height,var(--control-compact-min-height));width:auto;justify-self:end;min-width:clamp(80px,20vw,120px)}
+.initiative-field{--initiative-control-height:var(--roll-tools-pill-height,var(--control-min-height));display:grid;grid-template-columns:auto auto minmax(0,1fr) auto;align-items:stretch;gap:calc(var(--roll-tools-gap,var(--control-gap))*.6)}
+.initiative-field label{align-self:center}
+.initiative-field input{min-width:0}
+.initiative-field button{white-space:nowrap;display:flex;align-items:center;justify-content:center}
+.initiative-field :is(.pill.result,input,button){min-height:var(--initiative-control-height)}
+.initiative-field .pill.result{margin:0;display:flex;align-items:center;justify-content:center;width:auto;justify-self:end;min-width:clamp(80px,20vw,120px)}
 .hp-settings__section{display:flex;flex-direction:column;gap:8px;margin-top:12px}
 .hp-settings__section:first-of-type{margin-top:0}
 .hp-settings__row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}


### PR DESCRIPTION
## Summary
- reorder the initiative tool controls to show the roll result, bonus field, and roll button on a single row
- align the initiative controls to share a consistent height for a cleaner appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3d8dfb134832e9ac3798e8de0c00b