### PR TITLE
Prevent header navigation from clipping under the safe area

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -54,7 +54,20 @@ h1{font-size:clamp(1.75rem,4.6vw,2rem);font-weight:700;color:var(--accent)}
 h2{font-size:clamp(1.35rem,3.8vw,1.5rem);font-weight:600;color:var(--accent)}
 h3{font-size:clamp(1.1rem,3.2vw,1.25rem);font-weight:600}
 h4{font-size:clamp(1rem,2.8vw,1.1rem);font-weight:600}
-header{position:sticky;top:0;z-index:20;background:var(--surface);box-shadow:var(--shadow);padding-top:calc(4px * 1.15);padding-bottom:calc(4px * 1.15);display:flex;flex-direction:column;gap:calc(6px * 1.15);isolation:isolate}
+header{
+  --header-padding-block:calc(4px * 1.15);
+  position:sticky;
+  top:0;
+  z-index:20;
+  background:var(--surface);
+  box-shadow:var(--shadow);
+  padding-top:calc(var(--header-padding-block) + env(safe-area-inset-top, 0px));
+  padding-bottom:var(--header-padding-block);
+  display:flex;
+  flex-direction:column;
+  gap:calc(6px * 1.15);
+  isolation:isolate;
+}
 header.hide-tabs .tabs{opacity:0;pointer-events:none;transform:translateY(calc(-10px * 1.15))}
 header::before{content:none}
 @supports ((-webkit-backdrop-filter:blur(0)) or (backdrop-filter:blur(0))){
@@ -105,6 +118,8 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
   margin-inline:0;
   padding-left:calc(clamp(16px, 5vw, 32px) + env(safe-area-inset-left, 0px));
   padding-right:calc(clamp(16px, 5vw, 32px) + env(safe-area-inset-right, 0px));
+  margin-top:calc(-1 * env(safe-area-inset-top, 0px));
+  padding-top:env(safe-area-inset-top, 0px);
 }
 
 @media(max-width:600px){
@@ -123,6 +138,15 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
   max-width:100%;
   margin-inline:0;
   transition:opacity .4s ease,transform .4s ease;
+  position:sticky;
+  top:calc(env(safe-area-inset-top, 0px) + var(--header-padding-block));
+  z-index:5;
+  padding-left:calc(clamp(16px, 5vw, 32px) + env(safe-area-inset-left, 0px));
+  padding-right:calc(clamp(16px, 5vw, 32px) + env(safe-area-inset-right, 0px));
+  margin-left:calc(-1 * env(safe-area-inset-left, 0px));
+  margin-right:calc(-1 * env(safe-area-inset-right, 0px));
+  background:color-mix(in srgb,var(--surface) 94%, transparent);
+  backdrop-filter:blur(8px);
 }
 .tabs-title{
   padding:0 8px;


### PR DESCRIPTION
## Summary
- add a header padding variable that respects the device safe-area inset to keep the navigation rail clear of the top edge
- make the tab bar sticky with safe-area aware spacing and backdrop styling so it stays visible when the top row scrolls away

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3f80000b0832e82fc359cec8fc8b4