### PR TITLE
Adjust welcome modal button sizing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1888,6 +1888,7 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
 #modal-welcome .modal{font-size:.85rem;line-height:1.4}
 #modal-welcome{align-items:center;justify-content:center}
 #modal-welcome .actions{justify-content:center;width:100%;flex-wrap:nowrap;gap:var(--control-gap)}
+#modal-welcome .actions button{font-size:.8rem;padding:8px 12px;white-space:nowrap;flex:0 0 auto}
 #modal-welcome .welcome-modal__title{display:inline-flex;flex-wrap:wrap;gap:4px;align-items:baseline}
 #modal-welcome .welcome-modal__title-break{display:inline}
 #modal-welcome .welcome-modal__tab-label{text-decoration:underline;text-decoration-thickness:.08em;text-decoration-skip-ink:auto}


### PR DESCRIPTION
## Summary
- reduce the size of the welcome modal buttons to better fit the layout
- ensure button labels stay on a single line by preventing text wrapping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e411cc2cb0832e94641cf1380f09c4