### PR TITLE
Align header title and relax view mode lockouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,7 +469,7 @@
   </fieldset>
 
   <!-- ABILITIES -->
-  <fieldset data-tab="abilities" class="card">
+  <fieldset data-tab="abilities" class="card" data-view-lock>
     <h2 class="card-title">Ability Scores</h2>
     <div id="abil-grid" class="grid ability-grid"></div>
     <fieldset class="card">
@@ -609,13 +609,13 @@
   <fieldset data-tab="story" class="card">
     <h2 class="card-title">Character and Story</h2>
     <div class="grid grid-2">
-      <div class="card"><label for="superhero">Superhero Identity</label><input id="superhero" placeholder="Vigilante Name"/></div>
-      <div class="card"><label for="secret">Secret Identity</label><input id="secret" placeholder="Real name"/></div>
-      <div class="card">
+      <div class="card" data-view-lock><label for="superhero">Superhero Identity</label><input id="superhero" placeholder="Vigilante Name"/></div>
+      <div class="card" data-view-lock><label for="secret">Secret Identity</label><input id="secret" placeholder="Real name"/></div>
+      <div class="card" data-view-lock>
         <label for="publicIdentity">Public Identity</label>
         <select id="publicIdentity"><option value="Public">Public</option><option value="Secret" selected>Secret</option></select>
       </div>
-      <div class="card">
+      <div class="card" data-view-lock>
         <label for="tier">Tier</label>
         <input id="tier" type="text" readonly/>
       </div>
@@ -638,7 +638,7 @@
           <button id="xp-submit" class="btn-sm">Submit</button>
         </div>
       </div>
-      <div class="card">
+      <div class="card" data-view-lock>
         <label for="alignment">Alignment</label>
         <select id="alignment">
           <option value="">Select one</option>
@@ -654,14 +654,14 @@
         </select>
         <ul id="alignment-perks" class="perk-list"></ul>
       </div>
-      <div class="card">
+      <div class="card" data-view-lock>
         <label for="classification">Classification</label>
         <select id="classification">
           <option value="">Select one</option><option>Mutant</option><option>Enhanced Human</option><option>Magic User</option><option>Alien/Extraterrestrial</option><option>Mystical Being</option>
         </select>
         <ul id="classification-perks" class="perk-list"></ul>
       </div>
-      <div class="card">
+      <div class="card" data-view-lock>
         <label for="power-style">Primary Power Style</label>
         <select id="power-style">
           <option value="">Select one</option><option>Physical Powerhouse</option><option>Energy Manipulator</option><option>Speedster</option>
@@ -669,7 +669,7 @@
         </select>
         <ul id="power-style-perks" class="perk-list"></ul>
       </div>
-      <div class="card">
+      <div class="card" data-view-lock>
         <label for="power-style-2">Secondary Power Style</label>
         <select id="power-style-2">
           <option value="">Select one</option>
@@ -678,7 +678,7 @@
           <option>Telekinetic/Psychic</option><option>Illusionist</option><option>Shape-shifter</option><option>Elemental Controller</option>
         </select>
       </div>
-      <div class="card">
+      <div class="card" data-view-lock>
         <label for="origin">Origin Story</label>
         <select id="origin">
           <option value="">Select one</option>
@@ -816,30 +816,30 @@
 
     </div>
 
-    <div class="card">
+    <div class="card" data-view-lock>
       <label for="story-notes" data-animate-title>Backstory / Notes</label>
       <textarea id="story-notes" rows="6" placeholder="Key events, allies, vulnerabilities, research/training notes, etc."></textarea>
     </div>
       <h3>Character Questions</h3>
     <div class="grid grid-1">
-      <div class="card"><label for="q-mask">Who are you behind the mask?</label><textarea id="q-mask" rows="2"></textarea></div>
-      <div class="card"><label for="q-justice">What does justice mean to you?</label><textarea id="q-justice" rows="2"></textarea></div>
-      <div class="card"><label for="q-fear">What is your biggest fear or unresolved trauma?</label><textarea id="q-fear" rows="2"></textarea></div>
-      <div class="card"><label for="q-first-power">What moment first defined your sense of power—was it thrilling, terrifying, or tragic?</label><textarea id="q-first-power" rows="2"></textarea></div>
-      <div class="card"><label for="q-origin-meaning">What does your Origin Story mean to you now?</label><textarea id="q-origin-meaning" rows="2"></textarea></div>
-      <div class="card"><label for="q-before-powers">What was your life like before you had powers or before you remembered having them?</label><textarea id="q-before-powers" rows="2"></textarea></div>
-      <div class="card"><label for="q-power-scare">What is one way your powers scare even you?</label><textarea id="q-power-scare" rows="2"></textarea></div>
-      <div class="card"><label for="q-signature-move">What is your signature move or ability, and how does it reflect who you are?</label><textarea id="q-signature-move" rows="2"></textarea></div>
-      <div class="card"><label for="q-emotional">What happens to your powers when you are emotionally compromised?</label><textarea id="q-emotional" rows="2"></textarea></div>
-      <div class="card"><label for="q-no-line">What line will you never cross even if the world burns around you?</label><textarea id="q-no-line" rows="2"></textarea></div>
-      <div class="card"><label for="q-alignment-fear">Which Alignment do you identify with, and which do you fear becoming?</label><textarea id="q-alignment-fear" rows="2"></textarea></div>
-      <div class="card"><label for="q-opinion">Whose opinion matters more to you—civilians, teammates, or your faction superiors? Why?</label><textarea id="q-opinion" rows="2"></textarea></div>
-      <div class="card"><label for="q-drive">What drives you to fight—justice, guilt, revenge, legacy, redemption, or something else?</label><textarea id="q-drive" rows="2"></textarea></div>
-      <div class="card"><label for="q-walk-away">What would make you walk away from this life for good?</label><textarea id="q-walk-away" rows="2"></textarea></div>
-      <div class="card"><label for="q-secret">What is one major secret you are keeping from the rest of the team?</label><textarea id="q-secret" rows="2"></textarea></div>
-      <div class="card"><label for="q-vulnerable">What situation leaves you the most vulnerable—physically, emotionally, or strategically?</label><textarea id="q-vulnerable" rows="2"></textarea></div>
-      <div class="card"><label for="q-admire">Which teammate do you admire the most and what do they have that you lack?</label><textarea id="q-admire" rows="2"></textarea></div>
-      <div class="card"><label for="q-if-lost">If you lost your powers tomorrow, who would you still be?</label><textarea id="q-if-lost" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-mask">Who are you behind the mask?</label><textarea id="q-mask" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-justice">What does justice mean to you?</label><textarea id="q-justice" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-fear">What is your biggest fear or unresolved trauma?</label><textarea id="q-fear" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-first-power">What moment first defined your sense of power—was it thrilling, terrifying, or tragic?</label><textarea id="q-first-power" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-origin-meaning">What does your Origin Story mean to you now?</label><textarea id="q-origin-meaning" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-before-powers">What was your life like before you had powers or before you remembered having them?</label><textarea id="q-before-powers" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-power-scare">What is one way your powers scare even you?</label><textarea id="q-power-scare" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-signature-move">What is your signature move or ability, and how does it reflect who you are?</label><textarea id="q-signature-move" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-emotional">What happens to your powers when you are emotionally compromised?</label><textarea id="q-emotional" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-no-line">What line will you never cross even if the world burns around you?</label><textarea id="q-no-line" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-alignment-fear">Which Alignment do you identify with, and which do you fear becoming?</label><textarea id="q-alignment-fear" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-opinion">Whose opinion matters more to you—civilians, teammates, or your faction superiors? Why?</label><textarea id="q-opinion" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-drive">What drives you to fight—justice, guilt, revenge, legacy, redemption, or something else?</label><textarea id="q-drive" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-walk-away">What would make you walk away from this life for good?</label><textarea id="q-walk-away" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-secret">What is one major secret you are keeping from the rest of the team?</label><textarea id="q-secret" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-vulnerable">What situation leaves you the most vulnerable—physically, emotionally, or strategically?</label><textarea id="q-vulnerable" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-admire">Which teammate do you admire the most and what do they have that you lack?</label><textarea id="q-admire" rows="2"></textarea></div>
+      <div class="card" data-view-lock><label for="q-if-lost">If you lost your powers tomorrow, who would you still be?</label><textarea id="q-if-lost" rows="2"></textarea></div>
     </div>
   </fieldset>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1640,9 +1640,16 @@ function hasViewAllow(el){
   return !!el.closest('[data-view-allow]');
 }
 
+function hasViewLock(el){
+  if (!el || !el.closest) return false;
+  if (el.dataset && Object.prototype.hasOwnProperty.call(el.dataset, 'viewLock')) return true;
+  return !!el.closest('[data-view-lock]');
+}
+
 function shouldTransformElement(el){
   if (!el || el.nodeType !== Node.ELEMENT_NODE) return false;
   if (hasViewAllow(el)) return false;
+  if (!hasViewLock(el)) return false;
   const tag = el.tagName;
   if (tag === 'TEXTAREA' || tag === 'SELECT') return true;
   if (tag === 'INPUT') {

--- a/src/header-title.jsx
+++ b/src/header-title.jsx
@@ -54,6 +54,19 @@ function renderHeaderTitle() {
   const titleEl = document.querySelector('.tabs-title');
   if (!titleEl) return;
 
+  const headerRow = titleEl.closest('.top');
+  if (headerRow) {
+    const logoButton = headerRow.querySelector('.logo-button');
+    const menuContainer = headerRow.querySelector('.dropdown');
+    if (logoButton && menuContainer) {
+      if (logoButton.nextElementSibling !== titleEl) {
+        headerRow.insertBefore(titleEl, menuContainer);
+      } else if (titleEl.nextElementSibling !== menuContainer) {
+        headerRow.insertBefore(menuContainer, titleEl.nextSibling);
+      }
+    }
+  }
+
   const textNodes = Array.from(titleEl.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
   textNodes.forEach(node => titleEl.removeChild(node));
 
@@ -67,6 +80,13 @@ function renderHeaderTitle() {
   const logo = titleEl.querySelector('.logo');
   if (logo && logo.nextSibling !== mountNode) {
     titleEl.insertBefore(mountNode, logo.nextSibling);
+  }
+
+  if (!logo) {
+    const themeButton = headerRow?.querySelector('.logo-button');
+    if (themeButton && themeButton.nextElementSibling === titleEl && titleEl.firstChild !== mountNode) {
+      titleEl.appendChild(mountNode);
+    }
   }
 
   if (!rootInstance) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -124,11 +124,12 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 
 @media(max-width:600px){
   .top{
-    grid-template-columns:minmax(0, 1fr) auto;
-    grid-template-areas:
-      "logo menu"
-      "title title";
-    row-gap:clamp(10px, 3vw, 14px);
+    grid-template-columns:auto minmax(0, 1fr) auto;
+    grid-template-areas:"logo title menu";
+    row-gap:clamp(8px, 3vw, 12px);
+  }
+  .tabs-title{
+    justify-self:center;
   }
 }
 .tabs{


### PR DESCRIPTION
## Summary
- keep the header title positioned between the theme toggle and menu across breakpoints
- update the view mode helper to respect new data-view-lock markers so player controls remain usable
- mark ability and story-only sections as read-only while leaving gameplay adjustments interactive

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e42e19cdac832e9bda7f1496a0bee1