### PR TITLE
Limit view mode lock to story and ability scores

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,9 +469,9 @@
   </fieldset>
 
   <!-- ABILITIES -->
-  <fieldset data-tab="abilities" class="card" data-view-lock>
+  <fieldset data-tab="abilities" class="card">
     <h2 class="card-title">Ability Scores</h2>
-    <div id="abil-grid" class="grid ability-grid"></div>
+    <div id="abil-grid" class="grid ability-grid" data-view-lock></div>
     <fieldset class="card">
       <legend data-animate-title>Proficiency and Power</legend>
       <div class="proficiency-card__grid">


### PR DESCRIPTION
## Summary
- keep the abilities tab interactive in view mode by removing the global view lock from the section
- keep ability score selectors view-only by applying the lock directly to the ability grid container

## Testing
- npm test -- __tests__/new_character.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4a3a330dc832ebf4e712cb72c05ae