### PR TITLE
Add per-card editing toggles for view mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,6 @@
       </button>
       <div id="menu-actions" class="menu" hidden>
         <button id="btn-load" class="btn-sm">Load / Save</button>
-        <button id="btn-view-mode" class="btn-sm" type="button" aria-pressed="false" title="Switch to View Mode">View Character</button>
         <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
         <button id="btn-log" class="btn-sm">Action Log</button>
         <button id="btn-campaign" class="btn-sm">Campaign Log</button>
@@ -320,14 +319,16 @@
       </div>
     </fieldset>
     <div class="grid grid-1">
-      <fieldset class="card hp-field card--has-caret">
-        <legend data-animate-title>HP</legend>
-        <button type="button" class="card-caret" id="hp-settings-toggle" aria-haspopup="dialog" aria-expanded="false" aria-controls="modal-hp-settings">
-          <span class="sr-only">Open HP options</span>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4"/>
-          </svg>
-        </button>
+      <fieldset class="card hp-field">
+        <legend class="card-legend card-legend--actions" data-animate-title>
+          <span class="card-legend__title">HP</span>
+          <button type="button" class="card-caret" id="hp-settings-toggle" aria-haspopup="dialog" aria-expanded="false" aria-controls="modal-hp-settings">
+            <span class="sr-only">Open HP options</span>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4"/>
+            </svg>
+          </button>
+        </legend>
         <input id="hp-roll" type="hidden" value="0"/>
         <div class="inline">
           <div class="bar-label">
@@ -344,14 +345,16 @@
           <button id="hp-heal" class="btn-sm">Heal</button>
         </div>
       </fieldset>
-      <fieldset class="card sp-field card--has-caret">
-        <legend data-animate-title>SP</legend>
-        <button type="button" class="card-caret" id="sp-menu-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="sp-menu">
-          <span class="sr-only">Open SP options</span>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4"/>
-          </svg>
-        </button>
+      <fieldset class="card sp-field">
+        <legend class="card-legend card-legend--actions" data-animate-title>
+          <span class="card-legend__title">SP</span>
+          <button type="button" class="card-caret" id="sp-menu-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="sp-menu">
+            <span class="sr-only">Open SP options</span>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4"/>
+            </svg>
+          </button>
+        </legend>
         <div class="inline">
           <div class="bar-label">
             <progress id="sp-bar" max="5" value="5"></progress>
@@ -469,8 +472,22 @@
   </fieldset>
 
   <!-- ABILITIES -->
-  <fieldset data-tab="abilities" class="card">
-    <h2 class="card-title">Ability Scores</h2>
+  <fieldset data-tab="abilities" class="card" id="card-abilities">
+    <div class="card-toolbar">
+      <h2 class="card-title card-toolbar__title" id="card-abilities-title">Ability Scores</h2>
+      <div class="card-toolbar__actions">
+        <button
+          type="button"
+          class="btn-sm card-edit-toggle"
+          data-view-target="#card-abilities"
+          data-view-label="Ability Scores"
+          aria-describedby="card-abilities-title"
+        >
+          <span class="btn-icon" aria-hidden="true">✎</span>
+          <span class="btn-label card-edit-toggle__label">Edit</span>
+        </button>
+      </div>
+    </div>
     <div id="abil-grid" class="grid ability-grid" data-view-lock></div>
     <fieldset class="card">
       <legend data-animate-title>Proficiency and Power</legend>
@@ -606,8 +623,22 @@
   </fieldset>
 
   <!-- STORY -->
-  <fieldset data-tab="story" class="card">
-    <h2 class="card-title">Character and Story</h2>
+  <fieldset data-tab="story" class="card" id="card-story">
+    <div class="card-toolbar">
+      <h2 class="card-title card-toolbar__title" id="card-story-title">Character and Story</h2>
+      <div class="card-toolbar__actions">
+        <button
+          type="button"
+          class="btn-sm card-edit-toggle"
+          data-view-target="#card-story"
+          data-view-label="Character and Story"
+          aria-describedby="card-story-title"
+        >
+          <span class="btn-icon" aria-hidden="true">✎</span>
+          <span class="btn-label card-edit-toggle__label">Edit</span>
+        </button>
+      </div>
+    </div>
     <div class="grid grid-2">
       <div class="card" data-view-lock><label for="superhero">Superhero Identity</label><input id="superhero" placeholder="Vigilante Name"/></div>
       <div class="card" data-view-lock><label for="secret">Secret Identity</label><input id="secret" placeholder="Real name"/></div>
@@ -990,7 +1021,7 @@
       </li>
       <li>
         <b>Main Menu</b>
-        The header menu button opens overlays for Load / Save, Edit Character, Encounter / Initiative, Action Log, Campaign Log, Rules,
+        The header menu button opens overlays for Load / Save, Encounter / Initiative, Action Log, Campaign Log, Rules,
         and this Help screen. Each modal floats above the sheet so you never lose context, and you can close any of them with Esc
         or by tapping outside.
       </li>
@@ -1021,9 +1052,9 @@
     <h4>Session Tools</h4>
     <ul class="feature-list">
       <li>
-        <b>Edit Character</b>
-        Choose <i>Edit Character</i> from the menu to unlock the sheet for updates. When you're finished adjusting stats or notes,
-        select <i>View Character</i> to return to the read-only layout and avoid accidental changes during play.
+        <b>Card Editing</b>
+        Use the edit buttons on the Ability Scores and Character and Story cards to unlock those sections for updates. Toggle the
+        button again to relock the cards and avoid accidental changes during play.
       </li>
       <li>
         <b>Encounter / Initiative</b>

--- a/styles/main.css
+++ b/styles/main.css
@@ -940,13 +940,13 @@ main>:last-child{margin-bottom:0}
 fieldset[data-tab].card.active{opacity:1;transform:translate3d(0,0,0);pointer-events:auto;visibility:visible;filter:blur(0)saturate(1);position:relative;inset:auto;margin-bottom:14px}
 fieldset[data-tab].card>legend{font-size:clamp(1.1rem,3.4vw,1.5rem);font-weight:600;color:var(--accent);margin:0 0 6px;font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;letter-spacing:var(--title-letter-spacing);word-spacing:var(--title-word-spacing)}
 .card{position:relative}
-.card .card-caret{position:absolute;top:10px;right:10px;width:clamp(28px,6vw,34px);height:clamp(28px,6vw,34px);border-radius:8px;border:1px solid transparent;display:inline-flex;align-items:center;justify-content:center;background:var(--surface-2);color:var(--text);cursor:pointer;padding:0;transition:background .2s ease,border-color .2s ease,transform .2s ease}
-.card--has-caret{padding-right:calc(var(--card-padding, 8px) + clamp(28px, 6vw, 34px) + 8px)}
-.card--has-caret>legend{padding-right:calc(clamp(28px, 6vw, 34px) + 8px)}
-.card--has-caret .card-caret{top:var(--card-padding, 8px);right:var(--card-padding, 8px)}
+.card .card-caret{width:clamp(28px,6vw,34px);height:clamp(28px,6vw,34px);border-radius:8px;border:1px solid transparent;display:inline-flex;align-items:center;justify-content:center;background:var(--surface-2);color:var(--text);cursor:pointer;padding:0;transition:background .2s ease,border-color .2s ease,transform .2s ease;margin-inline-start:auto}
 .card .card-caret svg{width:clamp(14px,4vw,18px);height:clamp(14px,4vw,18px)}
 .card .card-caret:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .card .card-caret:hover{background:color-mix(in srgb,var(--surface-2) 80%,var(--accent) 20%);border-color:color-mix(in srgb,var(--accent) 35%,transparent)}
+.card-legend--actions{display:flex;align-items:center;gap:var(--control-gap);padding:0}
+.card-legend__title{flex:1 1 auto;display:flex;align-items:center;gap:var(--control-gap);font:inherit}
+.card-legend--actions .card-caret{margin-inline-start:auto;position:static}
 .card-menu{position:absolute;top:calc(var(--card-padding, 8px) + clamp(28px,6vw,34px) + var(--control-min-height) + var(--control-gap));right:var(--card-padding, 8px);background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:6px;display:flex;flex-direction:column;gap:6px;min-width:clamp(140px,48vw,200px);max-width:calc(100vw - 24px);width:max-content;max-height:var(--card-menu-max-height, none);overflow-x:hidden;overflow-y:auto;transform:translateX(calc(var(--card-menu-offset-x, 0px) * -1));z-index:5}
 .card-menu__item{width:100%;min-height:var(--control-compact-min-height);padding:clamp(6px,2.2vw,10px);font-size:clamp(.8rem,2.5vw,.95rem);background:var(--surface-2);border:1px solid transparent;border-radius:var(--radius);cursor:pointer;text-align:left}
 .card-menu__item:hover,.card-menu__item:focus-visible{background:color-mix(in srgb,var(--accent) 18%,var(--surface-2));border-color:color-mix(in srgb,var(--accent) 35%,transparent);outline:none}


### PR DESCRIPTION
## Summary
- replace the global Edit Character menu option with inline edit buttons on the Ability Scores and Character and Story cards
- update the view mode system to allow per-card unlocking and position the HP/SP caret controls beside their titles
- refresh help content and styling to reflect the revised editing flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4aad253a4832e9bb6ccea204640c8