### PR TITLE
Fix power menu toggle and ensure signature editor visible

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -8782,7 +8782,7 @@ function setupPowerPresetMenu() {
 
   document.addEventListener('click', event => {
     if (menu.dataset.open !== 'true') return;
-    if (event.target === addBtn || menu.contains(event.target)) return;
+    if ((addBtn && addBtn.contains(event.target)) || menu.contains(event.target)) return;
     hideMenu();
   });
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -2482,6 +2482,7 @@ body.touch-controls-disabled.somf-reveal-active .app-shell> :not(.somf-reveal-al
 body.is-view-mode .power-card{gap:calc(var(--control-gap)*.75)}
 body.is-view-mode .power-card__summary{display:flex}
 body.is-view-mode .power-card__body{display:none}
+body.is-view-mode .power-editor__content .power-card__body{display:flex}
 
 .power-preset-menu__groups{display:flex;flex-direction:column;gap:var(--control-gap)}
 .power-preset-menu__group{border:1px solid var(--line);border-radius:var(--radius);background:var(--surface-2);overflow:hidden}


### PR DESCRIPTION
## Summary
- prevent outside-click handler from closing the power preset menu when clicking inside the Add Power button
- keep signature move editor content visible even while the app is in view mode

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4af853a28832e8b1b3455f4fd59dc