### PR TITLE
Adjust header navigation spacing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -134,9 +134,9 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
 }
 .tabs{
   display:flex;
-  justify-content:center;
+  justify-content:space-evenly;
   align-items:stretch;
-  gap:calc(4px * 1.15);
+  gap:0;
   flex-wrap:wrap;
   width:100%;
   max-width:100%;
@@ -145,8 +145,8 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
   position:sticky;
   top:calc(env(safe-area-inset-top, 0px) + var(--header-padding-block));
   z-index:5;
-  padding-left:calc(clamp(16px, 5vw, 32px) + env(safe-area-inset-left, 0px));
-  padding-right:calc(clamp(16px, 5vw, 32px) + env(safe-area-inset-right, 0px));
+  padding-left:env(safe-area-inset-left, 0px);
+  padding-right:env(safe-area-inset-right, 0px);
   margin-left:calc(-1 * env(safe-area-inset-left, 0px));
   margin-right:calc(-1 * env(safe-area-inset-right, 0px));
   background:color-mix(in srgb,var(--surface) 94%, transparent);


### PR DESCRIPTION
## Summary
- space the header navigation tabs evenly so outer gaps match the gaps between buttons
- remove excess horizontal padding so the first and last tab align with the screen edge safe areas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4c2a06d5c832e999e1a498152c58e