### PR TITLE
Update HP/SP edit affordances and improve card toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,10 +322,30 @@
       <fieldset class="card hp-field">
         <legend class="card-legend card-legend--actions" data-animate-title>
           <span class="card-legend__title">HP</span>
-          <button type="button" class="card-caret" id="hp-settings-toggle" aria-haspopup="dialog" aria-expanded="false" aria-controls="modal-hp-settings">
-            <span class="sr-only">Open HP options</span>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4"/>
+          <button
+            type="button"
+            class="card-caret"
+            id="hp-settings-toggle"
+            aria-haspopup="dialog"
+            aria-expanded="false"
+            aria-controls="modal-hp-settings"
+            aria-label="Edit HP options"
+            title="Edit HP options"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M3 17.25V21h3.75L19.81 7.94a1.5 1.5 0 0 0 0-2.12l-2.63-2.63a1.5 1.5 0 0 0-2.12 0L3 15.38z"
+              />
+              <path stroke-linecap="round" d="M14.75 4.25l4 4" />
             </svg>
           </button>
         </legend>
@@ -348,10 +368,30 @@
       <fieldset class="card sp-field">
         <legend class="card-legend card-legend--actions" data-animate-title>
           <span class="card-legend__title">SP</span>
-          <button type="button" class="card-caret" id="sp-menu-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="sp-menu">
-            <span class="sr-only">Open SP options</span>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4"/>
+          <button
+            type="button"
+            class="card-caret"
+            id="sp-menu-toggle"
+            aria-haspopup="true"
+            aria-expanded="false"
+            aria-controls="sp-menu"
+            aria-label="Edit SP options"
+            title="Edit SP options"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M3 17.25V21h3.75L19.81 7.94a1.5 1.5 0 0 0 0-2.12l-2.63-2.63a1.5 1.5 0 0 0-2.12 0L3 15.38z"
+              />
+              <path stroke-linecap="round" d="M14.75 4.25l4 4" />
             </svg>
           </button>
         </legend>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2251,7 +2251,6 @@ function initCardEditToggles(){
     button.addEventListener('click', () => {
       if (mode !== 'view') {
         setMode('view');
-        return;
       }
       state.unlocked = !state.unlocked;
       applyCardEditToggleState(button, state);


### PR DESCRIPTION
## Summary
- replace the HP and SP caret buttons with pencil icons and aria labels that communicate editability
- ensure card edit toggles unlock their sections on the first click even after switching out of the global edit mode

## Testing
- npm test -- --runTestsByPath __tests__/helpers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4f3c546f8832e953622acf6f25262