### PR TITLE
Reduce checkbox indicator size

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1087,8 +1087,8 @@ input[type="checkbox"]{
   appearance:none;
   flex:0 0 auto;
   margin:0 4px 0 0;
-  inline-size:var(--control-indicator-size);
-  block-size:var(--control-indicator-size);
+  inline-size:calc(var(--control-indicator-size) * .5);
+  block-size:calc(var(--control-indicator-size) * .5);
   display:inline-flex;
   align-items:center;
   justify-content:center;


### PR DESCRIPTION
## Summary
- shrink all checkbox indicators to half their previous size by adjusting the CSS control sizing variables

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e4f8f714d8832e86d03b0a620601ae