### PR TITLE
Fix inline edit controls and legend duplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,19 +321,21 @@
     <div class="grid grid-1">
       <fieldset class="card hp-field">
         <legend class="card-legend card-legend--actions" data-animate-title>
-          <span class="card-legend__title">HP</span>
-          <button
-            type="button"
-            class="card-caret"
-            id="hp-settings-toggle"
-            aria-haspopup="dialog"
-            aria-expanded="false"
-            aria-controls="modal-hp-settings"
-            aria-label="Edit HP options"
-            title="Edit HP options"
-          >
-            <span class="btn-icon" aria-hidden="true">✎</span>
-          </button>
+          <span class="card-legend__content">
+            <span class="card-legend__title">HP</span>
+            <button
+              type="button"
+              class="card-caret"
+              id="hp-settings-toggle"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-controls="modal-hp-settings"
+              aria-label="Edit HP options"
+              title="Edit HP options"
+            >
+              <span class="btn-icon" aria-hidden="true">✎</span>
+            </button>
+          </span>
         </legend>
         <input id="hp-roll" type="hidden" value="0"/>
         <div class="inline">
@@ -353,19 +355,21 @@
       </fieldset>
       <fieldset class="card sp-field">
         <legend class="card-legend card-legend--actions" data-animate-title>
-          <span class="card-legend__title">SP</span>
-          <button
-            type="button"
-            class="card-caret"
-            id="sp-menu-toggle"
-            aria-haspopup="true"
-            aria-expanded="false"
-            aria-controls="sp-menu"
-            aria-label="Edit SP options"
-            title="Edit SP options"
-          >
-            <span class="btn-icon" aria-hidden="true">✎</span>
-          </button>
+          <span class="card-legend__content">
+            <span class="card-legend__title">SP</span>
+            <button
+              type="button"
+              class="card-caret"
+              id="sp-menu-toggle"
+              aria-haspopup="true"
+              aria-expanded="false"
+              aria-controls="sp-menu"
+              aria-label="Edit SP options"
+              title="Edit SP options"
+            >
+              <span class="btn-icon" aria-hidden="true">✎</span>
+            </button>
+          </span>
         </legend>
         <div class="inline">
           <div class="bar-label">
@@ -486,8 +490,8 @@
   <!-- ABILITIES -->
   <fieldset data-tab="abilities" class="card" id="card-abilities">
     <div class="card-toolbar">
-      <h2 class="card-title card-toolbar__title" id="card-abilities-title">Ability Scores</h2>
-      <div class="card-toolbar__actions">
+      <h2 class="card-title card-toolbar__title card-toolbar__title--inline" id="card-abilities-title">
+        <span class="card-toolbar__title-text">Ability Scores</span>
         <button
           type="button"
           class="btn-sm card-edit-toggle"
@@ -498,7 +502,7 @@
           <span class="btn-icon" aria-hidden="true">✎</span>
           <span class="btn-label card-edit-toggle__label sr-only">Edit</span>
         </button>
-      </div>
+      </h2>
     </div>
     <div id="abil-grid" class="grid ability-grid" data-view-lock></div>
     <fieldset class="card">
@@ -637,8 +641,8 @@
   <!-- STORY -->
   <fieldset data-tab="story" class="card" id="card-story">
     <div class="card-toolbar">
-      <h2 class="card-title card-toolbar__title" id="card-story-title">Character and Story</h2>
-      <div class="card-toolbar__actions">
+      <h2 class="card-title card-toolbar__title card-toolbar__title--inline" id="card-story-title">
+        <span class="card-toolbar__title-text">Character and Story</span>
         <button
           type="button"
           class="btn-sm card-edit-toggle"
@@ -649,7 +653,7 @@
           <span class="btn-icon" aria-hidden="true">✎</span>
           <span class="btn-label card-edit-toggle__label sr-only">Edit</span>
         </button>
-      </div>
+      </h2>
     </div>
     <div class="grid grid-2">
       <div class="card" data-view-lock><label for="superhero">Superhero Identity</label><input id="superhero" placeholder="Vigilante Name"/></div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -944,9 +944,10 @@ fieldset[data-tab].card>legend{font-size:clamp(1.1rem,3.4vw,1.5rem);font-weight:
 .card .card-caret svg{width:clamp(14px,4vw,18px);height:clamp(14px,4vw,18px)}
 .card .card-caret:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .card .card-caret:hover{background:color-mix(in srgb,var(--surface-2) 80%,var(--accent) 20%);border-color:color-mix(in srgb,var(--accent) 35%,transparent)}
-.card-legend--actions{display:flex;align-items:center;gap:var(--control-gap);padding:0}
+.card-legend--actions{padding:0}
+.card-legend__content{display:flex;align-items:center;gap:var(--control-gap)}
 .card-legend__title{flex:1 1 auto;display:flex;align-items:center;gap:var(--control-gap);font:inherit}
-.card-legend--actions .card-caret{margin-inline-start:auto;position:static}
+.card-legend__content .card-caret{margin-inline-start:auto;position:static}
 .card-menu{position:absolute;top:calc(var(--card-padding, 8px) + clamp(28px,6vw,34px) + var(--control-min-height) + var(--control-gap));right:var(--card-padding, 8px);background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:6px;display:flex;flex-direction:column;gap:6px;min-width:clamp(140px,48vw,200px);max-width:calc(100vw - 24px);width:max-content;max-height:var(--card-menu-max-height, none);overflow-x:hidden;overflow-y:auto;transform:translateX(calc(var(--card-menu-offset-x, 0px) * -1));z-index:5}
 .card-menu__item{width:100%;min-height:var(--control-compact-min-height);padding:clamp(6px,2.2vw,10px);font-size:clamp(.8rem,2.5vw,.95rem);background:var(--surface-2);border:1px solid transparent;border-radius:var(--radius);cursor:pointer;text-align:left}
 .card-menu__item:hover,.card-menu__item:focus-visible{background:color-mix(in srgb,var(--accent) 18%,var(--surface-2));border-color:color-mix(in srgb,var(--accent) 35%,transparent);outline:none}
@@ -1137,6 +1138,14 @@ button:focus-visible,
   flex:1 1 auto;
   min-width:min(220px,100%);
 }
+.card-toolbar__title--inline{
+  display:flex;
+  align-items:center;
+  gap:var(--control-gap);
+  flex-wrap:nowrap;
+  min-width:0;
+}
+.card-toolbar__title-text{flex:1 1 auto;min-width:0}
 
 .card-toolbar__actions{
   display:flex;
@@ -1153,6 +1162,7 @@ button:focus-visible,
   .card-toolbar{justify-content:flex-start}
   .card-toolbar__title,
   .card-toolbar__label{min-width:100%}
+  .card-toolbar__title--inline{min-width:0}
   .card-toolbar__actions{width:100%;justify-content:flex-start}
 }
 


### PR DESCRIPTION
## Summary
- wrap the HP and SP legend contents to prevent duplicate titles and edit icons in Safari while preserving the edit button controls
- align the Ability Scores and Character and Story edit buttons directly beside their headings for consistent inline layout on narrow screens
- add supporting CSS utilities for the new legend and toolbar structures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e52f0a4d2c832ea8eddac7f9b58ec8