### PR TITLE
Restyle edit toggles and HP/SP controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,22 +320,30 @@
     </fieldset>
     <div class="grid grid-1">
       <fieldset class="card hp-field">
-        <legend class="card-legend card-legend--actions" data-animate-title>
-          <span class="card-legend__content">
-            <span class="card-legend__title">HP</span>
-            <button
-              type="button"
-              class="card-caret"
-              id="hp-settings-toggle"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-              aria-controls="modal-hp-settings"
-              aria-label="Edit HP options"
-              title="Edit HP options"
-            >
-              <span class="btn-icon" aria-hidden="true">✎</span>
-            </button>
-          </span>
+        <legend class="card-legend card-legend--actions card-legend--title-icon" data-animate-title>
+          <span class="card-legend__title">HP</span>
+          <button
+            type="button"
+            class="card-title-icon card-title-icon--menu"
+            id="hp-settings-toggle"
+            aria-haspopup="dialog"
+            aria-expanded="false"
+            aria-controls="modal-hp-settings"
+            aria-label="Edit HP options"
+            title="Edit HP options"
+          >
+            <svg class="card-title-icon__glyph" aria-hidden="true" viewBox="0 0 24 24">
+              <path
+                d="M7 9l5 6 5-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              ></path>
+            </svg>
+            <span class="sr-only">Edit HP options</span>
+          </button>
         </legend>
         <input id="hp-roll" type="hidden" value="0"/>
         <div class="inline">
@@ -354,22 +362,30 @@
         </div>
       </fieldset>
       <fieldset class="card sp-field">
-        <legend class="card-legend card-legend--actions" data-animate-title>
-          <span class="card-legend__content">
-            <span class="card-legend__title">SP</span>
-            <button
-              type="button"
-              class="card-caret"
-              id="sp-menu-toggle"
-              aria-haspopup="true"
-              aria-expanded="false"
-              aria-controls="sp-menu"
-              aria-label="Edit SP options"
-              title="Edit SP options"
-            >
-              <span class="btn-icon" aria-hidden="true">✎</span>
-            </button>
-          </span>
+        <legend class="card-legend card-legend--actions card-legend--title-icon" data-animate-title>
+          <span class="card-legend__title">SP</span>
+          <button
+            type="button"
+            class="card-title-icon card-title-icon--menu"
+            id="sp-menu-toggle"
+            aria-haspopup="true"
+            aria-expanded="false"
+            aria-controls="sp-menu"
+            aria-label="Edit SP options"
+            title="Edit SP options"
+          >
+            <svg class="card-title-icon__glyph" aria-hidden="true" viewBox="0 0 24 24">
+              <path
+                d="M7 9l5 6 5-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              ></path>
+            </svg>
+            <span class="sr-only">Edit SP options</span>
+          </button>
         </legend>
         <div class="inline">
           <div class="bar-label">
@@ -492,17 +508,59 @@
     <div class="card-toolbar">
       <h2 class="card-title card-toolbar__title card-toolbar__title--inline" id="card-abilities-title">
         <span class="card-toolbar__title-text">Ability Scores</span>
-        <button
-          type="button"
-          class="btn-sm card-edit-toggle"
-          data-view-target="#card-abilities"
-          data-view-label="Ability Scores"
-          aria-describedby="card-abilities-title"
-        >
-          <span class="btn-icon" aria-hidden="true">✎</span>
-          <span class="btn-label card-edit-toggle__label sr-only">Edit</span>
-        </button>
       </h2>
+      <button
+        type="button"
+        class="card-title-icon card-edit-toggle"
+        data-icon-state="edit"
+        data-view-target="#card-abilities"
+        data-view-label="Ability Scores"
+        aria-describedby="card-abilities-title"
+      >
+        <svg class="card-title-icon__glyph" aria-hidden="true" viewBox="0 0 24 24" data-icon="edit">
+          <path
+            d="M4 20h4l10.5-10.5a1 1 0 0 0 0-1.41l-3.59-3.59a1 1 0 0 0-1.41 0L3 14v6z"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linejoin="round"
+          ></path>
+          <path
+            d="M13.5 6.5l4 4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path>
+        </svg>
+        <svg class="card-title-icon__glyph" aria-hidden="true" viewBox="0 0 24 24" data-icon="save" hidden>
+          <path
+            d="M5 3h12l4 4v12a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linejoin="round"
+          ></path>
+          <path
+            d="M16 21v-6H8v6"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path>
+          <path
+            d="M8 3v5h7"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path>
+        </svg>
+        <span class="card-edit-toggle__label sr-only">Edit</span>
+      </button>
     </div>
     <div id="abil-grid" class="grid ability-grid" data-view-lock></div>
     <fieldset class="card">
@@ -643,17 +701,59 @@
     <div class="card-toolbar">
       <h2 class="card-title card-toolbar__title card-toolbar__title--inline" id="card-story-title">
         <span class="card-toolbar__title-text">Character and Story</span>
-        <button
-          type="button"
-          class="btn-sm card-edit-toggle"
-          data-view-target="#card-story"
-          data-view-label="Character and Story"
-          aria-describedby="card-story-title"
-        >
-          <span class="btn-icon" aria-hidden="true">✎</span>
-          <span class="btn-label card-edit-toggle__label sr-only">Edit</span>
-        </button>
       </h2>
+      <button
+        type="button"
+        class="card-title-icon card-edit-toggle"
+        data-icon-state="edit"
+        data-view-target="#card-story"
+        data-view-label="Character and Story"
+        aria-describedby="card-story-title"
+      >
+        <svg class="card-title-icon__glyph" aria-hidden="true" viewBox="0 0 24 24" data-icon="edit">
+          <path
+            d="M4 20h4l10.5-10.5a1 1 0 0 0 0-1.41l-3.59-3.59a1 1 0 0 0-1.41 0L3 14v6z"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linejoin="round"
+          ></path>
+          <path
+            d="M13.5 6.5l4 4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path>
+        </svg>
+        <svg class="card-title-icon__glyph" aria-hidden="true" viewBox="0 0 24 24" data-icon="save" hidden>
+          <path
+            d="M5 3h12l4 4v12a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linejoin="round"
+          ></path>
+          <path
+            d="M16 21v-6H8v6"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path>
+          <path
+            d="M8 3v5h7"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path>
+        </svg>
+        <span class="card-edit-toggle__label sr-only">Edit</span>
+      </button>
     </div>
     <div class="grid grid-2">
       <div class="card" data-view-lock><label for="superhero">Superhero Identity</label><input id="superhero" placeholder="Vigilante Name"/></div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2208,6 +2208,21 @@ function applyCardEditToggleState(button, state, { skipApply = false } = {}){
     button.textContent = effectiveUnlocked ? doneText : editText;
   }
 
+  const iconState = effectiveUnlocked ? 'save' : 'edit';
+  try {
+    button.dataset.iconState = iconState;
+  } catch {}
+  button.querySelectorAll('[data-icon]').forEach(icon => {
+    if (!icon || typeof icon.getAttribute !== 'function') return;
+    const name = icon.getAttribute('data-icon');
+    if (!name) return;
+    if (name === iconState) {
+      icon.removeAttribute('hidden');
+    } else {
+      icon.setAttribute('hidden', '');
+    }
+  });
+
   if (isViewMode) {
     state.targets.forEach(target => {
       if (effectiveUnlocked) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,4 +1,4 @@
-:root{--bg-color:#0e1117;--bg:var(--bg-color) url('../images/Dark.PNG?v=2') center/cover no-repeat fixed;--surface:#151a23;--surface-2:#0b0f16;--text:#f3f4f6;--muted:#9ca3af;--accent:#3b82f6;--accent-2:#1e40af;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#fff;--radius:clamp(10px,3vw,12px);--control-min-height:clamp(34px,7.2vw,44px);--control-compact-min-height:clamp(26px,6vw,32px);--tracker-pill-height:var(--control-min-height);--control-padding-y:clamp(8px,2.8vw,12px);--control-padding-x:clamp(10px,5vw,18px);--control-font-size:clamp(1rem,2.8vw,1.1rem);--control-gap:clamp(6px,2.6vw,12px);--icon-size:clamp(18px,5.5vw,22px);--pill-padding-y:clamp(4px,2.4vw,6px);--pill-padding-x:clamp(8px,4vw,12px);--pill-font-size:clamp(.75rem,2.6vw,.95rem);--pill-font-size-lg:clamp(.9rem,3vw,1.1rem);--select-indicator-size:clamp(14px,4.4vw,18px);--select-indicator-gap:clamp(2px,1.2vw,4px);--form-control-height:var(--control-min-height);--control-indicator-size:var(--form-control-height);--pill-min-height:var(--form-control-height);--progress-min-height:var(--form-control-height);--transition:background-color .4s ease-in-out,color .4s ease-in-out,border-color .4s ease-in-out,transform .4s ease-in-out,opacity .4s ease-in-out;--success:#16a34a;--error:#dc2626;--icon-success:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2316a34a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");--icon-error:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23dc2626' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E");--chevron:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%2020%2020'%20fill%3D'none'%20stroke%3D'currentColor'%20stroke-width%3D'2'%20stroke-linecap%3D'round'%20stroke-linejoin%3D'round'%3E%3Cpath%20d%3D'M6%208l4%204%204-4'%2F%3E%3C%2Fsvg%3E");--vh:1vh;--app-max-width:clamp(320px,96vw,1100px);--content-width:min(var(--app-max-width),100vw);--modal-width:var(--content-width);--shell-width:100vw;--card-padding:8px;--card-gap:10px;--modal-padding-block:14px;--modal-padding-inline:20px;--modal-surface-padding:16px;--modal-padding-top-offset:10px;--modal-padding-top-min:8px;--title-letter-spacing:0.05em;--title-word-spacing:0.12em;--title-character-gap:0.08em;--title-letter-spacing-uppercase:0.12em;--title-word-spacing-uppercase:0.2em;--title-space-width:clamp(0.75em,0.6em + 0.45vw,1.1em);--safe-area-top:env(safe-area-inset-top,0px);--safe-area-right:env(safe-area-inset-right,0px);--safe-area-bottom:env(safe-area-inset-bottom,0px);--safe-area-left:env(safe-area-inset-left,0px);--view-label-color:color-mix(in srgb,var(--muted) 85%, transparent);--view-value-color:var(--text);--view-helper-color:color-mix(in srgb,var(--muted) 65%, transparent);--chip-bg:color-mix(in srgb,var(--accent) 22%, var(--surface-2) 78%);--chip-text:var(--text);}
+:root{--bg-color:#0e1117;--bg:var(--bg-color) url('../images/Dark.PNG?v=2') center/cover no-repeat fixed;--surface:#151a23;--surface-2:#0b0f16;--text:#f3f4f6;--muted:#9ca3af;--accent:#3b82f6;--accent-2:#1e40af;--line:rgba(255,255,255,.12);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#fff;--radius:clamp(10px,3vw,12px);--control-min-height:clamp(34px,7.2vw,44px);--control-compact-min-height:clamp(26px,6vw,32px);--tracker-pill-height:var(--control-min-height);--control-padding-y:clamp(8px,2.8vw,12px);--control-padding-x:clamp(10px,5vw,18px);--control-font-size:clamp(1rem,2.8vw,1.1rem);--control-gap:clamp(6px,2.6vw,12px);--icon-size:clamp(18px,5.5vw,22px);--card-title-icon-size:clamp(34px,8vw,44px);--card-title-icon-glyph:clamp(16px,4.6vw,20px);--pill-padding-y:clamp(4px,2.4vw,6px);--pill-padding-x:clamp(8px,4vw,12px);--pill-font-size:clamp(.75rem,2.6vw,.95rem);--pill-font-size-lg:clamp(.9rem,3vw,1.1rem);--select-indicator-size:clamp(14px,4.4vw,18px);--select-indicator-gap:clamp(2px,1.2vw,4px);--form-control-height:var(--control-min-height);--control-indicator-size:var(--form-control-height);--pill-min-height:var(--form-control-height);--progress-min-height:var(--form-control-height);--transition:background-color .4s ease-in-out,color .4s ease-in-out,border-color .4s ease-in-out,transform .4s ease-in-out,opacity .4s ease-in-out;--success:#16a34a;--error:#dc2626;--icon-success:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2316a34a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");--icon-error:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23dc2626' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E");--chevron:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2Fsvg'%20viewBox%3D'0%200%2020%2020'%20fill%3D'none'%20stroke%3D'currentColor'%20stroke-width%3D'2'%20stroke-linecap%3D'round'%20stroke-linejoin%3D'round'%3E%3Cpath%20d%3D'M6%208l4%204%204-4'%2F%3E%3C%2Fsvg%3E");--vh:1vh;--app-max-width:clamp(320px,96vw,1100px);--content-width:min(var(--app-max-width),100vw);--modal-width:var(--content-width);--shell-width:100vw;--card-padding:8px;--card-gap:10px;--modal-padding-block:14px;--modal-padding-inline:20px;--modal-surface-padding:16px;--modal-padding-top-offset:10px;--modal-padding-top-min:8px;--title-letter-spacing:0.05em;--title-word-spacing:0.12em;--title-character-gap:0.08em;--title-letter-spacing-uppercase:0.12em;--title-word-spacing-uppercase:0.2em;--title-space-width:clamp(0.75em,0.6em + 0.45vw,1.1em);--safe-area-top:env(safe-area-inset-top,0px);--safe-area-right:env(safe-area-inset-right,0px);--safe-area-bottom:env(safe-area-inset-bottom,0px);--safe-area-left:env(safe-area-inset-left,0px);--view-label-color:color-mix(in srgb,var(--muted) 85%, transparent);--view-value-color:var(--text);--view-helper-color:color-mix(in srgb,var(--muted) 65%, transparent);--chip-bg:color-mix(in srgb,var(--accent) 22%, var(--surface-2) 78%);--chip-text:var(--text);}
 @font-face{font-family:'CFTechnoMania Slanted';src:url('../CFTechnoMania-Slanted.ttf') format('truetype');font-weight:400;font-style:normal;font-display:swap}
 @font-face{font-family:'Race Sport';src:url('../Race Sport.ttf') format('truetype');font-weight:400;font-style:normal;font-display:swap}
 :root.theme-light{--bg-color:#f9fafb;--bg:var(--bg-color) url('../images/Light.PNG?v=2') center/cover no-repeat fixed;--surface:#fff;--surface-2:#f3f4f6;--text:#111827;--muted:#6b7280;--accent:#3b82f6;--accent-2:#1e40af;--line:rgba(0,0,0,.1);--shadow:0 8px 28px rgba(0,0,0,.2);--text-on-accent:#fff;--success:#16a34a;--error:#dc2626;--icon-success:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2316a34a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");--icon-error:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23dc2626' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E")}
@@ -939,16 +939,93 @@ main>:last-child{margin-bottom:0}
 fieldset[data-tab].card.active{opacity:1;transform:translate3d(0,0,0);pointer-events:auto;visibility:visible;filter:blur(0)saturate(1);position:relative;inset:auto;margin-bottom:14px}
 fieldset[data-tab].card>legend{font-size:clamp(1.1rem,3.4vw,1.5rem);font-weight:600;color:var(--accent);margin:0 0 6px;font-family:'CFTechnoMania Slanted','Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;letter-spacing:var(--title-letter-spacing);word-spacing:var(--title-word-spacing)}
 .card{position:relative}
-.card .card-caret{width:clamp(28px,6vw,34px);height:clamp(28px,6vw,34px);border-radius:8px;border:1px solid transparent;display:inline-flex;align-items:center;justify-content:center;background:var(--surface-2);color:var(--text);cursor:pointer;padding:0;transition:background .2s ease,border-color .2s ease,transform .2s ease;margin-inline-start:auto}
-.card .card-caret .btn-icon{margin-inline-end:0;font-size:1.2em}
-.card .card-caret svg{width:clamp(14px,4vw,18px);height:clamp(14px,4vw,18px)}
-.card .card-caret:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
-.card .card-caret:hover{background:color-mix(in srgb,var(--surface-2) 80%,var(--accent) 20%);border-color:color-mix(in srgb,var(--accent) 35%,transparent)}
 .card-legend--actions{padding:0}
-.card-legend__content{display:flex;align-items:center;gap:var(--control-gap)}
-.card-legend__title{flex:1 1 auto;display:flex;align-items:center;gap:var(--control-gap);font:inherit}
-.card-legend__content .card-caret{margin-inline-start:auto;position:static}
-.card-menu{position:absolute;top:calc(var(--card-padding, 8px) + clamp(28px,6vw,34px) + var(--control-min-height) + var(--control-gap));right:var(--card-padding, 8px);background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:6px;display:flex;flex-direction:column;gap:6px;min-width:clamp(140px,48vw,200px);max-width:calc(100vw - 24px);width:max-content;max-height:var(--card-menu-max-height, none);overflow-x:hidden;overflow-y:auto;transform:translateX(calc(var(--card-menu-offset-x, 0px) * -1));z-index:5}
+.card-legend--title-icon{
+  display:flex;
+  align-items:center;
+  gap:var(--control-gap);
+}
+.card-legend--title-icon .card-legend__title{
+  flex:1 1 auto;
+  display:flex;
+  align-items:center;
+  gap:var(--control-gap);
+  font:inherit;
+}
+.card-legend--title-icon .card-title-icon{
+  margin-inline-start:auto;
+}
+.card-title-icon{
+  min-height:0;
+  width:var(--card-title-icon-size);
+  height:var(--card-title-icon-size);
+  border-radius:999px;
+  border:1px solid transparent;
+  background:linear-gradient(
+    135deg,
+    color-mix(in srgb,var(--accent) 78%, transparent),
+    color-mix(in srgb,var(--accent-2) 68%, transparent)
+  );
+  color:var(--text-on-accent);
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:0;
+  font:inherit;
+  line-height:1;
+  cursor:pointer;
+  box-shadow:0 10px 22px rgba(0,0,0,.28);
+  filter:none;
+  transition:var(--transition), box-shadow .3s ease, transform .3s ease;
+}
+.card-title-icon svg{
+  width:var(--card-title-icon-glyph);
+  height:var(--card-title-icon-glyph);
+  pointer-events:none;
+}
+.card-title-icon__glyph{display:block}
+.card-title-icon:hover{
+  transform:translateY(-1px);
+  box-shadow:0 14px 26px rgba(0,0,0,.35);
+  filter:none;
+}
+.card-title-icon:active{
+  transform:translateY(0);
+}
+.card-title-icon:focus-visible{
+  outline:2px solid var(--text-on-accent);
+  outline-offset:3px;
+}
+.card-title-icon[data-icon-state="save"]{
+  background:linear-gradient(
+    135deg,
+    color-mix(in srgb,var(--accent) 45%, var(--success) 55%),
+    color-mix(in srgb,var(--accent-2) 50%, var(--success) 50%)
+  );
+}
+.card-title-icon--menu{
+  background:linear-gradient(
+    135deg,
+    color-mix(in srgb,var(--accent) 50%, transparent),
+    color-mix(in srgb,var(--accent-2) 60%, transparent)
+  );
+  box-shadow:0 9px 20px rgba(0,0,0,.24);
+}
+.card-title-icon--menu:hover,
+.card-title-icon--menu[aria-expanded="true"]{
+  background:linear-gradient(
+    135deg,
+    color-mix(in srgb,var(--accent) 35%, var(--success) 65%),
+    color-mix(in srgb,var(--accent-2) 45%, var(--success) 55%)
+  );
+}
+.card-title-icon--menu svg{
+  transition:transform .3s ease;
+}
+.card-title-icon--menu[aria-expanded="true"] svg{
+  transform:rotate(180deg);
+}
+.card-menu{position:absolute;top:calc(var(--card-padding, 8px) + var(--card-title-icon-size) + var(--control-min-height) + var(--control-gap));right:var(--card-padding, 8px);background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:6px;display:flex;flex-direction:column;gap:6px;min-width:clamp(140px,48vw,200px);max-width:calc(100vw - 24px);width:max-content;max-height:var(--card-menu-max-height, none);overflow-x:hidden;overflow-y:auto;transform:translateX(calc(var(--card-menu-offset-x, 0px) * -1));z-index:5}
 .card-menu__item{width:100%;min-height:var(--control-compact-min-height);padding:clamp(6px,2.2vw,10px);font-size:clamp(.8rem,2.5vw,.95rem);background:var(--surface-2);border:1px solid transparent;border-radius:var(--radius);cursor:pointer;text-align:left}
 .card-menu__item:hover,.card-menu__item:focus-visible{background:color-mix(in srgb,var(--accent) 18%,var(--surface-2));border-color:color-mix(in srgb,var(--accent) 35%,transparent);outline:none}
 .card-menu[hidden]{display:none}
@@ -1198,11 +1275,11 @@ button .btn-label{display:inline-flex;align-items:center}
 }
 
 .hp-field{
-  --hp-settings-button-size:clamp(28px,6vw,34px);
+  --hp-settings-button-size:var(--card-title-icon-size);
   position:relative;
 }
 
-.hp-field .card-caret{z-index:2}
+.hp-field .card-title-icon{z-index:2}
 
 .hp-field .inline:first-of-type{padding-right:calc(var(--hp-settings-button-size) + var(--card-padding,8px))}
 


### PR DESCRIPTION
## Summary
- replace the Ability Scores and Character & Story edit buttons with icon toggles that swap between pencil and save states when unlocked
- update HP and SP card headers to use the same icon-based layout for their option controls and refresh their styling
- add supporting styles and scripting so the new icons animate correctly and reflect edit state

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e54d838950832eba67d4d1b21df1ff