### PR TITLE
Align ability and story edit buttons with HP/SP style

### DIFF
--- a/index.html
+++ b/index.html
@@ -492,9 +492,11 @@
     <div class="card-toolbar">
       <h2 class="card-title card-toolbar__title card-toolbar__title--inline" id="card-abilities-title">
         <span class="card-toolbar__title-text">Ability Scores</span>
+      </h2>
+      <div class="card-toolbar__actions">
         <button
           type="button"
-          class="btn-sm card-edit-toggle"
+          class="card-caret card-edit-toggle"
           data-view-target="#card-abilities"
           data-view-label="Ability Scores"
           aria-describedby="card-abilities-title"
@@ -502,7 +504,7 @@
           <span class="btn-icon" aria-hidden="true">✎</span>
           <span class="btn-label card-edit-toggle__label sr-only">Edit</span>
         </button>
-      </h2>
+      </div>
     </div>
     <div id="abil-grid" class="grid ability-grid" data-view-lock></div>
     <fieldset class="card">
@@ -643,9 +645,11 @@
     <div class="card-toolbar">
       <h2 class="card-title card-toolbar__title card-toolbar__title--inline" id="card-story-title">
         <span class="card-toolbar__title-text">Character and Story</span>
+      </h2>
+      <div class="card-toolbar__actions">
         <button
           type="button"
-          class="btn-sm card-edit-toggle"
+          class="card-caret card-edit-toggle"
           data-view-target="#card-story"
           data-view-label="Character and Story"
           aria-describedby="card-story-title"
@@ -653,7 +657,7 @@
           <span class="btn-icon" aria-hidden="true">✎</span>
           <span class="btn-label card-edit-toggle__label sr-only">Edit</span>
         </button>
-      </h2>
+      </div>
     </div>
     <div class="grid grid-2">
       <div class="card" data-view-lock><label for="superhero">Superhero Identity</label><input id="superhero" placeholder="Vigilante Name"/></div>


### PR DESCRIPTION
## Summary
- update the Ability Scores and Character and Story card headers to use the same caret-style edit buttons as HP/SP
- ensure the edit toggles remain accessible while matching the shared toolbar layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e56de3ebf4832ebd6b8a89028b34d7