### PR TITLE
Align edit toggles with Ability Scores and Story headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -492,8 +492,6 @@
     <div class="card-toolbar">
       <h2 class="card-title card-toolbar__title card-toolbar__title--inline" id="card-abilities-title">
         <span class="card-toolbar__title-text">Ability Scores</span>
-      </h2>
-      <div class="card-toolbar__actions">
         <button
           type="button"
           class="card-caret card-edit-toggle"
@@ -504,7 +502,7 @@
           <span class="btn-icon" aria-hidden="true">✎</span>
           <span class="btn-label card-edit-toggle__label sr-only">Edit</span>
         </button>
-      </div>
+      </h2>
     </div>
     <div id="abil-grid" class="grid ability-grid" data-view-lock></div>
     <fieldset class="card">
@@ -645,8 +643,6 @@
     <div class="card-toolbar">
       <h2 class="card-title card-toolbar__title card-toolbar__title--inline" id="card-story-title">
         <span class="card-toolbar__title-text">Character and Story</span>
-      </h2>
-      <div class="card-toolbar__actions">
         <button
           type="button"
           class="card-caret card-edit-toggle"
@@ -657,7 +653,7 @@
           <span class="btn-icon" aria-hidden="true">✎</span>
           <span class="btn-label card-edit-toggle__label sr-only">Edit</span>
         </button>
-      </div>
+      </h2>
     </div>
     <div class="grid grid-2">
       <div class="card" data-view-lock><label for="superhero">Superhero Identity</label><input id="superhero" placeholder="Vigilante Name"/></div>


### PR DESCRIPTION
## Summary
- embed the Ability Scores edit toggle within the card heading so it sits inline with the title
- mirror the inline heading layout for the Character and Story card edit toggle

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e5734e1360832e9438905757170dfc