### PR TITLE
Adjust title character animation transitions

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -380,7 +380,10 @@ header .tab svg{
 .header-decrypted__char,
 .animated-decrypted__char{
   color:inherit;
-  transition:color .3s ease,text-shadow .3s ease;
+  opacity:1;
+  transform:translate3d(0,0,0);
+  transition:color .3s ease,text-shadow .3s ease,opacity .3s ease,transform .3s ease;
+  will-change:opacity,transform;
 }
 
 .header-decrypted__char,
@@ -411,6 +414,8 @@ header .tab svg{
 .animated-decrypted__char--scrambling{
   color:color-mix(in srgb,var(--muted) 65%,transparent);
   text-shadow:0 0 8px color-mix(in srgb,var(--accent) 55%,transparent);
+  opacity:.75;
+  transform:translateY(-3px);
 }
 
 [data-animate-title]{


### PR DESCRIPTION
## Summary
- extend header and animated decrypted character styles with opacity/transform transitions and will-change hints
- align scrambling state defaults for opacity and transform so CSS matches animation logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5ecd256dc832e9b669f29846d066e