### PR TITLE
Refine tab transition animation

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2966,23 +2966,28 @@ function animateTabTransition(currentName, nextName, direction){
   targetPanel.classList.add('animating');
   activePanel.style.pointerEvents = 'none';
   targetPanel.style.pointerEvents = 'none';
-  activePanel.style.willChange = 'opacity, filter';
-  targetPanel.style.willChange = 'opacity, filter';
+  activePanel.style.willChange = 'opacity, transform';
+  targetPanel.style.willChange = 'opacity, transform';
   activePanel.style.zIndex = '3';
   targetPanel.style.zIndex = '4';
   prepareContainerForAnimation();
   targetPanel.style.opacity = '0';
-  targetPanel.style.filter = 'blur(18px) saturate(1.35)';
+  const enteringOffset = direction === 'left' ? '16px' : direction === 'right' ? '-16px' : '0px';
+  const exitingOffset = direction === 'left' ? '-16px' : direction === 'right' ? '16px' : '0px';
+  const enteringTransform = direction ? `translateX(${enteringOffset}) scale(0.98)` : 'scale(0.98)';
+  const exitingTransform = direction ? `translateX(${exitingOffset}) scale(0.98)` : 'scale(0.98)';
+  targetPanel.style.transform = enteringTransform;
+  activePanel.style.transform = 'translateX(0px) scale(1)';
   targetPanel.style.visibility = 'visible';
 
   const animations = [
     targetPanel.animate([
-      { opacity: 0, filter: 'blur(18px) saturate(1.35)' },
-      { opacity: 1, filter: 'blur(0px) saturate(1)' }
+      { opacity: 0, transform: enteringTransform },
+      { opacity: 1, transform: 'translateX(0px) scale(1)' }
     ], { duration: TAB_ANIMATION_DURATION, easing: TAB_ANIMATION_EASING, fill: 'forwards' }),
     activePanel.animate([
-      { opacity: 1, filter: 'blur(0px) saturate(1)' },
-      { opacity: 0, filter: 'blur(18px) saturate(1.2)' }
+      { opacity: 1, transform: 'translateX(0px) scale(1)' },
+      { opacity: 0, transform: exitingTransform }
     ], { duration: TAB_ANIMATION_DURATION, easing: TAB_ANIMATION_EASING, fill: 'forwards' })
   ];
 


### PR DESCRIPTION
## Summary
- replace the tab transition blur animation with transform and opacity keyframes for a lighter depth effect
- initialize transform values and update will-change hints to match the new animation properties

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5ed255f64832ea56d823bc4e70606