### PR TITLE
Animate DM tools menu transitions

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -2258,8 +2258,18 @@ select[required]:valid{
   box-shadow:var(--shadow);
   z-index:2000;
   backdrop-filter:blur(10px);
+  opacity:0;
+  transform:translate3d(0, 12px, 0) scale(.96);
+  pointer-events:none;
+  transition:opacity .28s ease, transform .28s ease;
+  will-change:opacity, transform;
 }
 .dm-tools-menu[hidden]{display:none}
+.dm-tools-menu.is-open{
+  opacity:1;
+  transform:translate3d(0, 0, 0) scale(1);
+  pointer-events:auto;
+}
 .dm-tools-menu button{
   background:transparent;
   color:var(--text);


### PR DESCRIPTION
## Summary
- add fade/slide animation styles for the floating DM tools menu and expose an open modifier
- update DM tools menu logic to toggle the open class, sync aria attributes, and delay the hidden fallback until transitions complete

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5ed51c008832e81c64e3d4dad22f8