### PR TITLE
Align tab card filter transition with animation timing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -23,6 +23,11 @@
 :root.theme-alien{--bg-color:#004d40;--bg:var(--bg-color) url('../images/Alien:Extraterrestrial.PNG?v=2') center/cover no-repeat fixed;--surface:rgba(0,77,64,.8);--surface-2:rgba(27,20,60,.8);--text:#e0f2f1;--muted:#80cbc4;--accent:#00e5ff;--accent-2:#651fff;--line:rgba(255,255,255,.1);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#0e1117;--success:#4db6ac;--error:#ef5350;--icon-success:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%234db6ac' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");--icon-error:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23ef5350' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E")}
 :root.theme-mystic{--bg-color:#311b92;--bg:var(--bg-color) url('../images/Mystical Being.PNG?v=2') center/cover no-repeat fixed;--surface:rgba(49,27,146,.8);--surface-2:rgba(35,20,100,.8);--text:#fff8e1;--muted:#ffe082;--accent:#d4af37;--accent-2:#7b1fa2;--line:rgba(255,255,255,.1);--shadow:0 8px 28px rgba(0,0,0,.35);--text-on-accent:#0e1117;--success:#fff59d;--error:#ef5350;--icon-success:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23fff59d' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 10l3 3 7-7'/%3E%3C/svg%3E");--icon-error:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23ef5350' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 6l8 8M6 14l8-8'/%3E%3C/svg%3E")}
 @media (prefers-reduced-motion:reduce){*,*::before,*::after{transition:none!important;animation:none!important}}
+@media (prefers-reduced-motion:reduce){
+  fieldset[data-tab].card{
+    transition:opacity .36s cubic-bezier(.33,1,.68,1)!important,filter .36s cubic-bezier(.33,1,.68,1)!important,-webkit-backdrop-filter .36s cubic-bezier(.33,1,.68,1)!important,backdrop-filter .36s cubic-bezier(.33,1,.68,1)!important;
+  }
+}
 *,*::before,*::after{box-sizing:border-box}
 
 .menu button,
@@ -903,7 +908,7 @@ main{
 main.is-animating-tabs{
   overflow:hidden;
 }
-fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:var(--card-padding,10px);margin-bottom:0;box-shadow:var(--shadow);display:flex;flex-direction:column;opacity:0;transform:translate3d(0,0,0);cursor:default;pointer-events:none;will-change:opacity,filter;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);background-color:color-mix(in srgb,var(--surface) 5%,transparent);position:absolute;inset:0;width:100%;max-width:100%;min-width:0;visibility:hidden;filter:blur(18px) saturate(1.2);transition:opacity .3s cubic-bezier(.22,1,.36,1),filter .3s cubic-bezier(.22,1,.36,1),-webkit-backdrop-filter .3s cubic-bezier(.22,1,.36,1),backdrop-filter .3s cubic-bezier(.22,1,.36,1)}
+fieldset[data-tab].card{background:color-mix(in srgb,var(--surface) 5%,transparent);border:1px solid var(--line);border-radius:var(--radius);padding:var(--card-padding,10px);margin-bottom:0;box-shadow:var(--shadow);display:flex;flex-direction:column;opacity:0;transform:translate3d(0,0,0);cursor:default;pointer-events:none;will-change:opacity,filter;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);background-color:color-mix(in srgb,var(--surface) 5%,transparent);position:absolute;inset:0;width:100%;max-width:100%;min-width:0;visibility:hidden;filter:blur(18px) saturate(1.2);transition:opacity .36s cubic-bezier(.33,1,.68,1),filter .36s cubic-bezier(.33,1,.68,1),-webkit-backdrop-filter .36s cubic-bezier(.33,1,.68,1),backdrop-filter .36s cubic-bezier(.33,1,.68,1)}
 fieldset[data-tab].card:not(.active):not(.animating){
   height:0;
   max-height:0;


### PR DESCRIPTION
## Summary
- align the tab card filter and backdrop fallback transitions with the Web Animations API easing and duration so the blur fades smoothly when scripts fall back to CSS
- restore the fallback transitions when prefers-reduced-motion disables the Web Animations API path so the tab switch blur no longer snaps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6041a043c832e837787675b8b54e2