### PR TITLE
Add sync status badge for cloud saves

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
       </span>
       <span class="theme-toggle__label sr-only">Theme</span>
     </button>
-    <span class="tabs-title">Catalyst Core</span>
+    <span class="tabs-title"><span class="tabs-title__label">Catalyst Core</span><span id="cloud-sync-status" class="sync-status-badge" data-status="online" role="status" aria-live="polite">Online</span></span>
     <div class="dropdown">
       <button id="btn-menu" class="icon" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">

--- a/index.html
+++ b/index.html
@@ -148,13 +148,25 @@
       </span>
       <span class="theme-toggle__label sr-only">Theme</span>
     </button>
-    <span class="tabs-title"><span class="tabs-title__label">Catalyst Core</span><span id="cloud-sync-status" class="sync-status-badge" data-status="online" role="status" aria-live="polite">Online</span></span>
+    <span class="tabs-title"><span class="tabs-title__label">Catalyst Core</span></span>
     <div class="dropdown">
       <button id="btn-menu" class="icon" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15m-15 5.25h15m-15 5.25h15"/>
         </svg>
       </button>
+      <span
+        id="cloud-sync-status"
+        class="sync-status-indicator"
+        data-status="online"
+        role="status"
+        aria-live="polite"
+        aria-label="Cloud sync status: Online"
+        title="Online"
+      >
+        <span class="sync-status-indicator__light" aria-hidden="true"></span>
+        <span class="sr-only" data-sync-status-label>Online</span>
+      </span>
       <div id="menu-actions" class="menu" hidden>
         <button id="btn-load" class="btn-sm">Load / Save</button>
         <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>

--- a/styles/main.css
+++ b/styles/main.css
@@ -190,6 +190,48 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
   justify-self:center;
 }
 
+.tabs-title__label{
+  display:inline-flex;
+  align-items:center;
+}
+
+.sync-status-badge{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;
+  font-size:clamp(.6rem,2vw,.75rem);
+  letter-spacing:.05em;
+  text-transform:uppercase;
+  padding:3px 8px;
+  border-radius:999px;
+  border:1px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  background:color-mix(in srgb, var(--surface) 88%, transparent);
+  color:var(--accent);
+}
+
+.sync-status-badge::before{
+  content:"";
+  display:inline-block;
+  width:8px;
+  height:8px;
+  border-radius:999px;
+  background:currentColor;
+  box-shadow:0 0 0 1px color-mix(in srgb, currentColor 70%, transparent);
+}
+
+.sync-status-badge[data-status="offline"]{
+  color:var(--error);
+  border-color:color-mix(in srgb, var(--error) 50%, transparent);
+  background:color-mix(in srgb, var(--error) 14%, transparent);
+}
+
+.sync-status-badge[data-status="queued"]{
+  color:var(--warning, #f5c959);
+  border-color:color-mix(in srgb, var(--warning, #f5c959) 45%, transparent);
+  background:color-mix(in srgb, var(--warning, #f5c959) 18%, transparent);
+}
+
 header{
   --header-icon-size:calc(var(--icon-size) * 1.25);
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -96,7 +96,7 @@ header::before{content:none}
 }
 .actions{display:flex;gap:var(--control-gap);flex-wrap:wrap}
 .actions.actions--center{justify-content:center}
-.dropdown{position:relative;display:flex;align-items:center;justify-content:flex-end;flex:0 0 auto;justify-self:end;grid-area:menu}
+.dropdown{position:relative;display:flex;align-items:center;justify-content:flex-end;flex:0 0 auto;justify-self:end;grid-area:menu;gap:clamp(8px,2vw,14px)}
 .menu{position:absolute;top:calc(100% + 4px);right:0;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50;opacity:0;transform:translateY(-8px) scale(.99);visibility:hidden;transition:opacity .24s cubic-bezier(.22,1,.36,1),transform .24s cubic-bezier(.22,1,.36,1);pointer-events:none;transform-origin:top right;will-change:opacity,transform}
 .menu.show{opacity:1;transform:translateY(0) scale(1);visibility:visible;pointer-events:auto}
 .menu button{background:transparent;color:var(--text);border:none;padding:clamp(6px,2.2vw,10px) clamp(10px,3.6vw,14px);text-align:left;font-weight:400;min-height:auto;white-space:nowrap}
@@ -195,41 +195,93 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
   align-items:center;
 }
 
-.sync-status-badge{
+.sync-status-indicator{
+  --sync-indicator-size:clamp(10px,2.5vw,12px);
+  --sync-indicator-color:var(--success);
+  --sync-indicator-alt:var(--sync-indicator-color);
   display:inline-flex;
   align-items:center;
-  gap:6px;
-  font-family:'Inter',system-ui,-apple-system,Segoe UI,Arial,sans-serif;
-  font-size:clamp(.6rem,2vw,.75rem);
-  letter-spacing:.05em;
-  text-transform:uppercase;
-  padding:3px 8px;
+  justify-content:center;
+  padding:clamp(2px,.9vw,4px);
+  margin-left:clamp(8px,2vw,12px);
   border-radius:999px;
-  border:1px solid color-mix(in srgb, var(--accent) 55%, transparent);
-  background:color-mix(in srgb, var(--surface) 88%, transparent);
-  color:var(--accent);
+  background:color-mix(in srgb,var(--sync-indicator-color) 12%, transparent);
+  border:1px solid color-mix(in srgb,var(--sync-indicator-color) 50%, transparent);
+  box-shadow:0 2px 6px color-mix(in srgb,var(--sync-indicator-color) 22%, transparent);
+  transition:background .3s ease,border-color .3s ease,box-shadow .3s ease;
+  min-width:calc(var(--sync-indicator-size) + clamp(6px,1.4vw,10px));
+  min-height:calc(var(--sync-indicator-size) + clamp(6px,1.4vw,10px));
 }
 
-.sync-status-badge::before{
-  content:"";
-  display:inline-block;
-  width:8px;
-  height:8px;
+.sync-status-indicator__light{
+  width:var(--sync-indicator-size);
+  height:var(--sync-indicator-size);
   border-radius:999px;
-  background:currentColor;
-  box-shadow:0 0 0 1px color-mix(in srgb, currentColor 70%, transparent);
+  background:var(--sync-indicator-color);
+  box-shadow:0 0 0 1px color-mix(in srgb,var(--sync-indicator-color) 65%, transparent),0 0 8px color-mix(in srgb,var(--sync-indicator-color) 45%, transparent);
+  transition:background .3s ease,box-shadow .3s ease,transform .3s ease,opacity .3s ease;
 }
 
-.sync-status-badge[data-status="offline"]{
-  color:var(--error);
-  border-color:color-mix(in srgb, var(--error) 50%, transparent);
-  background:color-mix(in srgb, var(--error) 14%, transparent);
+.sync-status-indicator[data-status="online"]{
+  --sync-indicator-color:var(--success);
 }
 
-.sync-status-badge[data-status="queued"]{
-  color:var(--warning, #f5c959);
-  border-color:color-mix(in srgb, var(--warning, #f5c959) 45%, transparent);
-  background:color-mix(in srgb, var(--warning, #f5c959) 18%, transparent);
+.sync-status-indicator[data-status="syncing"]{
+  --sync-indicator-color:var(--success);
+}
+
+.sync-status-indicator[data-status="queued"]{
+  --sync-indicator-color:var(--warning, #f59e0b);
+  background:color-mix(in srgb,var(--warning, #f59e0b) 16%, transparent);
+  border-color:color-mix(in srgb,var(--warning, #f59e0b) 50%, transparent);
+  box-shadow:0 2px 8px color-mix(in srgb,var(--warning, #f59e0b) 30%, transparent);
+}
+
+.sync-status-indicator[data-status="reconnecting"]{
+  --sync-indicator-color:var(--success);
+  --sync-indicator-alt:var(--warning, #f59e0b);
+  background:color-mix(in srgb,var(--success) 14%, transparent);
+  border-color:color-mix(in srgb,var(--success) 48%, transparent);
+  box-shadow:0 2px 10px color-mix(in srgb,var(--success) 26%, transparent);
+}
+
+.sync-status-indicator[data-status="offline"]{
+  --sync-indicator-color:var(--error);
+  background:color-mix(in srgb,var(--error) 18%, transparent);
+  border-color:color-mix(in srgb,var(--error) 54%, transparent);
+  box-shadow:0 2px 8px color-mix(in srgb,var(--error) 32%, transparent);
+}
+
+.sync-status-indicator[data-status="syncing"] .sync-status-indicator__light{
+  animation:sync-status-pulse 1s ease-in-out infinite;
+}
+
+.sync-status-indicator[data-status="reconnecting"] .sync-status-indicator__light{
+  animation:sync-status-alternate 1.1s ease-in-out infinite;
+}
+
+@keyframes sync-status-pulse{
+  0%,100%{
+    transform:scale(1);
+    opacity:1;
+    box-shadow:0 0 0 1px color-mix(in srgb,var(--sync-indicator-color) 65%, transparent),0 0 8px color-mix(in srgb,var(--sync-indicator-color) 45%, transparent);
+  }
+  50%{
+    transform:scale(.7);
+    opacity:.55;
+    box-shadow:0 0 0 4px color-mix(in srgb,var(--sync-indicator-color) 25%, transparent),0 0 14px color-mix(in srgb,var(--sync-indicator-color) 55%, transparent);
+  }
+}
+
+@keyframes sync-status-alternate{
+  0%,45%{
+    background:var(--sync-indicator-color);
+    box-shadow:0 0 0 1px color-mix(in srgb,var(--sync-indicator-color) 65%, transparent),0 0 10px color-mix(in srgb,var(--sync-indicator-color) 45%, transparent);
+  }
+  55%,100%{
+    background:var(--sync-indicator-alt);
+    box-shadow:0 0 0 1px color-mix(in srgb,var(--sync-indicator-alt) 65%, transparent),0 0 10px color-mix(in srgb,var(--sync-indicator-alt) 45%, transparent);
+  }
 }
 
 header{


### PR DESCRIPTION
## Summary
- add a header badge that reflects the current cloud sync status
- expose sync status subscriptions in storage and update the badge from toast helpers
- clear offline indicators once a save succeeds so the badge returns to online

## Testing
- npm test -- auto_character_save

------
https://chatgpt.com/codex/tasks/task_e_68e6101bc300832ebbd43c29d77788a7