### PR TITLE
Display shard details in player modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -1342,6 +1342,11 @@
       </svg>
     </button>
     <img id="somf-min-image" class="somf-modal__art" alt="Shard artwork" loading="lazy">
+    <div id="somf-min-details" class="somf-modal__details">
+      <h3 id="somf-min-name" class="somf-modal__name"></h3>
+      <p id="somf-min-visual" class="somf-modal__visual"></p>
+      <ol id="somf-min-effects" class="somf-modal__effects"></ol>
+    </div>
   </div>
 </div>
 

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -2397,6 +2397,10 @@
         backdrop: dom.one('#somf-min-modal [data-somf-dismiss]'),
         close: dom.one('#somf-min-close'),
         image: dom.one('#somf-min-image'),
+        details: dom.one('#somf-min-details'),
+        name: dom.one('#somf-min-name'),
+        visual: dom.one('#somf-min-visual'),
+        effects: dom.one('#somf-min-effects'),
         revealInvite: dom.one('#somf-reveal-alert'),
         revealInviteCard: dom.one('#somf-reveal-alert .somf-reveal-alert__card'),
         revealInviteTitle: dom.one('#somf-reveal-title'),
@@ -2682,6 +2686,12 @@
       const entry = total ? this.queue[this.queueIndex] : null;
       let src = '';
       let label = '';
+      let visual = '';
+      let effects = [];
+      if (entry) {
+        visual = typeof entry.visual === 'string' ? entry.visual : '';
+        effects = Array.isArray(entry.player) ? entry.player : [];
+      }
       if (entry?.image) {
         src = entry.image;
         label = entry?.name || '';
@@ -2702,6 +2712,36 @@
         }
         const altLabel = label ? `${label} artwork` : 'Shard artwork';
         this.dom.image.alt = altLabel;
+      }
+      const detailName = entry?.name || this.tempArtwork?.name || '';
+      if (this.dom.name) {
+        this.dom.name.textContent = detailName;
+        this.dom.name.hidden = !detailName;
+      }
+      if (this.dom.visual) {
+        const text = typeof visual === 'string' ? visual.trim() : '';
+        this.dom.visual.textContent = text;
+        this.dom.visual.hidden = !text;
+      }
+      if (this.dom.effects) {
+        while (this.dom.effects.firstChild) {
+          this.dom.effects.removeChild(this.dom.effects.firstChild);
+        }
+        const normalizedEffects = Array.isArray(effects)
+          ? effects.map(line => (typeof line === 'string' ? line.trim() : '')).filter(Boolean)
+          : [];
+        normalizedEffects.forEach(line => {
+          const li = document.createElement('li');
+          li.textContent = line;
+          this.dom.effects.appendChild(li);
+        });
+        this.dom.effects.hidden = !normalizedEffects.length;
+      }
+      if (this.dom.details) {
+        const hasDetails = Boolean((this.dom.name && !this.dom.name.hidden)
+          || (this.dom.visual && !this.dom.visual.hidden)
+          || (this.dom.effects && !this.dom.effects.hidden));
+        this.dom.details.hidden = !hasDetails;
       }
     }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -2207,9 +2207,18 @@ select[required]:valid{
 .somf-modal { position:fixed; inset:0; z-index:9999; display:grid; place-items:center }
 .somf-modal__backdrop { position:absolute; inset:0; background:rgba(0,0,0,.5) }
 .somf-modal__card { position:relative; background:var(--surface); border:1px solid var(--line); color:var(--text); border-radius:var(--radius); width:min(var(--content-width),calc(100vw - 24px - var(--safe-area-left) - var(--safe-area-right))); max-width:min(var(--content-width),calc(100vw - 24px - var(--safe-area-left) - var(--safe-area-right))); max-height:min(88vh, calc(var(--vh,1vh)*100 - 32px - var(--safe-area-top) - var(--safe-area-bottom))); display:flex; flex-direction:column; box-shadow:var(--shadow); margin-inline:auto; overscroll-behavior:contain }
-.somf-modal__card--image{background:transparent;border:none;box-shadow:none;padding:0;display:block;width:auto;max-width:min(90vw,720px);max-height:90vh}
+.somf-modal__card--image{background:transparent;border:none;box-shadow:none;padding:0;display:flex;flex-direction:column;width:auto;max-width:min(90vw,720px);max-height:90vh;overflow:auto;gap:12px}
 .somf-modal__card--image .somf-modal__x{color:#fff;text-shadow:0 2px 6px rgba(0,0,0,.6)}
 .somf-modal__art{display:block;width:100%;height:auto;max-width:min(90vw,720px);max-height:90vh;border-radius:var(--radius);box-shadow:var(--shadow)}
+.somf-modal__details{padding:16px;border-radius:var(--radius);border:1px solid var(--line);background:var(--surface-2);color:var(--text);display:flex;flex-direction:column;gap:8px}
+.somf-modal__details[hidden]{display:none!important}
+.somf-modal__name{margin:0;font-size:1.3rem;font-weight:600;letter-spacing:.02em}
+.somf-modal__name[hidden]{display:none}
+.somf-modal__visual{margin:0;color:var(--muted);font-size:1rem;line-height:1.4}
+.somf-modal__visual[hidden]{display:none}
+.somf-modal__effects{margin:4px 0 0;padding-left:20px;font-size:1rem;line-height:1.45;display:flex;flex-direction:column;gap:6px}
+.somf-modal__effects[hidden]{display:none}
+.somf-modal__effects li{margin:0}
 .somf-modal__hdr, .somf-modal__ftr { display:flex; align-items:center; gap:8px; padding:6px 12px; border-bottom:1px solid var(--line) }
 .somf-modal__ftr { border-top:1px solid var(--line); border-bottom:none }
 .somf-modal__body { padding:12px; overflow:auto }
@@ -2221,6 +2230,8 @@ select[required]:valid{
 @media(max-width:640px){
   .somf-modal{align-items:flex-start;justify-content:center;padding:calc(12px + var(--safe-area-top)) calc(12px + var(--safe-area-right)) calc(12px + var(--safe-area-bottom)) calc(12px + var(--safe-area-left))}
   .somf-modal__card{width:calc(100vw - 24px - var(--safe-area-left) - var(--safe-area-right));max-width:calc(100vw - 24px - var(--safe-area-left) - var(--safe-area-right));max-height:calc(var(--vh,1vh)*100 - 24px - var(--safe-area-top) - var(--safe-area-bottom))}
+  .somf-modal__details{padding:12px;font-size:.95rem}
+  .somf-modal__name{font-size:1.15rem}
 }
 .somf-badge { font-size:12px; letter-spacing:.08em; text-transform:uppercase; color:var(--muted); opacity:.9 }
 .somf-subttl { margin:10px 0 6px 0; font-size:13px; color:var(--muted) }


### PR DESCRIPTION
## Summary
- add shard name, visual tagline, and effect list containers to the player shard modal markup
- populate the new modal fields from the active queue entry within the player controller
- style the modal details area to mirror shard card typography and stay readable on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e610310134832eb4ef4603837783c8