### PR TITLE
Add shard queue navigation and history drawer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1341,7 +1341,21 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
       </svg>
     </button>
-    <img id="somf-min-image" class="somf-modal__art" alt="Shard artwork" loading="lazy">
+    <div class="somf-modal__content">
+      <img id="somf-min-image" class="somf-modal__art" alt="Shard artwork" loading="lazy">
+      <div class="somf-modal__controls" aria-live="polite">
+        <button id="somf-min-prev" class="somf-btn somf-ghost" type="button" aria-label="Previous shard">Previous</button>
+        <span id="somf-min-counter" class="somf-modal__counter somf-muted" aria-hidden="true">0 / 0</span>
+        <button id="somf-min-next" class="somf-btn somf-ghost" type="button" aria-label="Next shard">Next</button>
+      </div>
+      <details id="somf-min-history" class="somf-modal__history" hidden>
+        <summary class="somf-modal__history-summary">
+          <span class="somf-modal__history-title">Shard Queue</span>
+          <span id="somf-min-history-count" class="somf-modal__history-count somf-muted"></span>
+        </summary>
+        <ol id="somf-min-history-list" class="somf-modal__history-list"></ol>
+      </details>
+    </div>
   </div>
 </div>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -2207,9 +2207,23 @@ select[required]:valid{
 .somf-modal { position:fixed; inset:0; z-index:9999; display:grid; place-items:center }
 .somf-modal__backdrop { position:absolute; inset:0; background:rgba(0,0,0,.5) }
 .somf-modal__card { position:relative; background:var(--surface); border:1px solid var(--line); color:var(--text); border-radius:var(--radius); width:min(var(--content-width),calc(100vw - 24px - var(--safe-area-left) - var(--safe-area-right))); max-width:min(var(--content-width),calc(100vw - 24px - var(--safe-area-left) - var(--safe-area-right))); max-height:min(88vh, calc(var(--vh,1vh)*100 - 32px - var(--safe-area-top) - var(--safe-area-bottom))); display:flex; flex-direction:column; box-shadow:var(--shadow); margin-inline:auto; overscroll-behavior:contain }
-.somf-modal__card--image{background:transparent;border:none;box-shadow:none;padding:0;display:block;width:auto;max-width:min(90vw,720px);max-height:90vh}
+.somf-modal__card--image{background:transparent;border:none;box-shadow:none;padding:0;display:flex;flex-direction:column;align-items:stretch;gap:12px;width:auto;max-width:min(90vw,720px);max-height:90vh}
 .somf-modal__card--image .somf-modal__x{color:#fff;text-shadow:0 2px 6px rgba(0,0,0,.6)}
-.somf-modal__art{display:block;width:100%;height:auto;max-width:min(90vw,720px);max-height:90vh;border-radius:var(--radius);box-shadow:var(--shadow)}
+.somf-modal__content{display:flex;flex-direction:column;align-items:stretch;gap:12px}
+.somf-modal__art{display:block;width:100%;height:auto;max-width:min(90vw,720px);max-height:70vh;border-radius:var(--radius);box-shadow:var(--shadow)}
+.somf-modal__controls{display:flex;align-items:center;justify-content:center;gap:12px;padding:0 12px}
+.somf-modal__controls .somf-btn{min-width:96px}
+.somf-modal__counter{font-weight:600}
+.somf-modal__history{margin:0 12px 12px;padding:12px;border-radius:var(--radius);border:1px solid var(--line);background:var(--surface-2);color:var(--text)}
+.somf-modal__history[hidden]{display:none}
+.somf-modal__history-summary{display:flex;align-items:center;justify-content:space-between;gap:12px;font-weight:600;cursor:pointer;list-style:none}
+.somf-modal__history-summary::-webkit-details-marker{display:none}
+.somf-modal__history-count{font-size:13px}
+.somf-modal__history-list{margin:12px 0 0;padding:0;list-style:none;display:flex;flex-direction:column;gap:6px;max-height:180px;overflow:auto}
+.somf-modal__history-list li{margin:0;padding:0}
+.somf-modal__history-btn{width:100%;justify-content:flex-start;text-align:left}
+.somf-modal__history-btn[aria-current="true"]{background:var(--accent);border-color:var(--accent-2);color:var(--text-on-accent)}
+.somf-modal__history-btn[aria-current="true"]:hover{background:var(--accent-2)}
 .somf-modal__hdr, .somf-modal__ftr { display:flex; align-items:center; gap:8px; padding:6px 12px; border-bottom:1px solid var(--line) }
 .somf-modal__ftr { border-top:1px solid var(--line); border-bottom:none }
 .somf-modal__body { padding:12px; overflow:auto }


### PR DESCRIPTION
## Summary
- add navigation controls and an unresolved queue drawer to the shard modal markup and styles
- wire the player controller to drive the new controls, keep the modal open, and render the history list from the shard queue

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e61046b81c832ea46d0eff27d0092a