### PR TITLE
Add accessible Shard draw confirmation dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -1575,6 +1575,24 @@
 <div id="load-animation" aria-hidden="true" hidden></div>
 <div id="draw-lightning" aria-hidden="true" hidden></div>
 <div id="draw-flash" aria-hidden="true" hidden></div>
+<div class="overlay hidden" id="somf-confirm-draw" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="somf-confirm-title" aria-describedby="somf-confirm-description somf-confirm-count somf-confirm-consequence-label">
+  <section class="modal somf-confirm" tabindex="-1">
+    <header class="somf-confirm__header">
+      <h3 id="somf-confirm-title" class="somf-confirm__title">Tempt Fate?</h3>
+      <p id="somf-confirm-description" class="somf-confirm__description">Drawing from the Shards of Many Fates invites unpredictable magic.</p>
+    </header>
+    <p id="somf-confirm-count" class="somf-confirm__count">You are about to draw 1 Shard.</p>
+    <p id="somf-confirm-consequence-label" class="somf-confirm__label">If you proceed, remember:</p>
+    <ul id="somf-confirm-consequences" class="somf-confirm__list">
+      <li>The Fates are fickle—outcomes may bless or curse.</li>
+      <li>Draws are permanent and cannot be undone.</li>
+    </ul>
+    <footer class="somf-confirm__actions">
+      <button type="button" class="btn-sm somf-confirm__cancel" data-somf-confirm-cancel>Not Now</button>
+      <button type="button" class="somf-btn somf-primary somf-confirm__accept" data-somf-confirm-accept>Draw 1 Shard</button>
+    </footer>
+  </section>
+</div>
 <div id="somf-reveal-alert" class="somf-reveal-alert" hidden role="alertdialog" aria-modal="true" aria-labelledby="somf-reveal-title" aria-describedby="somf-reveal-text" aria-hidden="true">
   <div class="somf-reveal-alert__card" tabindex="-1">
     <h3 id="somf-reveal-title" class="somf-reveal-alert__title">The Shards of Many Fates</h3>

--- a/shard-of-many-fates.js
+++ b/shard-of-many-fates.js
@@ -2376,6 +2376,7 @@
       this.toastShownHandler = evt => this.onGlobalToastShown(evt);
       this.toastDismissHandler = () => this.onGlobalToastDismissed();
       this.modalIsOpen = false;
+      this.drawConfirmState = null;
     }
 
     attach() {
@@ -2396,6 +2397,11 @@
         modal: dom.one('#somf-min-modal'),
         backdrop: dom.one('#somf-min-modal [data-somf-dismiss]'),
         close: dom.one('#somf-min-close'),
+        drawConfirmOverlay: dom.one('#somf-confirm-draw'),
+        drawConfirmDialog: dom.one('#somf-confirm-draw .somf-confirm'),
+        drawConfirmCount: dom.one('#somf-confirm-count'),
+        drawConfirmAccept: dom.one('[data-somf-confirm-accept]'),
+        drawConfirmCancel: dom.one('[data-somf-confirm-cancel]'),
         image: dom.one('#somf-min-image'),
         revealInvite: dom.one('#somf-reveal-alert'),
         revealInviteCard: dom.one('#somf-reveal-alert .somf-reveal-alert__card'),
@@ -2937,11 +2943,159 @@
       return true;
     }
 
+    showDrawConfirmation(count) {
+      const overlay = this.dom.drawConfirmOverlay;
+      const dialog = this.dom.drawConfirmDialog;
+      const accept = this.dom.drawConfirmAccept;
+      const cancel = this.dom.drawConfirmCancel;
+      const countEl = this.dom.drawConfirmCount;
+      if (!overlay || !dialog || !accept || !cancel) {
+        const first = window.confirm('The Fates are fickle, are you sure you wish to draw from the Shards?');
+        if (!first) return Promise.resolve(false);
+        return Promise.resolve(window.confirm('This cannot be undone, do you really wish to tempt Fate?'));
+      }
+      if (this.drawConfirmState && this.drawConfirmState.active) {
+        return Promise.resolve(false);
+      }
+      const label = `${count} ${pluralize('Shard', count)}`;
+      if (countEl) countEl.textContent = `You are about to draw ${label}.`;
+      accept.textContent = `Draw ${label}`;
+      accept.setAttribute('aria-label', `Draw ${label} now`);
+      overlay.hidden = false;
+      overlay.classList.remove('hidden');
+      overlay.setAttribute('aria-hidden', 'false');
+      document.body?.classList?.add('modal-open');
+      const previouslyFocused = typeof document !== 'undefined' ? document.activeElement : null;
+      const selectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+      const focusElement = element => {
+        if (!element || typeof element.focus !== 'function') return;
+        try { element.focus({ preventScroll: true }); }
+        catch {
+          try { element.focus(); }
+          catch { /* ignore focus errors */ }
+        }
+      };
+      const isFocusable = element => {
+        if (!element || element.disabled) return false;
+        if (element.hidden) return false;
+        if (element.getAttribute('aria-hidden') === 'true') return false;
+        const tabindex = element.getAttribute('tabindex');
+        if (tabindex === '-1') return false;
+        if (typeof element.getClientRects === 'function') {
+          const rects = element.getClientRects();
+          if (rects && rects.length === 0) return false;
+        }
+        return true;
+      };
+      const getFocusable = () => Array.from(overlay.querySelectorAll(selectors)).filter(isFocusable);
+      const initialFocus = () => {
+        const focusable = getFocusable();
+        focusElement(accept || focusable[0] || dialog);
+      };
+      if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(initialFocus);
+      } else {
+        setTimeout(initialFocus, 0);
+      }
+      return new Promise(resolve => {
+        this.drawConfirmState = { active: true };
+        let closing = false;
+        const cleanup = confirmed => {
+          if (closing) return;
+          closing = true;
+          overlay.removeEventListener('keydown', handleKeydown);
+          overlay.removeEventListener('click', handleBackdropClick);
+          document.removeEventListener('focusin', handleFocusIn, true);
+          cancel.removeEventListener('click', handleCancel);
+          accept.removeEventListener('click', handleAccept);
+          this.drawConfirmState = null;
+          document.body?.classList?.remove('modal-open');
+          overlay.classList.add('hidden');
+          overlay.setAttribute('aria-hidden', 'true');
+          const finalize = () => {
+            overlay.hidden = true;
+            if (typeof document !== 'undefined'
+              && previouslyFocused
+              && typeof previouslyFocused.focus === 'function'
+              && document.contains(previouslyFocused)) {
+              focusElement(previouslyFocused);
+            }
+            resolve(confirmed);
+          };
+          if (preferReducedMotion()) {
+            finalize();
+          } else {
+            let settled = false;
+            const onTransitionEnd = () => {
+              if (settled) return;
+              settled = true;
+              overlay.removeEventListener('transitionend', onTransitionEnd);
+              finalize();
+            };
+            overlay.addEventListener('transitionend', onTransitionEnd);
+            window.setTimeout(onTransitionEnd, 360);
+          }
+        };
+        const handleKeydown = event => {
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            cleanup(false);
+            return;
+          }
+          if (event.key !== 'Tab') return;
+          const focusable = getFocusable();
+          if (!focusable.length) {
+            event.preventDefault();
+            focusElement(dialog);
+            return;
+          }
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+          const active = document.activeElement;
+          if (event.shiftKey) {
+            if (active === first || !overlay.contains(active)) {
+              event.preventDefault();
+              focusElement(last);
+            }
+          } else if (active === last) {
+            event.preventDefault();
+            focusElement(first);
+          }
+        };
+        const handleFocusIn = event => {
+          if (closing) return;
+          if (!overlay.contains(event.target)) {
+            const focusable = getFocusable();
+            focusElement(focusable[0] || dialog);
+          }
+        };
+        const handleBackdropClick = event => {
+          if (event.target === overlay) {
+            event.preventDefault();
+            cleanup(false);
+          }
+        };
+        const handleCancel = event => {
+          event.preventDefault();
+          cleanup(false);
+        };
+        const handleAccept = event => {
+          event.preventDefault();
+          cleanup(true);
+        };
+        overlay.addEventListener('keydown', handleKeydown);
+        overlay.addEventListener('click', handleBackdropClick);
+        document.addEventListener('focusin', handleFocusIn, true);
+        cancel.addEventListener('click', handleCancel);
+        accept.addEventListener('click', handleAccept);
+      });
+    }
+
     async onDraw() {
       if (this.dom.count) this.dom.count.blur();
-      if (!confirm('The Fates are fickle, are you sure you wish to draw from the Shards?')) return;
-      if (!confirm('This cannot be undone, do you really wish to tempt Fate?')) return;
       const count = Math.max(1, Math.min(PLATES.length, Number(this.dom.count?.value) || 1));
+      const confirmed = await this.showDrawConfirmation(count);
+      if (!confirmed) return;
       try {
         const notice = await this.runtime.draw(count);
         if (notice) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1918,6 +1918,22 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
 .mini-game-invite__decline:focus-visible{outline:2px solid var(--error);outline-offset:2px}
 .mini-game-invite__accept{flex:1 1 160px;text-align:center;padding:12px 16px;font-weight:600}
 @media(max-width:540px){.mini-game-invite{padding:18px}.mini-game-invite__actions{flex-direction:column}.mini-game-invite__decline,.mini-game-invite__accept{flex:1 1 auto;width:100%}}
+#somf-confirm-draw .modal{max-width:min(420px,100%)}
+.somf-confirm{max-width:min(420px,100%);display:flex;flex-direction:column;gap:16px;padding:22px 24px}
+.somf-confirm__header{display:flex;flex-direction:column;gap:6px;text-align:center}
+.somf-confirm__title{margin:0;font-size:1.1rem;font-weight:700}
+.somf-confirm__description{margin:0;font-size:.9rem;color:var(--muted)}
+.somf-confirm__count{margin:0;font-size:1rem;font-weight:600;text-align:center}
+.somf-confirm__label{margin:0;font-size:.8rem;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);text-align:center}
+.somf-confirm__list{margin:0;padding-left:20px;display:flex;flex-direction:column;gap:6px;font-size:.9rem;line-height:1.5;text-align:left}
+.somf-confirm__actions{display:flex;flex-wrap:wrap;gap:12px;justify-content:space-between}
+.somf-confirm__cancel{flex:1 1 140px;border:1px solid var(--line);background:rgba(255,255,255,.04);color:var(--text);padding:10px 12px;border-radius:var(--radius);font-weight:600;cursor:pointer;transition:var(--transition)}
+.theme-light .somf-confirm__cancel{background:rgba(0,0,0,.04)}
+.somf-confirm__cancel:hover{background:rgba(255,255,255,.08)}
+.theme-light .somf-confirm__cancel:hover{background:rgba(0,0,0,.08)}
+.somf-confirm__cancel:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.somf-confirm__accept{flex:1 1 160px;text-align:center;padding:12px 16px;font-weight:600}
+@media(max-width:540px){.somf-confirm{padding:18px}.somf-confirm__actions{flex-direction:column}.somf-confirm__cancel,.somf-confirm__accept{flex:1 1 auto;width:100%}}
 #modal-help{align-items:flex-start;overflow-y:auto}
 #modal-help .modal{max-height:none}
 #modal-welcome .modal{font-size:.85rem;line-height:1.4}
@@ -1945,9 +1961,13 @@ body.touch-controls-disabled .app-shell{pointer-events:none}
 @media(max-width:520px){
   .overlay .modal{padding:16px 14px}
   .mini-game-invite{padding:16px}
+  .somf-confirm{padding:16px}
   .app-alert__card,
   .somf-reveal-alert__card{padding:24px 18px;border-radius:18px}
 }
+#somf-confirm-draw{transition:opacity .3s ease-in-out}
+#somf-confirm-draw .modal{transition:transform .3s ease-in-out,opacity .3s ease-in-out}
+@media (prefers-reduced-motion: reduce){#somf-confirm-draw{transition:none}#somf-confirm-draw .modal{transition:none}}
 #rules-text{white-space:pre-wrap}
 .toast{position:fixed;bottom:18px;right:18px;background:var(--surface);border:1px solid var(--accent);padding:10px 12px;border-radius:var(--radius);opacity:0;transform:translateY(8px);transition:opacity .3s ease-in-out,transform .3s ease-in-out;z-index:2000;display:flex;align-items:center;gap:6px;pointer-events:none;will-change:transform,opacity}
 .toast::before{content:"";width:16px;height:16px;background-size:contain;background-repeat:no-repeat}


### PR DESCRIPTION
## Summary
- add a dedicated Shards of Many Fates draw confirmation overlay with consequences messaging
- hook PlayerController.onDraw to show the modal, trap focus, and honor reduced-motion before drawing
- style the new dialog to align with existing overlays and update dynamic labels for the selected draw count

## Testing
- npm test *(fails: __tests__/dm.test.js expects menu hidden after pointerdown)*

------
https://chatgpt.com/codex/tasks/task_e_68e61058537c832e9373e174e4fe828d