### PR TITLE
Add dice roll breakdown panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,7 +257,10 @@
         <div class="roll-tools__panel">
           <h3 class="roll-tools__heading">Dice Roll</h3>
           <div class="dice-roll-grid">
-            <span class="pill result" id="dice-out" data-placeholder="000"></span>
+            <div class="dice-roll-grid__results">
+              <span class="pill result" id="dice-out" data-placeholder="000"></span>
+              <ul id="dice-breakdown" class="dice-breakdown" aria-live="polite" hidden></ul>
+            </div>
             <div class="dice-roll-grid__field">
               <label for="dice-sides" class="sr-only">Sides</label>
               <select id="dice-sides" data-view-allow>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5445,11 +5445,28 @@ renderFullLogs();
 $('roll-dice').addEventListener('click', ()=>{
   const s = num($('dice-sides').value), c=num($('dice-count').value)||1;
   const out = $('dice-out');
+  const breakdown = $('dice-breakdown');
   out.classList.remove('rolling');
   const rolls = Array.from({length:c}, ()=> 1+Math.floor(Math.random()*s));
   const sum = rolls.reduce((a,b)=>a+b,0);
   out.textContent = sum;
   void out.offsetWidth; out.classList.add('rolling');
+  if (breakdown) {
+    breakdown.textContent = '';
+    if (c > 1) {
+      const fragment = document.createDocumentFragment();
+      rolls.forEach((roll, index) => {
+        const item = document.createElement('li');
+        item.textContent = String(roll);
+        item.setAttribute('aria-label', `Roll ${index + 1}: ${roll}`);
+        fragment.appendChild(item);
+      });
+      breakdown.appendChild(fragment);
+      breakdown.hidden = false;
+    } else {
+      breakdown.hidden = true;
+    }
+  }
   playDamageAnimation(sum);
   logAction(`${c}×d${s}: ${rolls.join(', ')} = ${sum}`);
   window.dmNotify?.(`Rolled ${c}d${s}: ${rolls.join(', ')} = ${sum}`);

--- a/styles/main.css
+++ b/styles/main.css
@@ -2572,11 +2572,35 @@ body.is-view-mode .power-editor__content .power-card__body{display:flex}
   gap:calc(var(--roll-tools-gap)*.5);
   align-items:center;
 }
-.dice-roll-grid>.pill.result{
+.dice-roll-grid__results{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:calc(var(--roll-tools-gap)*.5);
+}
+.dice-roll-grid__results>.pill.result{
   margin:0;
+  flex:0 0 auto;
   justify-self:stretch;
-  width:100%;
   min-width:0;
+}
+.dice-roll-grid .dice-breakdown{
+  display:flex;
+  flex-wrap:wrap;
+  gap:calc(var(--roll-tools-gap)*.35);
+  margin:0;
+  padding:0;
+  list-style:none;
+  font-size:calc(var(--roll-tools-pill-font-size)*.85);
+  color:var(--muted);
+}
+.dice-roll-grid .dice-breakdown[hidden]{
+  display:none;
+}
+.dice-roll-grid .dice-breakdown li{
+  padding:0.2em 0.55em;
+  border-radius:calc(var(--radius)*.6);
+  background:rgba(255,255,255,.08);
 }
 .dice-roll-grid__field{display:flex;flex-direction:column;min-width:0}
 .dice-roll-grid__field>select{


### PR DESCRIPTION
## Summary
- add a dice roll breakdown panel next to the combat roll total
- style the breakdown list so multi-die results appear as compact chips
- update the roll handler to populate and announce the per-die values while hiding the list for single rolls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e610734f3c832e97156d4426570d77