### PR TITLE
Add modifier and roll mode controls to dice roller

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,6 +268,18 @@
               <label for="dice-count" class="sr-only">Count</label>
               <input id="dice-count" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" min="1" value="1"/>
             </div>
+            <div class="dice-roll-grid__field">
+              <label for="dice-modifier" class="sr-only">Modifier</label>
+              <input id="dice-modifier" data-view-allow type="number" inputmode="numeric" pattern="-?[0-9]*" value="0"/>
+            </div>
+            <div class="dice-roll-grid__field">
+              <label for="dice-mode" class="sr-only">Roll Mode</label>
+              <select id="dice-mode" data-view-allow>
+                <option value="normal" selected>Normal</option>
+                <option value="advantage">Advantage</option>
+                <option value="disadvantage">Disadvantage</option>
+              </select>
+            </div>
             <button id="roll-dice" class="btn-sm">Roll</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add modifier and roll mode controls to the dice roll UI
- extend the dice roll handler to apply modifiers, advantage/disadvantage, and share detailed results

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6107e9a14832e8af95b0062e466dd