### PR TITLE
Add dice roll modifier support

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,6 +268,10 @@
               <label for="dice-count" class="sr-only">Count</label>
               <input id="dice-count" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" min="1" value="1"/>
             </div>
+            <div class="dice-roll-grid__field">
+              <label for="dice-mod" class="sr-only">Modifier</label>
+              <input id="dice-mod" data-view-allow type="number" inputmode="numeric" pattern="-?[0-9]*" value="0"/>
+            </div>
             <button id="roll-dice" class="btn-sm">Roll</button>
           </div>
         </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5443,16 +5443,21 @@ function rollWithBonus(name, bonus, out, opts = {}){
 renderLogs();
 renderFullLogs();
 $('roll-dice').addEventListener('click', ()=>{
-  const s = num($('dice-sides').value), c=num($('dice-count').value)||1;
+  const s = num($('dice-sides').value), c = num($('dice-count').value)||1;
+  const modifierInput = $('dice-mod');
+  const modifier = modifierInput ? num(modifierInput.value) : 0;
   const out = $('dice-out');
   out.classList.remove('rolling');
   const rolls = Array.from({length:c}, ()=> 1+Math.floor(Math.random()*s));
   const sum = rolls.reduce((a,b)=>a+b,0);
-  out.textContent = sum;
+  const total = sum + modifier;
+  out.textContent = total;
   void out.offsetWidth; out.classList.add('rolling');
-  playDamageAnimation(sum);
-  logAction(`${c}×d${s}: ${rolls.join(', ')} = ${sum}`);
-  window.dmNotify?.(`Rolled ${c}d${s}: ${rolls.join(', ')} = ${sum}`);
+  playDamageAnimation(total);
+  const modifierLabel = modifier >= 0 ? `+${modifier}` : `${modifier}`;
+  const breakdown = modifier ? ` ${modifier >= 0 ? '+' : '-'} ${Math.abs(modifier)} = ${total}` : '';
+  logAction(`${c}×d${s}${modifier ? ` ${modifierLabel}` : ''}: ${rolls.join(', ')} = ${sum}${breakdown}`);
+  window.dmNotify?.(`Rolled ${c}d${s}${modifier ? ` ${modifierLabel}` : ''}: ${rolls.join(', ')} = ${sum}${breakdown}`);
 });
 $('flip').addEventListener('click', ()=>{
   const v = Math.random()<.5 ? 'Heads' : 'Tails';


### PR DESCRIPTION
## Summary
- add a modifier input to the dice rolling controls with an accessible label
- include the modifier in totals, animations, and roll logging for dice results

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e610cc0190832e92d69785c9c6a570