### PR TITLE
Fix duplicate header title when mounting sync badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
       </span>
       <span class="theme-toggle__label sr-only">Theme</span>
     </button>
-    <span class="tabs-title"><span class="tabs-title__label">Catalyst Core</span><span id="cloud-sync-status" class="sync-status-badge" data-status="online" role="status" aria-live="polite">Online</span></span>
+    <span class="tabs-title">Catalyst Core<span id="cloud-sync-status" class="sync-status-badge" data-status="online" role="status" aria-live="polite">Online</span></span>
     <div class="dropdown">
       <button id="btn-menu" class="icon" aria-label="Menu" title="Menu" aria-haspopup="true" aria-expanded="false" aria-controls="menu-actions" type="button">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">

--- a/styles/main.css
+++ b/styles/main.css
@@ -190,11 +190,6 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
   justify-self:center;
 }
 
-.tabs-title__label{
-  display:inline-flex;
-  align-items:center;
-}
-
 .sync-status-badge{
   display:inline-flex;
   align-items:center;


### PR DESCRIPTION
## Summary
- remove the extra span wrapper around the Catalyst Core fallback label so header-title.js clears it before React renders
- drop the unused .tabs-title__label styles that were only needed for the wrapper

## Testing
- not run (markup-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e615f9e198832e91c43b184bc0fe80