### PR TITLE
Sync weapon attack ability with range until manually changed

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -9060,7 +9060,11 @@ function createCard(kind, pref = {}) {
     return createPowerCard(pref, { signature: kind === 'sig' });
   }
   pref = { ...pref };
+  let attackAbilityWasProvided = false;
+  let providedAttackAbilityRaw;
   if (kind === 'weapon') {
+    attackAbilityWasProvided = Object.prototype.hasOwnProperty.call(pref, 'attackAbility');
+    providedAttackAbilityRaw = pref.attackAbility;
     if (pref.attackAbility) {
       pref.attackAbility = String(pref.attackAbility).toLowerCase();
     } else {
@@ -9149,6 +9153,31 @@ function createCard(kind, pref = {}) {
   });
   const delWrap = document.createElement('div');
   delWrap.className = 'inline';
+  if (kind === 'weapon') {
+    const rangeField = qs("[data-f='range']", card);
+    const abilityField = qs("[data-f='attackAbility']", card);
+    const abilityShouldAutoSync = !attackAbilityWasProvided || !providedAttackAbilityRaw;
+    if (abilityField) {
+      abilityField.dataset.autoSync = abilityShouldAutoSync ? 'true' : 'false';
+      const markManualAbilitySelection = () => {
+        abilityField.dataset.autoSync = 'false';
+      };
+      abilityField.addEventListener('change', markManualAbilitySelection);
+      abilityField.addEventListener('input', markManualAbilitySelection);
+    }
+    if (rangeField && abilityField) {
+      const syncAbilityToRange = () => {
+        if (abilityField.dataset.autoSync !== 'true') return;
+        const inferred = inferWeaponAttackAbility({ range: rangeField.value });
+        if (!inferred) return;
+        if (abilityField.value !== inferred) {
+          abilityField.value = inferred;
+        }
+      };
+      rangeField.addEventListener('input', syncAbilityToRange);
+      rangeField.addEventListener('change', syncAbilityToRange);
+    }
+  }
   if (kind === 'weapon' || kind === 'sig' || kind === 'power') {
     const hitBtn = document.createElement('button');
     hitBtn.className = 'btn-sm';


### PR DESCRIPTION
## Summary
- track whether a weapon card's attack ability selection was provided manually
- auto-update the attack ability dropdown when the range changes until the user selects a value themselves

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e621a01084832e93555c2d1872f846