### PR TITLE
Automate gear classification tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,44 @@ regenerate the compiled assets before deploying. This pipeline will:
 If you only need to refresh the manifest, the legacy
 `npm run build:manifest` command is still available.
 
+## Gear classification vocabulary
+
+The catalog build normalizes every item into a controlled set of
+`classifications` so search, filters, and character gating can reason about the
+gear consistently. The script infers tags from the source CSV using section,
+type, and keyword heuristics. The available tags are:
+
+| Tag | Meaning |
+| --- | --- |
+| `useful` | Items that originate from the **Useful** section of the source CSV. |
+| `gear` | Entries from the **Gear** section. |
+| `catalyst` | Entries from the **Catalyst** section. |
+| `weapon` | Weapon-type gear (automatically also tagged `offense`). |
+| `armor` | Armor entries. |
+| `shield` | Shield entries. |
+| `utility` | Utility-type gear providing general tools or support. |
+| `item` | Generic items without a more specific type. |
+| `melee` | Weapons with close-combat language (blade, gauntlet, spear, etc.). |
+| `ranged` | Weapons that reference shots, launchers, bows, or other ranged cues. |
+| `offense` | Weapons or gear that emphasize dealing damage. |
+| `defense` | Protective equipment or entries that focus on shielding, resistance, or mitigation. |
+| `support` | Boons that assist allies, coordination, or buffs. |
+| `healing` | Medical and restorative equipment. |
+| `mobility` | Gear that enhances movement, teleportation, or traversal. |
+| `stealth` | Items that aid stealth, invisibility, or concealment. |
+| `control` | Effects that hinder, restrain, or disable foes. |
+| `tech` | Clearly technological gadgets, drones, or devices. |
+| `magic` | Items with explicitly arcane, mystical, or enchanted themes. |
+| `psionic` | Gear flavored around psychic or telepathic effects. |
+| `chemical` | Chemical, toxic, or pharmaceutical consumables. |
+| `consumable` | Single-use or charge-based entries that are expended on use. |
+
+When new items are added to the CSV, ensure their copy includes descriptive
+language that lets the build heuristics assign the right tags, or supply
+explicit classifications in the CSV to supplement the inferred values. These
+descriptors are treated as non-restrictive; gating only applies when a catalog
+entry lists additional classification tokens outside of this vocabulary.
+
 ## Storage
 
 Saved characters are stored locally in your browser using `localStorage` and synchronized through a Firebase Realtime Database.

--- a/data/gear-catalog.json
+++ b/data/gear-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-30T09:04:55.746Z",
+  "generatedAt": "2025-10-08T08:51:32.529Z",
   "source": {
     "master": "CatalystCore_Master_Book.csv",
     "prices": "CatalystCore_Items_Prices.csv",
@@ -21,10 +21,18 @@
       "use": "Action on self or adjacent ally; consumes 1 use.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "chemical",
+        "consumable",
+        "healing",
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item nano-stim kit t5 ₡1200 heal 1d6 hp. medical-grade supplies and programmable injector. action on self or adjacent ally; consumes 1 use. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item nano-stim kit t5 ₡1200 heal 1d6 hp. medical-grade supplies and programmable injector. action on self or adjacent ally; consumes 1 use. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item healing support tech chemical consumable"
     },
     {
       "section": "Useful",
@@ -40,10 +48,16 @@
       "use": "Action on a creature at 0 HP.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "healing",
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item trauma foam canister t5 ₡2000 prevent bleedout this scene. expanding coagulant seals wounds on contact. action on a creature at 0 hp. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item trauma foam canister t5 ₡2000 prevent bleedout this scene. expanding coagulant seals wounds on contact. action on a creature at 0 hp. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item healing support tech"
     },
     {
       "section": "Useful",
@@ -59,10 +73,17 @@
       "use": "Bonus action to inject.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "chemical",
+        "item",
+        "mobility",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item cleanse ampoule t5 ₡2800 end one minor condition on self. dual-phase detox shot. bonus action to inject. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item cleanse ampoule t5 ₡2800 end one minor condition on self. dual-phase detox shot. bonus action to inject. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item mobility offense tech chemical"
     },
     {
       "section": "Useful",
@@ -78,10 +99,16 @@
       "use": "Action on self/adjacent ally.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "healing",
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item quick-patch field bandage t5 ₡3600 gain 5 temp hp until fight ends. rapid-fuse fibers stabilize impacts. action on self/adjacent ally. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item quick-patch field bandage t5 ₡3600 gain 5 temp hp until fight ends. rapid-fuse fibers stabilize impacts. action on self/adjacent ally. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item healing support tech"
     },
     {
       "section": "Useful",
@@ -97,10 +124,14 @@
       "use": "Action to ignite; 10 min burn.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item spark flares x3 t5 ₡4400 advantage on one search in darkness. high-candela flare sticks. action to ignite; 10 min burn. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item spark flares x3 t5 ₡4400 advantage on one search in darkness. high-candela flare sticks. action to ignite; 10 min burn. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item tech"
     },
     {
       "section": "Useful",
@@ -116,10 +147,15 @@
       "use": "Action to anchor ¤60 ft.; reel as move.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "mobility",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item grapple line wrist-head t5 ₡5200 climb checks at advantage for 10 min. mini head with auto-reel line. action to anchor ¤60 ft.; reel as move. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item grapple line wrist-head t5 ₡5200 climb checks at advantage for 10 min. mini head with auto-reel line. action to anchor ¤60 ft.; reel as move. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item mobility tech"
     },
     {
       "section": "Useful",
@@ -135,10 +171,15 @@
       "use": "Bonus action to deploy; 10 min.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "psionic",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item collapsible climbing spikes t5 ₡5900 ignore basic sheer surfaces. folding palm spikes bite into walls. bonus action to deploy; 10 min. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item collapsible climbing spikes t5 ₡5900 ignore basic sheer surfaces. folding palm spikes bite into walls. bonus action to deploy; 10 min. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item tech psionic"
     },
     {
       "section": "Useful",
@@ -154,10 +195,15 @@
       "use": "Action to flash code.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item signal mirror tile t5 ₡6700 ping ally up to 2 miles once. polished shard-coded signaling tile. action to flash code. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item signal mirror tile t5 ₡6700 ping ally up to 2 miles once. polished shard-coded signaling tile. action to flash code. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item support tech"
     },
     {
       "section": "Useful",
@@ -173,10 +219,15 @@
       "use": "Passive while consumed over a week.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "consumable",
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item ration brick weekpack t5 ₡7500 ignore food checks this week. dense nutrient bricks. passive while consumed over a week. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item ration brick weekpack t5 ₡7500 ignore food checks this week. dense nutrient bricks. passive while consumed over a week. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item tech consumable"
     },
     {
       "section": "Useful",
@@ -192,10 +243,14 @@
       "use": "Action to draw water.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item purifier straw t5 ₡8300 ignore water hazard checks 1 day. inline filter kills pathogens. action to draw water. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item purifier straw t5 ₡8300 ignore water hazard checks 1 day. inline filter kills pathogens. action to draw water. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item tech"
     },
     {
       "section": "Useful",
@@ -211,10 +266,13 @@
       "use": "Use during a Tools check.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item multi-tool mk1 t5 ₡9100 +1 to one tools check per scene. compact pliers, driver, edge. use during a tools check. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item multi-tool mk1 t5 ₡9100 +1 to one tools check per scene. compact pliers, driver, edge. use during a tools check. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item"
     },
     {
       "section": "Useful",
@@ -230,10 +288,13 @@
       "use": "1 minute to cut; fuel limited.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item flex-torch cutter t5 ₡9800 open light locks in 1 minute. heat wire torch on flex-arm. 1 minute to cut; fuel limited. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item flex-torch cutter t5 ₡9800 open light locks in 1 minute. heat wire torch on flex-arm. 1 minute to cut; fuel limited. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item"
     },
     {
       "section": "Useful",
@@ -249,10 +310,14 @@
       "use": "Action; add +1 to check.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item lockpick filaments t5 ₡10600 +1 to lockpicking. memory-metal micro picks. action; add +1 to check. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item lockpick filaments t5 ₡10600 +1 to lockpicking. memory-metal micro picks. action; add +1 to check. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item tech"
     },
     {
       "section": "Useful",
@@ -268,10 +333,15 @@
       "use": "Bonus action to apply.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "stealth",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item crowd masker spray t5 ₡11400 1 min advantage avoiding recognition. aerosol micro-glitter confuses cams. bonus action to apply. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item crowd masker spray t5 ₡11400 1 min advantage avoiding recognition. aerosol micro-glitter confuses cams. bonus action to apply. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item stealth tech"
     },
     {
       "section": "Useful",
@@ -287,10 +357,14 @@
       "use": "Action to throw (30 ft.).",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item optic flash grenade x2 t5 ₡12200 blind 1 round (con save). pin-pull flash pellet. action to throw (30 ft.). none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item optic flash grenade x2 t5 ₡12200 blind 1 round (con save). pin-pull flash pellet. action to throw (30 ft.). none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item tech"
     },
     {
       "section": "Useful",
@@ -306,10 +380,15 @@
       "use": "Action to throw (30 ft.).",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item smoke capsule x3 t5 ₡13000 create light cover 2 rounds. puff-smoke spheres. action to throw (30 ft.). none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item smoke capsule x3 t5 ₡13000 create light cover 2 rounds. puff-smoke spheres. action to throw (30 ft.). none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item defense tech"
     },
     {
       "section": "Useful",
@@ -325,10 +404,16 @@
       "use": "Declare before hit.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "item",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item shock baton compact t5 ₡13800 once per scene add stun (wis save). telescoping baton with shock head. declare before hit. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item shock baton compact t5 ₡13800 once per scene add stun (wis save). telescoping baton with shock head. declare before hit. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item control offense tech"
     },
     {
       "section": "Useful",
@@ -344,10 +429,14 @@
       "use": "Action to write/read.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item data shard blank t5 ₡14500 carry 1 secure file untraceable. one-time write anti-tamper chip. action to write/read. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item data shard blank t5 ₡14500 carry 1 secure file untraceable. one-time write anti-tamper chip. action to write/read. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item tech"
     },
     {
       "section": "Useful",
@@ -363,10 +452,14 @@
       "use": "Bonus action to tune.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item comms tap clip t5 ₡15300 intercept 1 unsecured channel this scene. clip-on rf sniffer. bonus action to tune. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item comms tap clip t5 ₡15300 intercept 1 unsecured channel this scene. clip-on rf sniffer. bonus action to tune. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item tech"
     },
     {
       "section": "Useful",
@@ -382,10 +475,16 @@
       "use": "Action to launch; bonus to direct.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "healing",
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item micro-drone scout t5 ₡16100 10 min remote peek; +1 passive perception. palm quad with stabilized cam. action to launch; bonus to direct. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item micro-drone scout t5 ₡16100 10 min remote peek; +1 passive perception. palm quad with stabilized cam. action to launch; bonus to direct. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item healing support tech"
     },
     {
       "section": "Useful",
@@ -401,10 +500,13 @@
       "use": "Passive for item inside.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item faraday pouch t5 ₡16900 item inside cannot be scanned. conductive weave pouch. passive for item inside. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item faraday pouch t5 ₡16900 item inside cannot be scanned. conductive weave pouch. passive for item inside. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item"
     },
     {
       "section": "Useful",
@@ -420,10 +522,15 @@
       "use": "Bonus action to activate.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "stealth",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item adhesive bootsoles t5 ₡17700 advantage on stealth 1 min. tacky microtread soles. bonus action to activate. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item adhesive bootsoles t5 ₡17700 advantage on stealth 1 min. tacky microtread soles. bonus action to activate. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item stealth tech"
     },
     {
       "section": "Useful",
@@ -439,10 +546,15 @@
       "use": "Use when resting/exposed.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "item",
+        "psionic",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item thermal blanket foil t5 ₡18400 resist environmental cold checks. reflective emergency foil. use when resting/exposed. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item thermal blanket foil t5 ₡18400 resist environmental cold checks. reflective emergency foil. use when resting/exposed. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item defense psionic"
     },
     {
       "section": "Useful",
@@ -458,10 +570,13 @@
       "use": "Present at clinic intake.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item medbay fast-pass t5 ₡19200 move to front of clinic queue. priority band with qr. present at clinic intake. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item medbay fast-pass t5 ₡19200 move to front of clinic queue. priority band with qr. present at clinic intake. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item"
     },
     {
       "section": "Useful",
@@ -477,10 +592,13 @@
       "use": "Flash on entry.",
       "attunement": "None required.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item transit badge city t5 ₡20000 free metro/ferries 1 month. coded transit badge. flash on entry. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "useful item transit badge city t5 ₡20000 free metro/ferries 1 month. coded transit badge. flash on entry. none required. pfv quartermaster, neighborhood outfitters, city surplus auctions. useful item"
     },
     {
       "section": "Useful",
@@ -496,10 +614,18 @@
       "use": "Action to inject.",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "chemical",
+        "control",
+        "healing",
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item auto-injector resin t4 ₡25000 heal 2d6; remove burn/freeze. programmable dual-resin cartridge. action to inject. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item auto-injector resin t4 ₡25000 heal 2d6; remove burn/freeze. programmable dual-resin cartridge. action to inject. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item healing support control tech chemical"
     },
     {
       "section": "Useful",
@@ -515,10 +641,17 @@
       "use": "Reaction when stunned.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "healing",
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item stabilizer collar t4 ₡28900 ignore stun once per scene. neck brace with micro-gyros. reaction when stunned. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item stabilizer collar t4 ₡28900 ignore stun once per scene. neck brace with micro-gyros. reaction when stunned. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item healing support control tech"
     },
     {
       "section": "Useful",
@@ -534,10 +667,14 @@
       "use": "Action to record/play.",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item echo recorder coin t4 ₡32900 replay last 10 sec of audio. shard-memory coin. action to record/play. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item echo recorder coin t4 ₡32900 replay last 10 sec of audio. shard-memory coin. action to record/play. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item tech"
     },
     {
       "section": "Useful",
@@ -553,10 +690,17 @@
       "use": "Action to place/throw (20 ft.).",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "consumable",
+        "control",
+        "item",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item emp charge pocket t4 ₡36800 disrupt 1 device/drone (int save). pocket coil charge. action to place/throw (20 ft.). none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item emp charge pocket t4 ₡36800 disrupt 1 device/drone (int save). pocket coil charge. action to place/throw (20 ft.). none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item control offense tech consumable"
     },
     {
       "section": "Useful",
@@ -572,10 +716,14 @@
       "use": "Bonus action to project.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item holo-projector palm t4 ₡40800 create decoy for 1 round. palm holo throws silhouette. bonus action to project. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item holo-projector palm t4 ₡40800 create decoy for 1 round. palm holo throws silhouette. bonus action to project. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item tech"
     },
     {
       "section": "Useful",
@@ -591,10 +739,15 @@
       "use": "Action to fire; move on reel.",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "mobility",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item grapple launcher pro t4 ₡44700 swing 30 ft. as movement. forearm launcher with barbed head. action to fire; move on reel. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item grapple launcher pro t4 ₡44700 swing 30 ft. as movement. forearm launcher with barbed head. action to fire; move on reel. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item mobility tech"
     },
     {
       "section": "Useful",
@@ -610,10 +763,15 @@
       "use": "Action to throw (20 ft.).",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item shock nets x2 t4 ₡48700 restrain medium target (str save). weighted electrified net. action to throw (20 ft.). none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item shock nets x2 t4 ₡48700 restrain medium target (str save). weighted electrified net. action to throw (20 ft.). none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item control tech"
     },
     {
       "section": "Useful",
@@ -629,10 +787,14 @@
       "use": "Bonus action to toggle.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item thermal scope clip t4 ₡52600 reveal hidden in smoke/dark this scene. clip-on thermal. bonus action to toggle. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item thermal scope clip t4 ₡52600 reveal hidden in smoke/dark this scene. clip-on thermal. bonus action to toggle. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item tech"
     },
     {
       "section": "Useful",
@@ -648,10 +810,15 @@
       "use": "Bonus action to arm (10 min).",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item voice scrambler larynx-tab t4 ₡56600 resist voice id checks. skin-tab modulates timbre. bonus action to arm (10 min). none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item voice scrambler larynx-tab t4 ₡56600 resist voice id checks. skin-tab modulates timbre. bonus action to arm (10 min). none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item defense tech"
     },
     {
       "section": "Useful",
@@ -667,10 +834,15 @@
       "use": "Action to don; passive 10 min.",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "chemical",
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item chemseal poncho t4 ₡60500 ignore poison terrain 10 min. sealed slicker with filters. action to don; passive 10 min. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item chemseal poncho t4 ₡60500 ignore poison terrain 10 min. sealed slicker with filters. action to don; passive 10 min. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item tech chemical"
     },
     {
       "section": "Useful",
@@ -686,10 +858,16 @@
       "use": "Reaction when falling.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "item",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item kinetic dampers anklets t4 ₡64500 reduce fall damage by 20. ankle damper pads. reaction when falling. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item kinetic dampers anklets t4 ₡64500 reduce fall damage by 20. ankle damper pads. reaction when falling. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item control offense tech"
     },
     {
       "section": "Useful",
@@ -705,10 +883,16 @@
       "use": "Bonus action to slot.",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "consumable",
+        "item",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item quick-charge cell t4 ₡68400 refresh one utility mid-scene. high-discharge battery puck. bonus action to slot. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item quick-charge cell t4 ₡68400 refresh one utility mid-scene. high-discharge battery puck. bonus action to slot. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item offense tech consumable"
     },
     {
       "section": "Useful",
@@ -724,10 +908,14 @@
       "use": "5 min to test; expendables limited.",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "consumable",
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item field lab kit t4 ₡72400 identify unknown sample in 5 min. portable assay bench. 5 min to test; expendables limited. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item field lab kit t4 ₡72400 identify unknown sample in 5 min. portable assay bench. 5 min to test; expendables limited. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item consumable"
     },
     {
       "section": "Useful",
@@ -743,10 +931,13 @@
       "use": "Hand-off to target.",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item bribe envelope city t4 ₡76300 one favor from minor official. discrete contact envelope. hand-off to target. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item bribe envelope city t4 ₡76300 one favor from minor official. discrete contact envelope. hand-off to target. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item"
     },
     {
       "section": "Useful",
@@ -762,10 +953,13 @@
       "use": "Present to handler.",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item media spin voucher t4 ₡80300 reroll one public trust check. agency favor marker. present to handler. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item media spin voucher t4 ₡80300 reroll one public trust check. agency favor marker. present to handler. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item"
     },
     {
       "section": "Useful",
@@ -781,10 +975,14 @@
       "use": "Action to summon courier.",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item courier drone hire t4 ₡84200 deliver item across city in 15 min. courier contract token. action to summon courier. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item courier drone hire t4 ₡84200 deliver item across city in 15 min. courier contract token. action to summon courier. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item tech"
     },
     {
       "section": "Useful",
@@ -800,10 +998,14 @@
       "use": "Passive while used.",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item hardcase satchel t4 ₡88200 contents immune to shatter/water. polymer armored satchel. passive while used. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item hardcase satchel t4 ₡88200 contents immune to shatter/water. polymer armored satchel. passive while used. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item defense"
     },
     {
       "section": "Useful",
@@ -819,10 +1021,16 @@
       "use": "Bonus action to apply (1 hr. cooldown).",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "healing",
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item reflex stim pack t4 ₡92100 +2 initiative this encounter. dermal patch floods adrenaline. bonus action to apply (1 hr. cooldown). none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item reflex stim pack t4 ₡92100 +2 initiative this encounter. dermal patch floods adrenaline. bonus action to apply (1 hr. cooldown). none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item healing support tech"
     },
     {
       "section": "Useful",
@@ -838,10 +1046,16 @@
       "use": "Bonus action to inject.",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "chemical",
+        "item",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item adrenal shot twin t4 ₡96100 gain 1 temp sp now and next round. dual-stage injector. bonus action to inject. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item adrenal shot twin t4 ₡96100 gain 1 temp sp now and next round. dual-stage injector. bonus action to inject. none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item offense tech chemical"
     },
     {
       "section": "Useful",
@@ -857,10 +1071,16 @@
       "use": "Action to coat (10 min cure).",
       "attunement": "None required.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "item",
+        "stealth",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item stealth paint spray t4 ₡100000 lower detection dc for vehicle/suit. radar-absorbent aerosol. action to coat (10 min cure). none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "useful item stealth paint spray t4 ₡100000 lower detection dc for vehicle/suit. radar-absorbent aerosol. action to coat (10 min cure). none required. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. useful item stealth defense tech"
     },
     {
       "section": "Useful",
@@ -876,10 +1096,15 @@
       "use": "Action to throw (30 ft.).",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item stasis grenade t3 ₡125000 freeze 10 ft. zone 1 round (dex save). temporal gel burst. action to throw (30 ft.). none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item stasis grenade t3 ₡125000 freeze 10 ft. zone 1 round (dex save). temporal gel burst. action to throw (30 ft.). none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item control tech"
     },
     {
       "section": "Useful",
@@ -895,10 +1120,14 @@
       "use": "Action to throw (30 ft.).",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item singularity marble t3 ₡138200 pull 15 ft.; prone on fail (str save). pocket gravity sink. action to throw (30 ft.). none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item singularity marble t3 ₡138200 pull 15 ft.; prone on fail (str save). pocket gravity sink. action to throw (30 ft.). none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item tech"
     },
     {
       "section": "Useful",
@@ -914,10 +1143,15 @@
       "use": "Action to deploy.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item portable shield wall t3 ₡151300 half-cover 3 rounds. folding carbon slab with anchors. action to deploy. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item portable shield wall t3 ₡151300 half-cover 3 rounds. folding carbon slab with anchors. action to deploy. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item defense tech"
     },
     {
       "section": "Useful",
@@ -933,10 +1167,15 @@
       "use": "Action to arm.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item echo-trace jammer t3 ₡164500 cannot be tracked for 1 hour. noise virus for comms/meta. action to arm. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item echo-trace jammer t3 ₡164500 cannot be tracked for 1 hour. noise virus for comms/meta. action to arm. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item control tech"
     },
     {
       "section": "Useful",
@@ -952,10 +1191,14 @@
       "use": "Bonus action to take.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item neural calm tab t3 ₡177600 end confused/fear on self. lingual neurotab. bonus action to take. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item neural calm tab t3 ₡177600 end confused/fear on self. lingual neurotab. bonus action to take. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item tech"
     },
     {
       "section": "Useful",
@@ -971,10 +1214,17 @@
       "use": "Action to deploy; reacts when ally hit.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "healing",
+        "item",
+        "offense",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item triage drone buddy t3 ₡190800 heal 1d6 to ally as reaction 1/scene. mini med-drone. action to deploy; reacts when ally hit. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item triage drone buddy t3 ₡190800 heal 1d6 to ally as reaction 1/scene. mini med-drone. action to deploy; reacts when ally hit. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item healing support offense tech"
     },
     {
       "section": "Useful",
@@ -990,10 +1240,14 @@
       "use": "Action to plant.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item remote door spike t3 ₡203900 seal door 2 rounds; breach dc +5. hydraulic ram wedge. action to plant. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item remote door spike t3 ₡203900 seal door 2 rounds; breach dc +5. hydraulic ram wedge. action to plant. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item tech"
     },
     {
       "section": "Useful",
@@ -1009,10 +1263,15 @@
       "use": "Action to step through.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "mobility",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item phase key fob t3 ₡217100 pass thin wall once (5 ft.). micro-phase key. action to step through. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item phase key fob t3 ₡217100 pass thin wall once (5 ft.). micro-phase key. action to step through. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item mobility tech"
     },
     {
       "section": "Useful",
@@ -1028,10 +1287,17 @@
       "use": "Bonus action to apply.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "defense",
+        "item",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item kinetic absorb gel t3 ₡230300 reduce next hit by 8. two-part impact gel. bonus action to apply. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item kinetic absorb gel t3 ₡230300 reduce next hit by 8. two-part impact gel. bonus action to apply. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item control defense offense tech"
     },
     {
       "section": "Useful",
@@ -1047,10 +1313,15 @@
       "use": "Bonus action to mark.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item target beacon tagger t3 ₡243400 allies +1 to hit target this scene. laser micro-tag. bonus action to mark. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item target beacon tagger t3 ₡243400 allies +1 to hit target this scene. laser micro-tag. bonus action to mark. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item offense tech"
     },
     {
       "section": "Useful",
@@ -1066,10 +1337,14 @@
       "use": "Bonus action to apply.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item reflex loop patch t3 ₡256600 +2 tc vs aoe for 1 minute. nerve loop patch. bonus action to apply. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item reflex loop patch t3 ₡256600 +2 tc vs aoe for 1 minute. nerve loop patch. bonus action to apply. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item tech"
     },
     {
       "section": "Useful",
@@ -1085,10 +1360,16 @@
       "use": "Action to apply.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "chemical",
+        "defense",
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item hazard antidote kit t3 ₡269700 resist poison or radiation 1 hour. neutralizer kit. action to apply. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item hazard antidote kit t3 ₡269700 resist poison or radiation 1 hour. neutralizer kit. action to apply. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item defense tech chemical"
     },
     {
       "section": "Useful",
@@ -1104,10 +1385,15 @@
       "use": "Action to release; 1 min map.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "mobility",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item survey swarm capsules t3 ₡282900 map 300 ft. area quickly. self-flying pucks. action to release; 1 min map. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item survey swarm capsules t3 ₡282900 map 300 ft. area quickly. self-flying pucks. action to release; 1 min map. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item mobility tech"
     },
     {
       "section": "Useful",
@@ -1123,10 +1409,14 @@
       "use": "Use at depot; lasts 1 day.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "mobility",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item sling-bike day rental t3 ₡296100 fast escape; +10 ft. travel speed. scrip for city sling-bike. use at depot; lasts 1 day. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item sling-bike day rental t3 ₡296100 fast escape; +10 ft. travel speed. scrip for city sling-bike. use at depot; lasts 1 day. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item mobility"
     },
     {
       "section": "Useful",
@@ -1142,10 +1432,14 @@
       "use": "Present card at stop.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item legal retainer basic t3 ₡309200 advantage to avoid detention once. law office on retainer. present card at stop. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item legal retainer basic t3 ₡309200 advantage to avoid detention once. law office on retainer. present card at stop. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item tech"
     },
     {
       "section": "Useful",
@@ -1161,10 +1455,14 @@
       "use": "Cash in with broker.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item data broker token t3 ₡322400 one actionable lead in 24 hr. broker chip. cash in with broker. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item data broker token t3 ₡322400 one actionable lead in 24 hr. broker chip. cash in with broker. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item tech"
     },
     {
       "section": "Useful",
@@ -1180,10 +1478,15 @@
       "use": "Action to clamp in melee.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item power sink clamp t3 ₡335500 drain 1 sp on hit (con save). clamp with reverse flow. action to clamp in melee. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item power sink clamp t3 ₡335500 drain 1 sp on hit (con save). clamp with reverse flow. action to clamp in melee. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item offense tech"
     },
     {
       "section": "Useful",
@@ -1199,10 +1502,14 @@
       "use": "Reaction on hearing effect.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item resonance tuning fork t3 ₡348700 cancel one sonic effect. counter-tone fork. reaction on hearing effect. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item resonance tuning fork t3 ₡348700 cancel one sonic effect. counter-tone fork. reaction on hearing effect. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item tech"
     },
     {
       "section": "Useful",
@@ -1218,10 +1525,16 @@
       "use": "Bonus action to fade.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "offense",
+        "stealth",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item micro-camo cloaklet t3 ₡361800 1 round invisibility (ends on attack). adaptive fabric mantle. bonus action to fade. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item micro-camo cloaklet t3 ₡361800 1 round invisibility (ends on attack). adaptive fabric mantle. bonus action to fade. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item stealth offense tech"
     },
     {
       "section": "Useful",
@@ -1237,10 +1550,14 @@
       "use": "Action to spray.",
       "attunement": "None required.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item riot foam sprayer t3 ₡375000 10 ft. difficult terrain 2 rounds. expanding riot foam. action to spray. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "useful item riot foam sprayer t3 ₡375000 10 ft. difficult terrain 2 rounds. expanding riot foam. action to spray. none required. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. useful item tech"
     },
     {
       "section": "Useful",
@@ -1256,10 +1573,16 @@
       "use": "10 min setup; action to begin.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "healing",
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item mobile med-pod hour t2 ₡400000 restore 3d6 hp to one ally. rental field med-pod hour. 10 min setup; action to begin. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item mobile med-pod hour t2 ₡400000 restore 3d6 hp to one ally. rental field med-pod hour. 10 min setup; action to begin. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item healing support tech"
     },
     {
       "section": "Useful",
@@ -1275,10 +1598,14 @@
       "use": "File payload; auto-deliver.",
       "attunement": "None required.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item quantum courier contract t2 ₡442900 secure off-world drop in 12 hr. quantum-address token. file payload; auto-deliver. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item quantum courier contract t2 ₡442900 secure off-world drop in 12 hr. quantum-address token. file payload; auto-deliver. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item tech"
     },
     {
       "section": "Useful",
@@ -1294,10 +1621,13 @@
       "use": "Use at checkpoint.",
       "attunement": "None required.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item blackline secure id t2 ₡485700 pass two deep scans per week. forged identity packet. use at checkpoint. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item blackline secure id t2 ₡485700 pass two deep scans per week. forged identity packet. use at checkpoint. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item"
     },
     {
       "section": "Useful",
@@ -1313,10 +1643,14 @@
       "use": "Bonus action to pulse.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item aegis field projector t2 ₡528600 allies in 10 ft. gain +1 tc 1 round. hip projector. bonus action to pulse. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item aegis field projector t2 ₡528600 allies in 10 ft. gain +1 tc 1 round. hip projector. bonus action to pulse. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item tech"
     },
     {
       "section": "Useful",
@@ -1332,10 +1666,14 @@
       "use": "Action to trigger; 3 round delay.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item recall beacon home t2 ₡571400 return to safehouse (30 ft. circle). beacon keyed to home node. action to trigger; 3 round delay. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item recall beacon home t2 ₡571400 return to safehouse (30 ft. circle). beacon keyed to home node. action to trigger; 3 round delay. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item tech"
     },
     {
       "section": "Useful",
@@ -1351,10 +1689,14 @@
       "use": "Action to plant/throw (20 ft.).",
       "attunement": "None required.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item arc-emp mine x2 t2 ₡614300 shut down mechs 1 round (int save). dual arc plates. action to plant/throw (20 ft.). none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item arc-emp mine x2 t2 ₡614300 shut down mechs 1 round (int save). dual arc plates. action to plant/throw (20 ft.). none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item tech"
     },
     {
       "section": "Useful",
@@ -1370,10 +1712,16 @@
       "use": "Action to initiate; lasts scene.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item tactical net suite t2 ₡657100 team shares passive perception. encrypted sync suite. action to initiate; lasts scene. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item tactical net suite t2 ₡657100 team shares passive perception. encrypted sync suite. action to initiate; lasts scene. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item control support tech"
     },
     {
       "section": "Useful",
@@ -1389,10 +1737,14 @@
       "use": "1 hour to cook camp meal.",
       "attunement": "None required.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "support",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item field kitchen rig t2 ₡700000 camp grants +1 save next day to allies. portable galley. 1 hour to cook camp meal. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item field kitchen rig t2 ₡700000 camp grants +1 save next day to allies. portable galley. 1 hour to cook camp meal. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item support"
     },
     {
       "section": "Useful",
@@ -1408,10 +1760,14 @@
       "use": "Action to ping.",
       "attunement": "None required.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item skyhook extraction ping t2 ₡742900 evac to roof in 3 rounds. beacon for skyhook. action to ping. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item skyhook extraction ping t2 ₡742900 evac to roof in 3 rounds. beacon for skyhook. action to ping. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item tech"
     },
     {
       "section": "Useful",
@@ -1427,10 +1783,13 @@
       "use": "Use at purchase.",
       "attunement": "None required.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item ghost account credit t2 ₡785700 one purchase cannot be traced. blind credit escrow. use at purchase. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item ghost account credit t2 ₡785700 one purchase cannot be traced. blind credit escrow. use at purchase. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item"
     },
     {
       "section": "Useful",
@@ -1446,10 +1805,14 @@
       "use": "Bonus action to arm.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item power amplifier spur t2 ₡828600 next 3 sp ability add +1d4 effect. clip-on amplifier. bonus action to arm. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item power amplifier spur t2 ₡828600 next 3 sp ability add +1d4 effect. clip-on amplifier. bonus action to arm. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item tech"
     },
     {
       "section": "Useful",
@@ -1465,10 +1828,14 @@
       "use": "Action to throw (30 ft.).",
       "attunement": "None required.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item ion fog canister t2 ₡871400 block optics/thermal 2 rounds. aerosol ion fog. action to throw (30 ft.). none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item ion fog canister t2 ₡871400 block optics/thermal 2 rounds. aerosol ion fog. action to throw (30 ft.). none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item tech"
     },
     {
       "section": "Useful",
@@ -1484,10 +1851,15 @@
       "use": "Action to fire (crossbow/launcher).",
       "attunement": "None required.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "mobility",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item smart grapple bolts t2 ₡914300 pull medium target 10 ft. (str save). guided grapple bolts. action to fire (crossbow/launcher). none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item smart grapple bolts t2 ₡914300 pull medium target 10 ft. (str save). guided grapple bolts. action to fire (crossbow/launcher). none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item mobility tech"
     },
     {
       "section": "Useful",
@@ -1503,10 +1875,14 @@
       "use": "Present to authority.",
       "attunement": "None required.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item portable court order t2 ₡957100 lawful entry for 1 location. sealed warrant wafer. present to authority. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item portable court order t2 ₡957100 lawful entry for 1 location. sealed warrant wafer. present to authority. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item tech"
     },
     {
       "section": "Useful",
@@ -1522,10 +1898,13 @@
       "use": "10 min to inflate.",
       "attunement": "None required.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item enviro-pod bubble t2 ₡1000000 safe shelter in hazard 8 hours. inflatable life-pod. 10 min to inflate. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "useful item enviro-pod bubble t2 ₡1000000 safe shelter in hazard 8 hours. inflatable life-pod. 10 min to inflate. none required. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. useful item"
     },
     {
       "section": "Useful",
@@ -1541,10 +1920,16 @@
       "use": "Use during long rest.",
       "attunement": "None required.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "healing",
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item autodoc suite night t1 ₡1250000 full heal & remove conditions overnight. clinical full-suite stay. use during long rest. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item autodoc suite night t1 ₡1250000 full heal & remove conditions overnight. clinical full-suite stay. use during long rest. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item healing support tech"
     },
     {
       "section": "Useful",
@@ -1560,10 +1945,14 @@
       "use": "Free when invoked (1/session).",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item time-slip marker t1 ₡1409100 revert your position to start of turn once. chrono seal fob. free when invoked (1/session). required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item time-slip marker t1 ₡1409100 revert your position to start of turn once. chrono seal fob. free when invoked (1/session). required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item tech"
     },
     {
       "section": "Useful",
@@ -1579,10 +1968,14 @@
       "use": "Present to Conclave envoy.",
       "attunement": "None required.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item conclave medallion t1 ₡1568200 one diplomatic audience this arc. inscribed authority token. present to conclave envoy. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item conclave medallion t1 ₡1568200 one diplomatic audience this arc. inscribed authority token. present to conclave envoy. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item tech"
     },
     {
       "section": "Useful",
@@ -1598,10 +1991,14 @@
       "use": "Redeem with O.M.N.I. quartermaster.",
       "attunement": "None required.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item o.m.n.i. requisition token t1 ₡1727300 borrow 1 elite item 1 session. black-book token. redeem with o.m.n.i. quartermaster. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item o.m.n.i. requisition token t1 ₡1727300 borrow 1 elite item 1 session. black-book token. redeem with o.m.n.i. quartermaster. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item tech"
     },
     {
       "section": "Useful",
@@ -1617,10 +2014,15 @@
       "use": "Schedule with dispatcher.",
       "attunement": "None required.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "mobility",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item fleet skimmer charter t1 ₡1886400 air insertion anywhere in city. flight charter voucher. schedule with dispatcher. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item fleet skimmer charter t1 ₡1886400 air insertion anywhere in city. flight charter voucher. schedule with dispatcher. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item mobility tech"
     },
     {
       "section": "Useful",
@@ -1636,10 +2038,13 @@
       "use": "1 hour focused check.",
       "attunement": "None required.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item adaptive cipher seed t1 ₡2045500 crack one ultra lock in 1 hour. self-mutating cipher. 1 hour focused check. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item adaptive cipher seed t1 ₡2045500 crack one ultra lock in 1 hour. self-mutating cipher. 1 hour focused check. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item"
     },
     {
       "section": "Useful",
@@ -1655,10 +2060,16 @@
       "use": "Action to fire.",
       "attunement": "None required.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "item",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item blackout sat-burst t1 ₡2204500 disable district comms 1 round. one-shot sat uplink jammer. action to fire. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item blackout sat-burst t1 ₡2204500 disable district comms 1 round. one-shot sat uplink jammer. action to fire. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item control offense tech"
     },
     {
       "section": "Useful",
@@ -1674,10 +2085,15 @@
       "use": "Apply at checkout.",
       "attunement": "None required.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "offense",
+        "support",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item justice fund grant t1 ₡2363600 purchase at 30% discount once. grant chit. apply at checkout. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item justice fund grant t1 ₡2363600 purchase at 30% discount once. grant chit. apply at checkout. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item support offense"
     },
     {
       "section": "Useful",
@@ -1693,10 +2109,17 @@
       "use": "Action to inject; rare.",
       "attunement": "None required.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "chemical",
+        "healing",
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item miracle serum vials t1 ₡2522700 heal 6d6 hp; cleanse 2 conditions. two-part serum kit. action to inject; rare. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item miracle serum vials t1 ₡2522700 heal 6d6 hp; cleanse 2 conditions. two-part serum kit. action to inject; rare. none required. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item healing support tech chemical"
     },
     {
       "section": "Useful",
@@ -1712,10 +2135,16 @@
       "use": "Passive while installed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "consumable",
+        "item",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item phoenix charge t1 ₡2681800 if downed, stand at 1 hp 1/session. chest filament. passive while installed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item phoenix charge t1 ₡2681800 if downed, stand at 1 hp 1/session. chest filament. passive while installed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item offense tech consumable"
     },
     {
       "section": "Useful",
@@ -1731,10 +2160,14 @@
       "use": "Action to boot; lasts session.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item tactical ai lease t1 ₡2840900 +2 to one roll per scene for 3 scenes. temporary ai license. action to boot; lasts session. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item tactical ai lease t1 ₡2840900 +2 to one roll per scene for 3 scenes. temporary ai license. action to boot; lasts session. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item tech"
     },
     {
       "section": "Useful",
@@ -1750,10 +2183,15 @@
       "use": "Bonus action by either wearer.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "support",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item warp-tag transponder t1 ₡3000000 swap positions with ally once. twin-tag transponder. bonus action by either wearer. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "useful item warp-tag transponder t1 ₡3000000 swap positions with ally once. twin-tag transponder. bonus action by either wearer. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. useful item support tech"
     },
     {
       "section": "Useful",
@@ -1769,10 +2207,14 @@
       "use": "Reaction on seeing AoE.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item chorus-shard key t0 ₡3750000 negate one entire aoe once. keystone chorus crystal. reaction on seeing aoe. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "useful item chorus-shard key t0 ₡3750000 negate one entire aoe once. keystone chorus crystal. reaction on seeing aoe. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. useful item tech"
     },
     {
       "section": "Useful",
@@ -1788,10 +2230,14 @@
       "use": "Free at round start.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item chronal favor script t0 ₡4642900 act twice in one round, then fatigued. bound time contract. free at round start. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "useful item chronal favor script t0 ₡4642900 act twice in one round, then fatigued. bound time contract. free at round start. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. useful item tech"
     },
     {
       "section": "Useful",
@@ -1807,10 +2253,14 @@
       "use": "Bonus action to seal.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item void-seal capsule t0 ₡5535700 untargetable for 1 round. absolute null capsule. bonus action to seal. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "useful item void-seal capsule t0 ₡5535700 untargetable for 1 round. absolute null capsule. bonus action to seal. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. useful item tech"
     },
     {
       "section": "Useful",
@@ -1826,10 +2276,15 @@
       "use": "Reaction on lethal hit.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "offense",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item destiny bond locket t0 ₡6428600 redirect lethal hit to echo (no death). twin-soul locket. reaction on lethal hit. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "useful item destiny bond locket t0 ₡6428600 redirect lethal hit to echo (no death). twin-soul locket. reaction on lethal hit. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. useful item offense tech"
     },
     {
       "section": "Useful",
@@ -1845,10 +2300,14 @@
       "use": "Free on declaration.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item perfect mirror die t0 ₡7321400 treat any roll as 20 (1/session). flawless die. free on declaration. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "useful item perfect mirror die t0 ₡7321400 treat any roll as 20 (1/session). flawless die. free on declaration. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. useful item tech"
     },
     {
       "section": "Useful",
@@ -1864,10 +2323,15 @@
       "use": "Action to trigger.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item starwarden beacon t0 ₡8214300 summon conclave extraction. royal beacon. action to trigger. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "useful item starwarden beacon t0 ₡8214300 summon conclave extraction. royal beacon. action to trigger. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. useful item defense tech"
     },
     {
       "section": "Useful",
@@ -1883,10 +2347,14 @@
       "use": "Free when spending another item.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item law of return token t0 ₡9107100 one spent item refreshes instantly. paradox token. free when spending another item. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "useful item law of return token t0 ₡9107100 one spent item refreshes instantly. paradox token. free when spending another item. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. useful item tech"
     },
     {
       "section": "Useful",
@@ -1902,10 +2370,14 @@
       "use": "Free, narrative timing.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "item",
+        "tech",
+        "useful"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "useful item angels iou t0 ₡10000000 gm-approved miracle, once. bound promise. free, narrative timing. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "useful item angels iou t0 ₡10000000 gm-approved miracle, once. bound promise. free, narrative timing. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. useful item tech"
     },
     {
       "section": "Gear",
@@ -1921,10 +2393,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor street mesh mk i t5 ₡1200 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear armor street mesh mk i t5 ₡1200 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -1940,10 +2418,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor kevlayer suit mk i t5 ₡2000 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear armor kevlayer suit mk i t5 ₡2000 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -1959,10 +2443,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor shock-pad harness mk i t5 ₡2800 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear armor shock-pad harness mk i t5 ₡2800 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -1978,10 +2468,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor reflex stitch vest mk i t5 ₡3600 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear armor reflex stitch vest mk i t5 ₡3600 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -1997,10 +2493,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor enviro-matched suit mk i t5 ₡4400 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear armor enviro-matched suit mk i t5 ₡4400 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -2016,10 +2518,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor cryo-lined suit mk i t5 ₡5200 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear armor cryo-lined suit mk i t5 ₡5200 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -2035,10 +2543,17 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "stealth",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor k-weave cloak mk i t5 ₡5900 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear armor k-weave cloak mk i t5 ₡5900 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear armor defense stealth control tech"
     },
     {
       "section": "Gear",
@@ -2054,10 +2569,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor haztech plating mk i t5 ₡6700 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear armor haztech plating mk i t5 ₡6700 +1 tc; reduce shove once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -2073,10 +2594,16 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "defense",
+        "gear",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield kinetic bracer mk i t5 ₡7500 +1 tc; pop 5 ft. cover 1 round. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear shield kinetic bracer mk i t5 ₡7500 +1 tc; pop 5 ft. cover 1 round. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear shield defense control tech"
     },
     {
       "section": "Gear",
@@ -2092,10 +2619,16 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "shield",
+        "support",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield surge buffer mk i t5 ₡8300 +1 tc; pop 5 ft. cover 1 round. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear shield surge buffer mk i t5 ₡8300 +1 tc; pop 5 ft. cover 1 round. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear shield defense support tech"
     },
     {
       "section": "Gear",
@@ -2111,10 +2644,15 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield displacement arc shield mk i t5 ₡9100 +1 tc; pop 5 ft. cover 1 round. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear shield displacement arc shield mk i t5 ₡9100 +1 tc; pop 5 ft. cover 1 round. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear shield defense tech"
     },
     {
       "section": "Gear",
@@ -2130,10 +2668,15 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield titan barrier cuff mk i t5 ₡9800 +1 tc; pop 5 ft. cover 1 round. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear shield titan barrier cuff mk i t5 ₡9800 +1 tc; pop 5 ft. cover 1 round. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear shield defense tech"
     },
     {
       "section": "Gear",
@@ -2149,10 +2692,17 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "gear",
+        "offense",
+        "ranged",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon net launcher mk i t5 ₡10600 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear weapon net launcher mk i t5 ₡10600 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear weapon offense ranged control tech"
     },
     {
       "section": "Gear",
@@ -2168,10 +2718,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "ranged",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon arc bow mk i t5 ₡11400 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear weapon arc bow mk i t5 ₡11400 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear weapon offense ranged tech"
     },
     {
       "section": "Gear",
@@ -2187,10 +2743,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "ranged",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon sonic pistol mk i t5 ₡12200 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear weapon sonic pistol mk i t5 ₡12200 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear weapon offense ranged tech"
     },
     {
       "section": "Gear",
@@ -2206,10 +2768,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "melee",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon gauss lance mk i t5 ₡13000 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear weapon gauss lance mk i t5 ₡13000 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear weapon offense melee tech"
     },
     {
       "section": "Gear",
@@ -2225,10 +2793,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "melee",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon grav-axe mk i t5 ₡13800 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear weapon grav-axe mk i t5 ₡13800 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear weapon offense melee tech"
     },
     {
       "section": "Gear",
@@ -2244,10 +2818,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "ranged",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon rail pistol mk i t5 ₡14500 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear weapon rail pistol mk i t5 ₡14500 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear weapon offense ranged tech"
     },
     {
       "section": "Gear",
@@ -2263,10 +2843,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon cryo lancer mk i t5 ₡15300 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear weapon cryo lancer mk i t5 ₡15300 damage 1d61d10; apply a minor another creature once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear weapon offense tech"
     },
     {
       "section": "Gear",
@@ -2282,10 +2867,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility perception sync visor mk i t5 ₡16100 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear utility perception sync visor mk i t5 ₡16100 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -2301,10 +2891,16 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility kinetic assist boots mk i t5 ₡16900 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear utility kinetic assist boots mk i t5 ₡16900 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear utility support control tech"
     },
     {
       "section": "Gear",
@@ -2320,10 +2916,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility mirror-gate charm mk i t5 ₡17700 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear utility mirror-gate charm mk i t5 ₡17700 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -2339,10 +2940,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility choir-shard focus mk i t5 ₡18400 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear utility choir-shard focus mk i t5 ₡18400 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -2358,10 +2964,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility time-slip marker mk i t5 ₡19200 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear utility time-slip marker mk i t5 ₡19200 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -2377,10 +2988,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV quartermaster, neighborhood outfitters, city surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility combat reflex bead mk i t5 ₡20000 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions."
+      "search": "gear utility combat reflex bead mk i t5 ₡20000 +1 initiative or +1 tc on round one. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv quartermaster, neighborhood outfitters, city surplus auctions. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -2396,10 +3012,18 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "psionic",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor street mesh mk ii t4 ₡25000 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear armor street mesh mk ii t4 ₡25000 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear armor defense control offense tech psionic"
     },
     {
       "section": "Gear",
@@ -2415,10 +3039,18 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "psionic",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor kevlayer suit mk ii t4 ₡28900 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear armor kevlayer suit mk ii t4 ₡28900 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear armor defense control offense tech psionic"
     },
     {
       "section": "Gear",
@@ -2434,10 +3066,18 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "psionic",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor shock-pad harness mk ii t4 ₡32900 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear armor shock-pad harness mk ii t4 ₡32900 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear armor defense control offense tech psionic"
     },
     {
       "section": "Gear",
@@ -2453,10 +3093,18 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "psionic",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor reflex stitch vest mk ii t4 ₡36800 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear armor reflex stitch vest mk ii t4 ₡36800 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear armor defense control offense tech psionic"
     },
     {
       "section": "Gear",
@@ -2472,10 +3120,18 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "psionic",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor enviro-matched suit mk ii t4 ₡40800 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear armor enviro-matched suit mk ii t4 ₡40800 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear armor defense control offense tech psionic"
     },
     {
       "section": "Gear",
@@ -2491,10 +3147,18 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "psionic",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor cryo-lined suit mk ii t4 ₡44700 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear armor cryo-lined suit mk ii t4 ₡44700 +2 tc; first elemental hit 3. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear armor defense control offense tech psionic"
     },
     {
       "section": "Gear",
@@ -2510,10 +3174,15 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield echo-deflector disk mk ii t4 ₡48700 +2 tc; 1 lightning on a miss. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear shield echo-deflector disk mk ii t4 ₡48700 +2 tc; 1 lightning on a miss. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear shield defense tech"
     },
     {
       "section": "Gear",
@@ -2529,10 +3198,16 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "defense",
+        "gear",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield kinetic bracer mk ii t4 ₡52600 +2 tc; 1 lightning on a miss. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear shield kinetic bracer mk ii t4 ₡52600 +2 tc; 1 lightning on a miss. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear shield defense control tech"
     },
     {
       "section": "Gear",
@@ -2548,10 +3223,16 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "shield",
+        "support",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield surge buffer mk ii t4 ₡56600 +2 tc; 1 lightning on a miss. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear shield surge buffer mk ii t4 ₡56600 +2 tc; 1 lightning on a miss. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear shield defense support tech"
     },
     {
       "section": "Gear",
@@ -2567,10 +3248,17 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "melee",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon shock maul mk ii t4 ₡60500 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear weapon shock maul mk ii t4 ₡60500 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear weapon offense melee defense tech"
     },
     {
       "section": "Gear",
@@ -2586,10 +3274,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon coil carbine mk ii t4 ₡64500 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear weapon coil carbine mk ii t4 ₡64500 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear weapon offense defense tech"
     },
     {
       "section": "Gear",
@@ -2605,10 +3299,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon cryo sprayer mk ii t4 ₡68400 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear weapon cryo sprayer mk ii t4 ₡68400 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear weapon offense defense tech"
     },
     {
       "section": "Gear",
@@ -2624,10 +3324,17 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "melee",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon monofilament whip mk ii t4 ₡72400 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear weapon monofilament whip mk ii t4 ₡72400 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear weapon offense melee defense tech"
     },
     {
       "section": "Gear",
@@ -2643,10 +3350,18 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "ranged",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon stun rifle mk ii t4 ₡76300 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear weapon stun rifle mk ii t4 ₡76300 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear weapon offense ranged control defense tech"
     },
     {
       "section": "Gear",
@@ -2662,10 +3377,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon thermal pike mk ii t4 ₡80300 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear weapon thermal pike mk ii t4 ₡80300 damage 1d81d10; ignore light cover 1/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear weapon offense defense tech"
     },
     {
       "section": "Gear",
@@ -2681,10 +3402,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility aegis burst pack mk ii t4 ₡84200 +2 tc for 1 round after spend. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear utility aegis burst pack mk ii t4 ₡84200 +2 tc for 1 round after spend. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -2700,10 +3426,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility loopfield projector mk ii t4 ₡88200 +2 tc for 1 round after spend. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear utility loopfield projector mk ii t4 ₡88200 +2 tc for 1 round after spend. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -2719,10 +3450,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility perception sync visor mk ii t4 ₡92100 +2 tc for 1 round after spend. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear utility perception sync visor mk ii t4 ₡92100 +2 tc for 1 round after spend. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -2738,10 +3474,16 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility kinetic assist boots mk ii t4 ₡96100 +2 tc for 1 round after spend. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear utility kinetic assist boots mk ii t4 ₡96100 +2 tc for 1 round after spend. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear utility support control tech"
     },
     {
       "section": "Gear",
@@ -2757,10 +3499,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Optional: 10 minutes focus + 3 SP imprint.",
       "source": "PFV elite cases, licensed vendors, O.M.N.I. requisition with return clause.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility mirror-gate charm mk ii t4 ₡100000 +2 tc for 1 round after spend. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause."
+      "search": "gear utility mirror-gate charm mk ii t4 ₡100000 +2 tc for 1 round after spend. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. optional: 10 minutes focus + 3 sp imprint. pfv elite cases, licensed vendors, o.m.n.i. requisition with return clause. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -2776,10 +3523,17 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor street mesh mk iii t3 ₡125000 +3 tc; gain 1 sp when hit by aoe 1/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear armor street mesh mk iii t3 ₡125000 +3 tc; gain 1 sp when hit by aoe 1/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear armor defense control offense tech"
     },
     {
       "section": "Gear",
@@ -2795,10 +3549,17 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor kevlayer suit mk iii t3 ₡138200 +3 tc; gain 1 sp when hit by aoe 1/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear armor kevlayer suit mk iii t3 ₡138200 +3 tc; gain 1 sp when hit by aoe 1/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear armor defense control offense tech"
     },
     {
       "section": "Gear",
@@ -2814,10 +3575,17 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor shock-pad harness mk iii t3 ₡151300 +3 tc; gain 1 sp when hit by aoe 1/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear armor shock-pad harness mk iii t3 ₡151300 +3 tc; gain 1 sp when hit by aoe 1/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear armor defense control offense tech"
     },
     {
       "section": "Gear",
@@ -2833,10 +3601,17 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor reflex stitch vest mk iii t3 ₡164500 +3 tc; gain 1 sp when hit by aoe 1/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear armor reflex stitch vest mk iii t3 ₡164500 +3 tc; gain 1 sp when hit by aoe 1/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear armor defense control offense tech"
     },
     {
       "section": "Gear",
@@ -2852,10 +3627,17 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor enviro-matched suit mk iii t3 ₡177600 +3 tc; gain 1 sp when hit by aoe 1/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear armor enviro-matched suit mk iii t3 ₡177600 +3 tc; gain 1 sp when hit by aoe 1/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear armor defense control offense tech"
     },
     {
       "section": "Gear",
@@ -2871,10 +3653,16 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "defense",
+        "gear",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield flex-wall strap mk iii t3 ₡190800 +2 tc; 50% miss once/day. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear shield flex-wall strap mk iii t3 ₡190800 +2 tc; 50% miss once/day. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear shield defense control tech"
     },
     {
       "section": "Gear",
@@ -2890,10 +3678,15 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield reactive guard mk iii t3 ₡203900 +2 tc; 50% miss once/day. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear shield reactive guard mk iii t3 ₡203900 +2 tc; 50% miss once/day. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear shield defense tech"
     },
     {
       "section": "Gear",
@@ -2909,10 +3702,15 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield thermal diffuser mk iii t3 ₡217100 +2 tc; 50% miss once/day. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear shield thermal diffuser mk iii t3 ₡217100 +2 tc; 50% miss once/day. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear shield defense tech"
     },
     {
       "section": "Gear",
@@ -2928,10 +3726,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "melee",
+        "offense",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon carbon hammer mk iii t3 ₡230300 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear weapon carbon hammer mk iii t3 ₡230300 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear weapon offense melee"
     },
     {
       "section": "Gear",
@@ -2947,10 +3750,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "ranged",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon smart pistol mk iii t3 ₡243400 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear weapon smart pistol mk iii t3 ₡243400 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear weapon offense ranged"
     },
     {
       "section": "Gear",
@@ -2966,10 +3774,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "gear",
+        "offense",
+        "ranged",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon net launcher mk iii t3 ₡256600 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear weapon net launcher mk iii t3 ₡256600 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear weapon offense ranged control"
     },
     {
       "section": "Gear",
@@ -2985,10 +3799,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "ranged",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon arc bow mk iii t3 ₡269700 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear weapon arc bow mk iii t3 ₡269700 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear weapon offense ranged"
     },
     {
       "section": "Gear",
@@ -3004,10 +3823,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "ranged",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon sonic pistol mk iii t3 ₡282900 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear weapon sonic pistol mk iii t3 ₡282900 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear weapon offense ranged"
     },
     {
       "section": "Gear",
@@ -3023,10 +3847,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "melee",
+        "offense",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon gauss lance mk iii t3 ₡296100 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear weapon gauss lance mk iii t3 ₡296100 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear weapon offense melee"
     },
     {
       "section": "Gear",
@@ -3042,10 +3871,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "melee",
+        "offense",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon grav-axe mk iii t3 ₡309200 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear weapon grav-axe mk iii t3 ₡309200 damage 1d102d8; line or cone special once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear weapon offense melee"
     },
     {
       "section": "Gear",
@@ -3061,10 +3895,16 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility aegis burst pack mk iii t3 ₡322400 reflect a failed attack once/scene. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear utility aegis burst pack mk iii t3 ₡322400 reflect a failed attack once/scene. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear utility support offense tech"
     },
     {
       "section": "Gear",
@@ -3080,10 +3920,16 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility loopfield projector mk iii t3 ₡335500 reflect a failed attack once/scene. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear utility loopfield projector mk iii t3 ₡335500 reflect a failed attack once/scene. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear utility support offense tech"
     },
     {
       "section": "Gear",
@@ -3099,10 +3945,16 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility perception sync visor mk iii t3 ₡348700 reflect a failed attack once/scene. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear utility perception sync visor mk iii t3 ₡348700 reflect a failed attack once/scene. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear utility support offense tech"
     },
     {
       "section": "Gear",
@@ -3118,10 +3970,17 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "gear",
+        "offense",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility kinetic assist boots mk iii t3 ₡361800 reflect a failed attack once/scene. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear utility kinetic assist boots mk iii t3 ₡361800 reflect a failed attack once/scene. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear utility support control offense tech"
     },
     {
       "section": "Gear",
@@ -3137,10 +3996,16 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 30 minutes focus + 3 SP imprint. Max 3 active.",
       "source": "O.M.N.I. requisitions, Greyline brokers, vetted private labs, reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility mirror-gate charm mk iii t3 ₡375000 reflect a failed attack once/scene. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers."
+      "search": "gear utility mirror-gate charm mk iii t3 ₡375000 reflect a failed attack once/scene. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 30 minutes focus + 3 sp imprint. max 3 active. o.m.n.i. requisitions, greyline brokers, vetted private labs, reliquary dealers. gear utility support offense tech"
     },
     {
       "section": "Gear",
@@ -3156,10 +4021,17 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor street mesh prime t2 ₡400000 +3 tc; first hit 5 damage. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear armor street mesh prime t2 ₡400000 +3 tc; first hit 5 damage. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear armor defense control offense tech"
     },
     {
       "section": "Gear",
@@ -3175,10 +4047,17 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor kevlayer suit prime t2 ₡442900 +3 tc; first hit 5 damage. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear armor kevlayer suit prime t2 ₡442900 +3 tc; first hit 5 damage. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear armor defense control offense tech"
     },
     {
       "section": "Gear",
@@ -3194,10 +4073,17 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor shock-pad harness prime t2 ₡485700 +3 tc; first hit 5 damage. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear armor shock-pad harness prime t2 ₡485700 +3 tc; first hit 5 damage. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear armor defense control offense tech"
     },
     {
       "section": "Gear",
@@ -3213,10 +4099,17 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor reflex stitch vest prime t2 ₡528600 +3 tc; first hit 5 damage. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear armor reflex stitch vest prime t2 ₡528600 +3 tc; first hit 5 damage. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear armor defense control offense tech"
     },
     {
       "section": "Gear",
@@ -3232,10 +4125,15 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield impact cuff prime t2 ₡571400 +3 tc; adjacent allies +1 tc. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear shield impact cuff prime t2 ₡571400 +3 tc; adjacent allies +1 tc. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear shield defense tech"
     },
     {
       "section": "Gear",
@@ -3251,10 +4149,15 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield echo-deflector disk prime t2 ₡614300 +3 tc; adjacent allies +1 tc. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear shield echo-deflector disk prime t2 ₡614300 +3 tc; adjacent allies +1 tc. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear shield defense tech"
     },
     {
       "section": "Gear",
@@ -3270,10 +4173,16 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "defense",
+        "gear",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield kinetic bracer prime t2 ₡657100 +3 tc; adjacent allies +1 tc. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear shield kinetic bracer prime t2 ₡657100 +3 tc; adjacent allies +1 tc. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear shield defense control tech"
     },
     {
       "section": "Gear",
@@ -3289,10 +4198,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon throwing disks prime t2 ₡700000 damage 2d8; burst line 30 ft. once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear weapon throwing disks prime t2 ₡700000 damage 2d8; burst line 30 ft. once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear weapon offense tech"
     },
     {
       "section": "Gear",
@@ -3308,10 +4222,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "melee",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon shock maul prime t2 ₡742900 damage 2d8; burst line 30 ft. once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear weapon shock maul prime t2 ₡742900 damage 2d8; burst line 30 ft. once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear weapon offense melee tech"
     },
     {
       "section": "Gear",
@@ -3327,10 +4247,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon coil carbine prime t2 ₡785700 damage 2d8; burst line 30 ft. once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear weapon coil carbine prime t2 ₡785700 damage 2d8; burst line 30 ft. once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear weapon offense tech"
     },
     {
       "section": "Gear",
@@ -3346,10 +4271,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon cryo sprayer prime t2 ₡828600 damage 2d8; burst line 30 ft. once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear weapon cryo sprayer prime t2 ₡828600 damage 2d8; burst line 30 ft. once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear weapon offense tech"
     },
     {
       "section": "Gear",
@@ -3365,10 +4295,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "melee",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon monofilament whip prime t2 ₡871400 damage 2d8; burst line 30 ft. once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear weapon monofilament whip prime t2 ₡871400 damage 2d8; burst line 30 ft. once/scene. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear weapon offense melee tech"
     },
     {
       "section": "Gear",
@@ -3384,10 +4320,16 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "mobility",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility phase-step belt prime t2 ₡914300 your next sp effect +1d4. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear utility phase-step belt prime t2 ₡914300 your next sp effect +1d4. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear utility support mobility tech"
     },
     {
       "section": "Gear",
@@ -3403,10 +4345,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility nullskin emitter prime t2 ₡957100 your next sp effect +1d4. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear utility nullskin emitter prime t2 ₡957100 your next sp effect +1d4. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -3422,10 +4369,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Greyline masterworks, Conclave-aligned houses, O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility chrono-anchor locket prime t2 ₡1000000 your next sp effect +1d4. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue."
+      "search": "gear utility chrono-anchor locket prime t2 ₡1000000 your next sp effect +1d4. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. greyline masterworks, conclave-aligned houses, o.m.n.i. vault issue. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -3441,10 +4393,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor street mesh royal t1 ₡1250000 +3 tc; immune to stun once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear armor street mesh royal t1 ₡1250000 +3 tc; immune to stun once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -3460,10 +4418,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor kevlayer suit royal t1 ₡1409100 +3 tc; immune to stun once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear armor kevlayer suit royal t1 ₡1409100 +3 tc; immune to stun once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -3479,10 +4443,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor shock-pad harness royal t1 ₡1568200 +3 tc; immune to stun once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear armor shock-pad harness royal t1 ₡1568200 +3 tc; immune to stun once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -3498,10 +4468,16 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "offense",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield magseal guard royal t1 ₡1727300 +3 tc; reflect one ranged hit/encounter. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear shield magseal guard royal t1 ₡1727300 +3 tc; reflect one ranged hit/encounter. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear shield defense offense tech"
     },
     {
       "section": "Gear",
@@ -3517,10 +4493,17 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "control",
+        "defense",
+        "gear",
+        "offense",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield flex-wall strap royal t1 ₡1886400 +3 tc; reflect one ranged hit/encounter. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear shield flex-wall strap royal t1 ₡1886400 +3 tc; reflect one ranged hit/encounter. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear shield defense control offense tech"
     },
     {
       "section": "Gear",
@@ -3536,10 +4519,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon climbers pick royal t1 ₡2045500 damage 2d10; reflect or disarm another creature. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear weapon climbers pick royal t1 ₡2045500 damage 2d10; reflect or disarm another creature. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear weapon offense tech"
     },
     {
       "section": "Gear",
@@ -3555,10 +4543,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon throwing disks royal t1 ₡2204500 damage 2d10; reflect or disarm another creature. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear weapon throwing disks royal t1 ₡2204500 damage 2d10; reflect or disarm another creature. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear weapon offense tech"
     },
     {
       "section": "Gear",
@@ -3574,10 +4567,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "melee",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon shock maul royal t1 ₡2363600 damage 2d10; reflect or disarm another creature. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear weapon shock maul royal t1 ₡2363600 damage 2d10; reflect or disarm another creature. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear weapon offense melee tech"
     },
     {
       "section": "Gear",
@@ -3593,10 +4592,15 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon coil carbine royal t1 ₡2522700 damage 2d10; reflect or disarm another creature. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear weapon coil carbine royal t1 ₡2522700 damage 2d10; reflect or disarm another creature. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear weapon offense tech"
     },
     {
       "section": "Gear",
@@ -3612,10 +4616,16 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility pulse guard band royal t1 ₡2681800 auto-succeed your first concentration save. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear utility pulse guard band royal t1 ₡2681800 auto-succeed your first concentration save. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear utility support defense tech"
     },
     {
       "section": "Gear",
@@ -3631,10 +4641,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility hazard comp implant royal t1 ₡2840900 auto-succeed your first concentration save. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear utility hazard comp implant royal t1 ₡2840900 auto-succeed your first concentration save. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -3650,10 +4665,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave vault access, O.M.N.I. black-book issue, invitation-only markets.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility temporal leech ring royal t1 ₡3000000 auto-succeed your first concentration save. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets."
+      "search": "gear utility temporal leech ring royal t1 ₡3000000 auto-succeed your first concentration save. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave vault access, o.m.n.i. black-book issue, invitation-only markets. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -3669,10 +4689,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor street mesh absolute t0 ₡3750000 +4 tc; ignore crit once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "gear armor street mesh absolute t0 ₡3750000 +4 tc; ignore crit once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -3688,10 +4714,16 @@
       "use": "Wear; passive protection; some reaction triggers.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "armor",
+        "control",
+        "defense",
+        "gear",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear armor kevlayer suit absolute t0 ₡4642900 +4 tc; ignore crit once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "gear armor kevlayer suit absolute t0 ₡4642900 +4 tc; ignore crit once/scene. protective wear with kinetic weave and responsive plating. wear; passive protection; some reaction triggers. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. gear armor defense control tech"
     },
     {
       "section": "Gear",
@@ -3707,10 +4739,17 @@
       "use": "Forearm mount; passive; some perks use a reaction.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "mobility",
+        "offense",
+        "shield",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear shield kite bracer absolute t0 ₡5535700 +4 tc; phase one attack per scene. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "gear shield kite bracer absolute t0 ₡5535700 +4 tc; phase one attack per scene. portable defense module projecting micro-fields. forearm mount; passive; some perks use a reaction. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. gear shield defense mobility offense tech"
     },
     {
       "section": "Gear",
@@ -3726,10 +4765,17 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "offense",
+        "ranged",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon scatter dart-gun absolute t0 ₡6428600 damage 3d8; pierce nonliving cover and shield once/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "gear weapon scatter dart-gun absolute t0 ₡6428600 damage 3d8; pierce nonliving cover and shield once/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. gear weapon offense ranged defense tech"
     },
     {
       "section": "Gear",
@@ -3745,10 +4791,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon climbers pick absolute t0 ₡7321400 damage 3d8; pierce nonliving cover and shield once/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "gear weapon climbers pick absolute t0 ₡7321400 damage 3d8; pierce nonliving cover and shield once/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. gear weapon offense defense tech"
     },
     {
       "section": "Gear",
@@ -3764,10 +4816,16 @@
       "use": "Standard attack rules; perk triggers as listed.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "defense",
+        "gear",
+        "offense",
+        "tech",
+        "weapon"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear weapon throwing disks absolute t0 ₡8214300 damage 3d8; pierce nonliving cover and shield once/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "gear weapon throwing disks absolute t0 ₡8214300 damage 3d8; pierce nonliving cover and shield once/round. reliable combat tool engineered for catalyst ops. standard attack rules; perk triggers as listed. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. gear weapon offense defense tech"
     },
     {
       "section": "Gear",
@@ -3783,10 +4841,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility echo-node charm absolute t0 ₡9107100 treat any roll as 20 once/session. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "gear utility echo-node charm absolute t0 ₡9107100 treat any roll as 20 once/session. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. gear utility support tech"
     },
     {
       "section": "Gear",
@@ -3802,10 +4865,15 @@
       "use": "Wear/deploy; bonus action to toggle unless noted.",
       "attunement": "Required: 1 hour calibration + 5 SP imprint. Max 3 active.",
       "source": "Conclave reliquary keepers or unique story rewards only.",
-      "classifications": [],
+      "classifications": [
+        "gear",
+        "support",
+        "tech",
+        "utility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "gear utility adrenal booster absolute t0 ₡10000000 treat any roll as 20 once/session. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only."
+      "search": "gear utility adrenal booster absolute t0 ₡10000000 treat any roll as 20 once/session. personal focus apparatus channeling local resonance. wear/deploy; bonus action to toggle unless noted. required: 1 hour calibration + 5 sp imprint. max 3 active. conclave reliquary keepers or unique story rewards only. gear utility support tech"
     },
     {
       "section": "Catalyst",
@@ -3821,10 +4889,16 @@
       "use": "Bonus action to charge; effect expires end of turn.",
       "attunement": "None.",
       "source": "PFV quartermaster, city outfitters.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "consumable",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item ember-vein gauntlet t5 ₡4000 +1d4 fire on a melee hit once per scene thin heat channels woven through a glove, channeling a shards ember resonance. bonus action to charge; effect expires end of turn. none. pfv quartermaster, city outfitters."
+      "search": "catalyst item ember-vein gauntlet t5 ₡4000 +1d4 fire on a melee hit once per scene thin heat channels woven through a glove, channeling a shards ember resonance. bonus action to charge; effect expires end of turn. none. pfv quartermaster, city outfitters. catalyst item offense tech consumable"
     },
     {
       "section": "Catalyst",
@@ -3840,10 +4914,16 @@
       "use": "Passive while worn.",
       "attunement": "Optional, 10 minutes focus and 3 SP imprint.",
       "source": "PFV, licensed vendors.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "mobility",
+        "stealth",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item whisper-step treads t5 ₡6000 advantage on stealth while moving ¤15 ft./turn micro-baffled soles dissipate footfall noise. passive while worn. optional, 10 minutes focus and 3 sp imprint. pfv, licensed vendors."
+      "search": "catalyst item whisper-step treads t5 ₡6000 advantage on stealth while moving ¤15 ft./turn micro-baffled soles dissipate footfall noise. passive while worn. optional, 10 minutes focus and 3 sp imprint. pfv, licensed vendors. catalyst item mobility stealth tech"
     },
     {
       "section": "Catalyst",
@@ -3859,10 +4939,15 @@
       "use": "Reaction on being targeted.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV rare case, O.M.N.I. returns.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "mobility",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item flicker pin t5 ₡8000 5 ft. teleport reaction when targeted, 1/scene shard mote mounted in a lapel pin flashes space-sideways. reaction on being targeted. optional, 10 minutes and 3 sp. pfv rare case, o.m.n.i. returns."
+      "search": "catalyst item flicker pin t5 ₡8000 5 ft. teleport reaction when targeted, 1/scene shard mote mounted in a lapel pin flashes space-sideways. reaction on being targeted. optional, 10 minutes and 3 sp. pfv rare case, o.m.n.i. returns. catalyst item mobility tech"
     },
     {
       "section": "Catalyst",
@@ -3878,10 +4963,15 @@
       "use": "Passive.",
       "attunement": "None.",
       "source": "City surplus auctions.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "magic",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item lens of clarity t5 ₡3500 +1 passive perception, advantage vs visual illusions monocle etched with clarity runes. passive. none. city surplus auctions."
+      "search": "catalyst item lens of clarity t5 ₡3500 +1 passive perception, advantage vs visual illusions monocle etched with clarity runes. passive. none. city surplus auctions. catalyst item tech magic"
     },
     {
       "section": "Catalyst",
@@ -3897,10 +4987,15 @@
       "use": "Passive.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV quartermaster.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item surge-weave undersuit t5 ₡10000 +1 tc on the first round of combat kinetic-responsive mesh primes at first contact. passive. optional, 10 minutes and 3 sp. pfv quartermaster."
+      "search": "catalyst item surge-weave undersuit t5 ₡10000 +1 tc on the first round of combat kinetic-responsive mesh primes at first contact. passive. optional, 10 minutes and 3 sp. pfv quartermaster. catalyst item control tech"
     },
     {
       "section": "Catalyst",
@@ -3916,10 +5011,17 @@
       "use": "Bonus action before attack; single use.",
       "attunement": "None.",
       "source": "Neighborhood outfitters.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "chemical",
+        "consumable",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item ember capsule x3 t5 ₡2500 next weapon hit inflicts burn 1, con save negates catalytic vials that lace a strike with heat. bonus action before attack; single use. none. neighborhood outfitters."
+      "search": "catalyst item ember capsule x3 t5 ₡2500 next weapon hit inflicts burn 1, con save negates catalytic vials that lace a strike with heat. bonus action before attack; single use. none. neighborhood outfitters. catalyst item offense tech chemical consumable"
     },
     {
       "section": "Catalyst",
@@ -3935,10 +5037,14 @@
       "use": "Free on failure.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV rare bin.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item echo charm t5 ₡7500 once per scene reroll a failed check pendant storing a micro-echo of success. free on failure. optional, 10 minutes and 3 sp. pfv rare bin."
+      "search": "catalyst item echo charm t5 ₡7500 once per scene reroll a failed check pendant storing a micro-echo of success. free on failure. optional, 10 minutes and 3 sp. pfv rare bin. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -3954,10 +5060,17 @@
       "use": "Action on self or adjacent ally.",
       "attunement": "None.",
       "source": "Clinic vendors.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "healing",
+        "item",
+        "mobility",
+        "support",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item phase stitch bandage t5 ₡5000 heal 1d6 hp and ignore one minor condition for 1 minute phase-aligned fibers re-knit wounds briefly. action on self or adjacent ally. none. clinic vendors."
+      "search": "catalyst item phase stitch bandage t5 ₡5000 heal 1d6 hp and ignore one minor condition for 1 minute phase-aligned fibers re-knit wounds briefly. action on self or adjacent ally. none. clinic vendors. catalyst item healing support mobility tech"
     },
     {
       "section": "Catalyst",
@@ -3973,10 +5086,15 @@
       "use": "Bonus action to activate.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV quartermaster.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "stealth",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item galesong cloaklet t5 ₡9000 +10 ft. move for 1 minute, 1/scene light mantle that drinks the wind. bonus action to activate. optional, 10 minutes and 3 sp. pfv quartermaster."
+      "search": "catalyst item galesong cloaklet t5 ₡9000 +10 ft. move for 1 minute, 1/scene light mantle that drinks the wind. bonus action to activate. optional, 10 minutes and 3 sp. pfv quartermaster. catalyst item stealth tech"
     },
     {
       "section": "Catalyst",
@@ -3992,10 +5110,14 @@
       "use": "Bonus action to place or read.",
       "attunement": "None.",
       "source": "Street techs.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item shard-tuned compass t5 ₡4500 points to last placed personal marker within 2 miles resonance needle locks to your mark. bonus action to place or read. none. street techs."
+      "search": "catalyst item shard-tuned compass t5 ₡4500 points to last placed personal marker within 2 miles resonance needle locks to your mark. bonus action to place or read. none. street techs. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4011,10 +5133,14 @@
       "use": "Passive.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "City jewelers, PFV.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item halo-spark ring t5 ₡6500 +1 to initiative ring with micro-capacitor woven to a shard. passive. optional, 10 minutes and 3 sp. city jewelers, pfv."
+      "search": "catalyst item halo-spark ring t5 ₡6500 +1 to initiative ring with micro-capacitor woven to a shard. passive. optional, 10 minutes and 3 sp. city jewelers, pfv. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4030,10 +5156,15 @@
       "use": "Action to throw within 30 ft.",
       "attunement": "None.",
       "source": "Outfitters.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item tangle thread capsule x2 t5 ₡3000 create 10 ft. sticky terrain for 2 rounds (dex save to avoid restrained) burst-net microspools detonate into adhesive mesh. action to throw within 30 ft. none. outfitters."
+      "search": "catalyst item tangle thread capsule x2 t5 ₡3000 create 10 ft. sticky terrain for 2 rounds (dex save to avoid restrained) burst-net microspools detonate into adhesive mesh. action to throw within 30 ft. none. outfitters. catalyst item control tech"
     },
     {
       "section": "Catalyst",
@@ -4049,10 +5180,13 @@
       "use": "Passive trigger.",
       "attunement": "None.",
       "source": "PFV quartermaster.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item sentinel patch t5 ₡1500 autosucceed on a simple alertness/wake-up check once per scene micro-vibe alert patch keyed to heart rhythm. passive trigger. none. pfv quartermaster."
+      "search": "catalyst item sentinel patch t5 ₡1500 autosucceed on a simple alertness/wake-up check once per scene micro-vibe alert patch keyed to heart rhythm. passive trigger. none. pfv quartermaster. catalyst item"
     },
     {
       "section": "Catalyst",
@@ -4068,10 +5202,16 @@
       "use": "Bonus action to apply.",
       "attunement": "None.",
       "source": "Med kiosks.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "item",
+        "mobility",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item ember-cool gel t5 ₡2500 end burn or freeze on self dual-phase salve that quenches extremes. bonus action to apply. none. med kiosks."
+      "search": "catalyst item ember-cool gel t5 ₡2500 end burn or freeze on self dual-phase salve that quenches extremes. bonus action to apply. none. med kiosks. catalyst item mobility control tech"
     },
     {
       "section": "Catalyst",
@@ -4087,10 +5227,14 @@
       "use": "Bonus action to ignite.",
       "attunement": "None.",
       "source": "Licensed vendors.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item lightweave shawl t5 ₡7000 bright light 20 ft.; advantage on search in darkness 10 minutes photonic filament woven through a shawl. bonus action to ignite. none. licensed vendors."
+      "search": "catalyst item lightweave shawl t5 ₡7000 bright light 20 ft.; advantage on search in darkness 10 minutes photonic filament woven through a shawl. bonus action to ignite. none. licensed vendors. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4106,10 +5250,15 @@
       "use": "Reaction when falling.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item gravitic buckle t5 ₡8500 reduce fall damage by 20 pulse field cushions terminal descent. reaction when falling. optional, 10 minutes and 3 sp. pfv."
+      "search": "catalyst item gravitic buckle t5 ₡8500 reduce fall damage by 20 pulse field cushions terminal descent. reaction when falling. optional, 10 minutes and 3 sp. pfv. catalyst item offense tech"
     },
     {
       "section": "Catalyst",
@@ -4125,10 +5274,16 @@
       "use": "Reaction.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "support",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item static wick cuff t5 ₡5500 impose disadvantage on one lightning attack against you (reaction), 1/scene discharge braid wicks hostile current. reaction. optional, 10 minutes and 3 sp. pfv."
+      "search": "catalyst item static wick cuff t5 ₡5500 impose disadvantage on one lightning attack against you (reaction), 1/scene discharge braid wicks hostile current. reaction. optional, 10 minutes and 3 sp. pfv. catalyst item support offense tech"
     },
     {
       "section": "Catalyst",
@@ -4144,10 +5299,17 @@
       "use": "Bonus action.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "Meditation stalls, PFV.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "item",
+        "psionic",
+        "stealth",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item mind-quiet beads t5 ₡6000 advantage on concentration saves for 1 minute, 1/scene clicking focus beads slow racing thoughts. bonus action. optional, 10 minutes and 3 sp. meditation stalls, pfv."
+      "search": "catalyst item mind-quiet beads t5 ₡6000 advantage on concentration saves for 1 minute, 1/scene clicking focus beads slow racing thoughts. bonus action. optional, 10 minutes and 3 sp. meditation stalls, pfv. catalyst item stealth control tech psionic"
     },
     {
       "section": "Catalyst",
@@ -4163,10 +5325,15 @@
       "use": "Action to apply to a weapon.",
       "attunement": "None.",
       "source": "Weapon smiths.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item ember-kissed blade oil t5 ₡3500 +1 fire damage for 1 minute catalytic oil that flares on impact. action to apply to a weapon. none. weapon smiths."
+      "search": "catalyst item ember-kissed blade oil t5 ₡3500 +1 fire damage for 1 minute catalytic oil that flares on impact. action to apply to a weapon. none. weapon smiths. catalyst item offense tech"
     },
     {
       "section": "Catalyst",
@@ -4182,10 +5349,15 @@
       "use": "Action to fire; reel during movement.",
       "attunement": "None.",
       "source": "PFV.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "mobility",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item shrike-line grappler t5 ₡12000 60 ft. swing or pull as movement wrist-mounted grapple head with auto-reel. action to fire; reel during movement. none. pfv."
+      "search": "catalyst item shrike-line grappler t5 ₡12000 60 ft. swing or pull as movement wrist-mounted grapple head with auto-reel. action to fire; reel during movement. none. pfv. catalyst item mobility tech"
     },
     {
       "section": "Catalyst",
@@ -4201,10 +5373,16 @@
       "use": "Reaction on first hit.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item bulwark brooch t5 ₡9500 +1 tc for one round when first hit each encounter impact-sensing clip stiffens kinetic weave. reaction on first hit. optional, 10 minutes and 3 sp. pfv."
+      "search": "catalyst item bulwark brooch t5 ₡9500 +1 tc for one round when first hit each encounter impact-sensing clip stiffens kinetic weave. reaction on first hit. optional, 10 minutes and 3 sp. pfv. catalyst item control offense tech"
     },
     {
       "section": "Catalyst",
@@ -4220,10 +5398,14 @@
       "use": "Bonus action to toggle.",
       "attunement": "None.",
       "source": "Optics vendors.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item cold-sight lens t5 ₡8000 see heat signatures 60 ft. for 10 minutes thermal monocle keyed to living heat. bonus action to toggle. none. optics vendors."
+      "search": "catalyst item cold-sight lens t5 ₡8000 see heat signatures 60 ft. for 10 minutes thermal monocle keyed to living heat. bonus action to toggle. none. optics vendors. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4239,10 +5421,16 @@
       "use": "Reaction.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item",
+        "mobility",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item rookstone token t5 ₡10000 resist shove or grapple once per scene dense shard chip anchors your footing. reaction. optional, 10 minutes and 3 sp. pfv."
+      "search": "catalyst item rookstone token t5 ₡10000 resist shove or grapple once per scene dense shard chip anchors your footing. reaction. optional, 10 minutes and 3 sp. pfv. catalyst item mobility defense tech"
     },
     {
       "section": "Catalyst",
@@ -4258,10 +5446,14 @@
       "use": "Action to call.",
       "attunement": "None.",
       "source": "Courier stalls.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item wind-key whistle t5 ₡4000 call a micro-drone courier in ~10 minutes anywhere in district tuned whistle routes a courier drone. action to call. none. courier stalls."
+      "search": "catalyst item wind-key whistle t5 ₡4000 call a micro-drone courier in ~10 minutes anywhere in district tuned whistle routes a courier drone. action to call. none. courier stalls. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4277,10 +5469,14 @@
       "use": "Bonus action to ignite.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "Boutique vendors.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item lantern of honesty t5 ₡15000 advantage to detect lies in 10 ft. for 1 minute resonance lamp brightens micro-inflections. bonus action to ignite. optional, 10 minutes and 3 sp. boutique vendors."
+      "search": "catalyst item lantern of honesty t5 ₡15000 advantage to detect lies in 10 ft. for 1 minute resonance lamp brightens micro-inflections. bonus action to ignite. optional, 10 minutes and 3 sp. boutique vendors. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4296,10 +5492,17 @@
       "use": "Passive while worn.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV, O.M.N.I. return program.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "item",
+        "offense",
+        "psionic",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item aegis-chord vest t4 ₡40000 +2 tc; first elemental hit each scene reduced by 3 chorded kinetic filaments cross-link on impact. passive while worn. optional, 10 minutes and 3 sp. pfv, o.m.n.i. return program."
+      "search": "catalyst item aegis-chord vest t4 ₡40000 +2 tc; first elemental hit each scene reduced by 3 chorded kinetic filaments cross-link on impact. passive while worn. optional, 10 minutes and 3 sp. pfv, o.m.n.i. return program. catalyst item control offense tech psionic"
     },
     {
       "section": "Catalyst",
@@ -4315,10 +5518,15 @@
       "use": "Passive while mounted to a firearm.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "Licensed weapon vendors.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item hunters prism scope t4 ₡55000 ignore light cover once per round refractive stack recomputes trajectories. passive while mounted to a firearm. optional, 10 minutes and 3 sp. licensed weapon vendors."
+      "search": "catalyst item hunters prism scope t4 ₡55000 ignore light cover once per round refractive stack recomputes trajectories. passive while mounted to a firearm. optional, 10 minutes and 3 sp. licensed weapon vendors. catalyst item defense tech"
     },
     {
       "section": "Catalyst",
@@ -4334,10 +5542,14 @@
       "use": "Passive while worn.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I. requisition.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "mobility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item phase-step anklets t4 ₡75000 ignore difficult terrain; +2 tc while moving  15 ft. anklets phase your step a hair out of sync. passive while worn. required, 30 minutes and 3 sp. o.m.n.i. requisition."
+      "search": "catalyst item phase-step anklets t4 ₡75000 ignore difficult terrain; +2 tc while moving  15 ft. anklets phase your step a hair out of sync. passive while worn. required, 30 minutes and 3 sp. o.m.n.i. requisition. catalyst item mobility"
     },
     {
       "section": "Catalyst",
@@ -4353,10 +5565,16 @@
       "use": "Declare before hit resolves.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV elite kit.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item ember-pulse baton t4 ₡60000 once per scene add stun on hit (wis save) baton with surge cell overdrives on impact. declare before hit resolves. optional, 10 minutes and 3 sp. pfv elite kit."
+      "search": "catalyst item ember-pulse baton t4 ₡60000 once per scene add stun on hit (wis save) baton with surge cell overdrives on impact. declare before hit resolves. optional, 10 minutes and 3 sp. pfv elite kit. catalyst item control offense tech"
     },
     {
       "section": "Catalyst",
@@ -4372,10 +5590,14 @@
       "use": "Passive.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "Licensed outfitters.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item gale-singer hood t4 ₡70000 you cannot be deafened; voice carries clearly in storms resonant cowl cancels turbulent noise. passive. optional, 10 minutes and 3 sp. licensed outfitters."
+      "search": "catalyst item gale-singer hood t4 ₡70000 you cannot be deafened; voice carries clearly in storms resonant cowl cancels turbulent noise. passive. optional, 10 minutes and 3 sp. licensed outfitters. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4391,10 +5613,16 @@
       "use": "Reaction when targeted.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Greyline brokers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "stealth",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item mirror-veil bracer t4 ₡90000 reaction: impose disadvantage on one ranged attack each scene prismatic plates create a mirage edge. reaction when targeted. required, 30 minutes and 3 sp. greyline brokers."
+      "search": "catalyst item mirror-veil bracer t4 ₡90000 reaction: impose disadvantage on one ranged attack each scene prismatic plates create a mirage edge. reaction when targeted. required, 30 minutes and 3 sp. greyline brokers. catalyst item stealth offense tech"
     },
     {
       "section": "Catalyst",
@@ -4410,10 +5638,18 @@
       "use": "Action to uncork toward target area.",
       "attunement": "None.",
       "source": "Licensed alchemists.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "chemical",
+        "consumable",
+        "defense",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item tidemark flask t4 ₡35000 10 ft. wave pushes 10 ft. (str save), 3 charges/long rest bound tide in a glass ampoule. action to uncork toward target area. none. licensed alchemists."
+      "search": "catalyst item tidemark flask t4 ₡35000 10 ft. wave pushes 10 ft. (str save), 3 charges/long rest bound tide in a glass ampoule. action to uncork toward target area. none. licensed alchemists. catalyst item defense offense tech chemical consumable"
     },
     {
       "section": "Catalyst",
@@ -4429,10 +5665,14 @@
       "use": "Bonus action.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item stalwarts coin t4 ₡50000 end frightened on self once per scene coin etched with rampart sigils. bonus action. optional, 10 minutes and 3 sp. pfv."
+      "search": "catalyst item stalwarts coin t4 ₡50000 end frightened on self once per scene coin etched with rampart sigils. bonus action. optional, 10 minutes and 3 sp. pfv. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4448,10 +5688,14 @@
       "use": "Passive while worn.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "Optics vendors.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item night-candle goggles t4 ₡65000 darkvision-like sight 120 ft.; see lightly through smoke twin lenses amplify scant photons. passive while worn. optional, 10 minutes and 3 sp. optics vendors."
+      "search": "catalyst item night-candle goggles t4 ₡65000 darkvision-like sight 120 ft.; see lightly through smoke twin lenses amplify scant photons. passive while worn. optional, 10 minutes and 3 sp. optics vendors. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4467,10 +5711,15 @@
       "use": "Action to fire.",
       "attunement": "None.",
       "source": "PFV.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item ember-net launcher t4 ₡80000 restrain medium target (str save ends) catalytic net hardens on contact. action to fire. none. pfv."
+      "search": "catalyst item ember-net launcher t4 ₡80000 restrain medium target (str save ends) catalytic net hardens on contact. action to fire. none. pfv. catalyst item control tech"
     },
     {
       "section": "Catalyst",
@@ -4486,10 +5735,13 @@
       "use": "Passive trigger.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I. requisition.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item resonance lattice ring t4 ₡95000 +1 sp the first time you spend sp each encounter miniature lattice crystal stores a pulse. passive trigger. required, 30 minutes and 3 sp. o.m.n.i. requisition."
+      "search": "catalyst item resonance lattice ring t4 ₡95000 +1 sp the first time you spend sp each encounter miniature lattice crystal stores a pulse. passive trigger. required, 30 minutes and 3 sp. o.m.n.i. requisition. catalyst item"
     },
     {
       "section": "Catalyst",
@@ -4505,10 +5757,14 @@
       "use": "Bonus action to invoke.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "Civic vendors.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item heralds medallion t4 ₡30000 advantage on diplomatic checks once per scene cyan enamel crest opens doors. bonus action to invoke. optional, 10 minutes and 3 sp. civic vendors."
+      "search": "catalyst item heralds medallion t4 ₡30000 advantage on diplomatic checks once per scene cyan enamel crest opens doors. bonus action to invoke. optional, 10 minutes and 3 sp. civic vendors. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4524,10 +5780,14 @@
       "use": "Passive.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Greyline brokers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item ember-cold mantle t4 ₡85000 resist fire and cold bicolor mantle quenches extremes. passive. required, 30 minutes and 3 sp. greyline brokers."
+      "search": "catalyst item ember-cold mantle t4 ₡85000 resist fire and cold bicolor mantle quenches extremes. passive. required, 30 minutes and 3 sp. greyline brokers. catalyst item defense"
     },
     {
       "section": "Catalyst",
@@ -4543,10 +5803,15 @@
       "use": "Passive.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "PFV.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "mobility",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item quick-weave gloves t4 ₡45000 +1 tools checks per scene; craft at 2 speed micro-servos steady fine motions. passive. optional, 10 minutes and 3 sp. pfv."
+      "search": "catalyst item quick-weave gloves t4 ₡45000 +1 tools checks per scene; craft at 2 speed micro-servos steady fine motions. passive. optional, 10 minutes and 3 sp. pfv. catalyst item mobility tech"
     },
     {
       "section": "Catalyst",
@@ -4562,10 +5827,16 @@
       "use": "Reaction.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "Temple fronts, PFV.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "item",
+        "support",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item oath-bound sigil t4 ₡30000 reroll a failed save vs charm/compulsion once per scene inlaid sigil binds your will. reaction. optional, 10 minutes and 3 sp. temple fronts, pfv."
+      "search": "catalyst item oath-bound sigil t4 ₡30000 reroll a failed save vs charm/compulsion once per scene inlaid sigil binds your will. reaction. optional, 10 minutes and 3 sp. temple fronts, pfv. catalyst item control support tech"
     },
     {
       "section": "Catalyst",
@@ -4581,10 +5852,14 @@
       "use": "Passive.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I. requisition.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "mobility"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item skystep harness t4 ₡100000 jump distance 3; ignore first 30 ft. of falling vane-pack catches air like stairs. passive. required, 30 minutes and 3 sp. o.m.n.i. requisition."
+      "search": "catalyst item skystep harness t4 ₡100000 jump distance 3; ignore first 30 ft. of falling vane-pack catches air like stairs. passive. required, 30 minutes and 3 sp. o.m.n.i. requisition. catalyst item mobility"
     },
     {
       "section": "Catalyst",
@@ -4600,10 +5875,15 @@
       "use": "Passive.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Vendors.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item trueshot armband t4 ₡75000 +1 to hit once per round with a ranged attack tension regulator smooths draw. passive. required, 30 minutes and 3 sp. vendors."
+      "search": "catalyst item trueshot armband t4 ₡75000 +1 to hit once per round with a ranged attack tension regulator smooths draw. passive. required, 30 minutes and 3 sp. vendors. catalyst item offense tech"
     },
     {
       "section": "Catalyst",
@@ -4619,10 +5899,15 @@
       "use": "Action to place.",
       "attunement": "Optional, 10 minutes and 3 SP.",
       "source": "Relic dealers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item wardens censer t4 ₡55000 create 10 ft. sanctified zone: allies +1 to saves for 1 minute, 1/session hanging censer spills protective tone. action to place. optional, 10 minutes and 3 sp. relic dealers."
+      "search": "catalyst item wardens censer t4 ₡55000 create 10 ft. sanctified zone: allies +1 to saves for 1 minute, 1/session hanging censer spills protective tone. action to place. optional, 10 minutes and 3 sp. relic dealers. catalyst item defense tech"
     },
     {
       "section": "Catalyst",
@@ -4638,10 +5923,14 @@
       "use": "Passive.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Greyline brokers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item flux-tuned satchel t4 ₡65000 extradimensional storage 200 lb.; weightless pocket-fold storage woven into lining. passive. required, 30 minutes and 3 sp. greyline brokers."
+      "search": "catalyst item flux-tuned satchel t4 ₡65000 extradimensional storage 200 lb.; weightless pocket-fold storage woven into lining. passive. required, 30 minutes and 3 sp. greyline brokers. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4657,10 +5946,15 @@
       "use": "Reaction.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I. requisition.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "support",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item tacticians die t4 ₡95000 add +1d6 to an ally's roll after seeing it, 1/scene, 30 ft. clicking die forecasts the near-now. reaction. required, 30 minutes and 3 sp. o.m.n.i. requisition."
+      "search": "catalyst item tacticians die t4 ₡95000 add +1d6 to an ally's roll after seeing it, 1/scene, 30 ft. clicking die forecasts the near-now. reaction. required, 30 minutes and 3 sp. o.m.n.i. requisition. catalyst item support tech"
     },
     {
       "section": "Catalyst",
@@ -4676,10 +5970,15 @@
       "use": "Standard attacks; perk is passive.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I., Greyline.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "mobility",
+        "offense"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item echo-blade, minor t3 ₡150000 1d8; after-image causes next attack vs you 1 to hit phase-trailing sword confuses aim. standard attacks; perk is passive. required, 30 minutes and 3 sp. o.m.n.i., greyline."
+      "search": "catalyst item echo-blade, minor t3 ₡150000 1d8; after-image causes next attack vs you 1 to hit phase-trailing sword confuses aim. standard attacks; perk is passive. required, 30 minutes and 3 sp. o.m.n.i., greyline. catalyst item mobility offense"
     },
     {
       "section": "Catalyst",
@@ -4695,10 +5994,14 @@
       "use": "Free when invoked.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Greyline brokers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item chrono-anchor locket, improved t3 ₡220000 reset position and tc to start of turn, 1/day tuned locket pins your moment in time. free when invoked. required, 30 minutes and 3 sp. greyline brokers."
+      "search": "catalyst item chrono-anchor locket, improved t3 ₡220000 reset position and tc to start of turn, 1/day tuned locket pins your moment in time. free when invoked. required, 30 minutes and 3 sp. greyline brokers. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4714,10 +6017,15 @@
       "use": "Passive.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I. requisition.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "consumable",
+        "item",
+        "offense"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item storm-cage buckler t3 ₡260000 +2 tc, reflect 1 lightning on a miss coil buckler cages hostile charge. passive. required, 30 minutes and 3 sp. o.m.n.i. requisition."
+      "search": "catalyst item storm-cage buckler t3 ₡260000 +2 tc, reflect 1 lightning on a miss coil buckler cages hostile charge. passive. required, 30 minutes and 3 sp. o.m.n.i. requisition. catalyst item offense consumable"
     },
     {
       "section": "Catalyst",
@@ -4733,10 +6041,14 @@
       "use": "Passive.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item phoenix filament t3 ₡300000 if reduced to 0 hp, stand at 1 hp once per session thin chest filament reignites your spark. passive. required, 30 minutes and 3 sp. reliquary dealers."
+      "search": "catalyst item phoenix filament t3 ₡300000 if reduced to 0 hp, stand at 1 hp once per session thin chest filament reignites your spark. passive. required, 30 minutes and 3 sp. reliquary dealers. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4752,10 +6064,15 @@
       "use": "Passive.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Conclave-friendly shops.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item",
+        "psionic"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item mind-ward circlet t3 ₡180000 resist psychic; advantage vs charm etched circlet dampens invasive hum. passive. required, 30 minutes and 3 sp. conclave-friendly shops."
+      "search": "catalyst item mind-ward circlet t3 ₡180000 resist psychic; advantage vs charm etched circlet dampens invasive hum. passive. required, 30 minutes and 3 sp. conclave-friendly shops. catalyst item defense psionic"
     },
     {
       "section": "Catalyst",
@@ -4771,10 +6088,14 @@
       "use": "Attacks; perk on crit.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Greyline master vendors.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item ember-fang rifle t3 ₡350000 1d10; on 20 add burn coil rifle seats an ember chamber. attacks; perk on crit. required, 30 minutes and 3 sp. greyline master vendors."
+      "search": "catalyst item ember-fang rifle t3 ₡350000 1d10; on 20 add burn coil rifle seats an ember chamber. attacks; perk on crit. required, 30 minutes and 3 sp. greyline master vendors. catalyst item offense"
     },
     {
       "section": "Catalyst",
@@ -4790,10 +6111,16 @@
       "use": "Passive.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "consumable",
+        "defense",
+        "item",
+        "offense"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item shard-warden armor t3 ₡320000 +3 tc; gain 1 sp when hit by an aoe once/scene layered mesh funnels blast into charge. passive. required, 30 minutes and 3 sp. o.m.n.i. vault issue."
+      "search": "catalyst item shard-warden armor t3 ₡320000 +3 tc; gain 1 sp when hit by an aoe once/scene layered mesh funnels blast into charge. passive. required, 30 minutes and 3 sp. o.m.n.i. vault issue. catalyst item defense offense consumable"
     },
     {
       "section": "Catalyst",
@@ -4809,10 +6136,14 @@
       "use": "Bonus action; 1/round.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Greyline brokers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item gale-crest cape t3 ₡140000 disengage as a bonus action once per round pressure-shifting cape parts pursuers. bonus action; 1/round. required, 30 minutes and 3 sp. greyline brokers."
+      "search": "catalyst item gale-crest cape t3 ₡140000 disengage as a bonus action once per round pressure-shifting cape parts pursuers. bonus action; 1/round. required, 30 minutes and 3 sp. greyline brokers. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4828,10 +6159,15 @@
       "use": "Action to step through.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I. requisition.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "mobility",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item rift-key trinket t3 ₡240000 pass through a thin wall once per scene (5 ft.) shard key vibrates you across a seam. action to step through. required, 30 minutes and 3 sp. o.m.n.i. requisition."
+      "search": "catalyst item rift-key trinket t3 ₡240000 pass through a thin wall once per scene (5 ft.) shard key vibrates you across a seam. action to step through. required, 30 minutes and 3 sp. o.m.n.i. requisition. catalyst item mobility tech"
     },
     {
       "section": "Catalyst",
@@ -4847,10 +6183,15 @@
       "use": "Action; 1 minute reading.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Conclave scriptoriums.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "magic",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item star-lore codex t3 ₡170000 auto identify unknown tech or magic once/day fold-out compendium consults the lattice. action; 1 minute reading. required, 30 minutes and 3 sp. conclave scriptoriums."
+      "search": "catalyst item star-lore codex t3 ₡170000 auto identify unknown tech or magic once/day fold-out compendium consults the lattice. action; 1 minute reading. required, 30 minutes and 3 sp. conclave scriptoriums. catalyst item tech magic"
     },
     {
       "section": "Catalyst",
@@ -4866,10 +6207,15 @@
       "use": "Bonus action to start.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I. requisition.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "mobility",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item pulse-drive boots t3 ₡270000 +10 ft. speed and ignore difficult terrain for 1 minute, 1/scene heel actuators pulse the ground underfoot. bonus action to start. required, 30 minutes and 3 sp. o.m.n.i. requisition."
+      "search": "catalyst item pulse-drive boots t3 ₡270000 +10 ft. speed and ignore difficult terrain for 1 minute, 1/scene heel actuators pulse the ground underfoot. bonus action to start. required, 30 minutes and 3 sp. o.m.n.i. requisition. catalyst item mobility tech"
     },
     {
       "section": "Catalyst",
@@ -4885,10 +6231,14 @@
       "use": "Action to throw within 30 ft.",
       "attunement": "None.",
       "source": "Greyline.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item gravity well grenade x1 t3 ₡150000 pull 15 ft.; str save or prone singularity marble bottled to throw. action to throw within 30 ft. none. greyline."
+      "search": "catalyst item gravity well grenade x1 t3 ₡150000 pull 15 ft.; str save or prone singularity marble bottled to throw. action to throw within 30 ft. none. greyline. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -4904,10 +6254,16 @@
       "use": "Reaction on miss.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Brokers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "psionic",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item mirror-mind shard t3 ₡125000 reflect a failed attack back at attacker for half damage, 1/scene mind-mirror flips force back along intent. reaction on miss. required, 30 minutes and 3 sp. brokers."
+      "search": "catalyst item mirror-mind shard t3 ₡125000 reflect a failed attack back at attacker for half damage, 1/scene mind-mirror flips force back along intent. reaction on miss. required, 30 minutes and 3 sp. brokers. catalyst item offense tech psionic"
     },
     {
       "section": "Catalyst",
@@ -4923,10 +6279,15 @@
       "use": "Bonus action.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I. requisition.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item ember-ward aegis t3 ₡300000 allies in 10 ft. gain +1 tc for 1 round, 1/scene back-mounted projector spills a guard-hum. bonus action. required, 30 minutes and 3 sp. o.m.n.i. requisition."
+      "search": "catalyst item ember-ward aegis t3 ₡300000 allies in 10 ft. gain +1 tc for 1 round, 1/scene back-mounted projector spills a guard-hum. bonus action. required, 30 minutes and 3 sp. o.m.n.i. requisition. catalyst item defense tech"
     },
     {
       "section": "Catalyst",
@@ -4942,10 +6303,15 @@
       "use": "Action to ignite.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Relic shops.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "stealth",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item lantern of true sight t3 ₡375000 see invisibility 30 ft. for 1 minute, 1/scene prismatic lantern peels false layers. action to ignite. required, 30 minutes and 3 sp. relic shops."
+      "search": "catalyst item lantern of true sight t3 ₡375000 see invisibility 30 ft. for 1 minute, 1/scene prismatic lantern peels false layers. action to ignite. required, 30 minutes and 3 sp. relic shops. catalyst item stealth tech"
     },
     {
       "section": "Catalyst",
@@ -4961,10 +6327,16 @@
       "use": "Bonus action to mark.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I. requisition.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "support",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item seekers wrist-node t3 ₡200000 mark a target; allies gain +1 to hit it this scene wrist beacon paints a shared lock. bonus action to mark. required, 30 minutes and 3 sp. o.m.n.i. requisition."
+      "search": "catalyst item seekers wrist-node t3 ₡200000 mark a target; allies gain +1 to hit it this scene wrist beacon paints a shared lock. bonus action to mark. required, 30 minutes and 3 sp. o.m.n.i. requisition. catalyst item support offense tech"
     },
     {
       "section": "Catalyst",
@@ -4980,10 +6352,14 @@
       "use": "Passive.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "PFV elite.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item wardrum heartbeat t3 ₡160000 +2 initiative and advantage vs fear on round one haptic chest module sets a war cadence. passive. required, 30 minutes and 3 sp. pfv elite."
+      "search": "catalyst item wardrum heartbeat t3 ₡160000 +2 initiative and advantage vs fear on round one haptic chest module sets a war cadence. passive. required, 30 minutes and 3 sp. pfv elite. catalyst item defense"
     },
     {
       "section": "Catalyst",
@@ -4999,10 +6375,16 @@
       "use": "Passive.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Greyline.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "defense",
+        "item",
+        "stealth"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item frost-quell cloak t3 ₡210000 resist cold; ignore freeze chilled weave bleeds off frostbite. passive. required, 30 minutes and 3 sp. greyline."
+      "search": "catalyst item frost-quell cloak t3 ₡210000 resist cold; ignore freeze chilled weave bleeds off frostbite. passive. required, 30 minutes and 3 sp. greyline. catalyst item stealth control defense"
     },
     {
       "section": "Catalyst",
@@ -5018,10 +6400,15 @@
       "use": "Action to inscribe.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "O.M.N.I. requisition.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "magic",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item ember-scribe gloves t3 ₡260000 place a 5 ft. glyph that detonates for 2d6 fire when a foe enters, 1/scene filaments trace volatile runes. action to inscribe. required, 30 minutes and 3 sp. o.m.n.i. requisition."
+      "search": "catalyst item ember-scribe gloves t3 ₡260000 place a 5 ft. glyph that detonates for 2d6 fire when a foe enters, 1/scene filaments trace volatile runes. action to inscribe. required, 30 minutes and 3 sp. o.m.n.i. requisition. catalyst item tech magic"
     },
     {
       "section": "Catalyst",
@@ -5037,10 +6424,15 @@
       "use": "Attack or line thrust.",
       "attunement": "Required, 30 minutes and 3 SP.",
       "source": "Greyline.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item echo-spear t3 ₡275000 1d8; line 15 ft. once per scene vibrational spear channels a piercing wave. attack or line thrust. required, 30 minutes and 3 sp. greyline."
+      "search": "catalyst item echo-spear t3 ₡275000 1d8; line 15 ft. once per scene vibrational spear channels a piercing wave. attack or line thrust. required, 30 minutes and 3 sp. greyline. catalyst item offense tech"
     },
     {
       "section": "Catalyst",
@@ -5056,10 +6448,15 @@
       "use": "Passive.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave-aligned dealers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "psionic",
+        "stealth"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item crown of the calm t2 ₡440000 immunity to confused; advantage on wis saves serene lattice circlet quiets mental noise. passive. required, 1 hour and 5 sp. conclave-aligned dealers."
+      "search": "catalyst item crown of the calm t2 ₡440000 immunity to confused; advantage on wis saves serene lattice circlet quiets mental noise. passive. required, 1 hour and 5 sp. conclave-aligned dealers. catalyst item stealth psionic"
     },
     {
       "section": "Catalyst",
@@ -5075,10 +6472,15 @@
       "use": "Attacks; special line shot 1/scene.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item",
+        "offense"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item starlance carbine t2 ₡900000 2d8 line 30 ft. once per scene; ignores nonliving cover starlight channel cored through a carbine. attacks; special line shot 1/scene. required, 1 hour and 5 sp. o.m.n.i. vault issue."
+      "search": "catalyst item starlance carbine t2 ₡900000 2d8 line 30 ft. once per scene; ignores nonliving cover starlight channel cored through a carbine. attacks; special line shot 1/scene. required, 1 hour and 5 sp. o.m.n.i. vault issue. catalyst item defense offense"
     },
     {
       "section": "Catalyst",
@@ -5094,10 +6496,16 @@
       "use": "Passive.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item bulwark halo t2 ₡760000 +3 tc; first hit each encounter 5 damage deflection crown forms a guard band. passive. required, 1 hour and 5 sp. o.m.n.i. vault issue."
+      "search": "catalyst item bulwark halo t2 ₡760000 +3 tc; first hit each encounter 5 damage deflection crown forms a guard band. passive. required, 1 hour and 5 sp. o.m.n.i. vault issue. catalyst item defense offense tech"
     },
     {
       "section": "Catalyst",
@@ -5113,10 +6521,13 @@
       "use": "Passive on SP spend.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Greyline masterworks.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item resonant soul engine t2 ₡1000000 when you spend sp, add +1d4 to the effect up to 3/scene chest core harmonizes your output. passive on sp spend. required, 1 hour and 5 sp. greyline masterworks."
+      "search": "catalyst item resonant soul engine t2 ₡1000000 when you spend sp, add +1d4 to the effect up to 3/scene chest core harmonizes your output. passive on sp spend. required, 1 hour and 5 sp. greyline masterworks. catalyst item"
     },
     {
       "section": "Catalyst",
@@ -5132,10 +6543,16 @@
       "use": "Passive.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "item",
+        "mobility",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item gale-runner exosuit t2 ₡800000 +3 tc, speed +10 ft, immune to knockdown light exo translates motion to lift. passive. required, 1 hour and 5 sp. o.m.n.i. vault issue."
+      "search": "catalyst item gale-runner exosuit t2 ₡800000 +3 tc, speed +10 ft, immune to knockdown light exo translates motion to lift. passive. required, 1 hour and 5 sp. o.m.n.i. vault issue. catalyst item mobility control tech"
     },
     {
       "section": "Catalyst",
@@ -5151,10 +6568,14 @@
       "use": "Bonus action.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave brokers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item eye of the tide t2 ₡480000 reposition two willing allies within 30 ft by 10 ft, 1/scene aqua-lens amulet bends local currents. bonus action. required, 1 hour and 5 sp. conclave brokers."
+      "search": "catalyst item eye of the tide t2 ₡480000 reposition two willing allies within 30 ft by 10 ft, 1/scene aqua-lens amulet bends local currents. bonus action. required, 1 hour and 5 sp. conclave brokers. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5170,10 +6591,14 @@
       "use": "Passive.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Greyline.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item ember-crown mantle t2 ₡420000 resist fire and lightning; melee adds +1 fire on crit crackling mantle channels storm heat. passive. required, 1 hour and 5 sp. greyline."
+      "search": "catalyst item ember-crown mantle t2 ₡420000 resist fire and lightning; melee adds +1 fire on crit crackling mantle channels storm heat. passive. required, 1 hour and 5 sp. greyline. catalyst item defense"
     },
     {
       "section": "Catalyst",
@@ -5189,10 +6614,15 @@
       "use": "Bonus action by either wearer.",
       "attunement": "Required for both, 1 hour and 5 SP.",
       "source": "Greyline brokers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "support",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item mirror-gate charm t2 ₡950000 swap positions with an ally in 60 ft, 1/scene twin-etched charms handshake through space. bonus action by either wearer. required for both, 1 hour and 5 sp. greyline brokers."
+      "search": "catalyst item mirror-gate charm t2 ₡950000 swap positions with an ally in 60 ft, 1/scene twin-etched charms handshake through space. bonus action by either wearer. required for both, 1 hour and 5 sp. greyline brokers. catalyst item support tech"
     },
     {
       "section": "Catalyst",
@@ -5208,10 +6638,14 @@
       "use": "10 minutes focused reading.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave scriptorium.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item archivists codex prime t2 ₡600000 learn a secret about a location or npc once per session living book that converses in margins. 10 minutes focused reading. required, 1 hour and 5 sp. conclave scriptorium."
+      "search": "catalyst item archivists codex prime t2 ₡600000 learn a secret about a location or npc once per session living book that converses in margins. 10 minutes focused reading. required, 1 hour and 5 sp. conclave scriptorium. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5227,10 +6661,16 @@
       "use": "Action to deploy.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item",
+        "support",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item storm-warden dome t2 ₡820000 10 ft dome grants +1 tc to allies for 3 rounds, 1/scene portable projector establishes a calm eye. action to deploy. required, 1 hour and 5 sp. o.m.n.i. vault issue."
+      "search": "catalyst item storm-warden dome t2 ₡820000 10 ft dome grants +1 tc to allies for 3 rounds, 1/scene portable projector establishes a calm eye. action to deploy. required, 1 hour and 5 sp. o.m.n.i. vault issue. catalyst item support defense tech"
     },
     {
       "section": "Catalyst",
@@ -5246,10 +6686,15 @@
       "use": "Reaction after a miss.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Greyline master smiths.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item heartforge brand t2 ₡700000 turn a failed melee attack into half damage on hit, 1/scene brand sigil seals intent to strike true. reaction after a miss. required, 1 hour and 5 sp. greyline master smiths."
+      "search": "catalyst item heartforge brand t2 ₡700000 turn a failed melee attack into half damage on hit, 1/scene brand sigil seals intent to strike true. reaction after a miss. required, 1 hour and 5 sp. greyline master smiths. catalyst item offense tech"
     },
     {
       "section": "Catalyst",
@@ -5265,10 +6710,14 @@
       "use": "Bonus action.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Greyline brokers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item moon-tread greaves t2 ₡460000 move along vertical surfaces for 1 round, 1/scene gravitic greaves cancel the weight vector. bonus action. required, 1 hour and 5 sp. greyline brokers."
+      "search": "catalyst item moon-tread greaves t2 ₡460000 move along vertical surfaces for 1 round, 1/scene gravitic greaves cancel the weight vector. bonus action. required, 1 hour and 5 sp. greyline brokers. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5284,10 +6733,15 @@
       "use": "Bonus action to declare.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave reliquary.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item choir-shard focus t2 ₡520000 your next attack or power cannot be countered, 1/scene chorus crystal sets an undeniable tone. bonus action to declare. required, 1 hour and 5 sp. conclave reliquary."
+      "search": "catalyst item choir-shard focus t2 ₡520000 your next attack or power cannot be countered, 1/scene chorus crystal sets an undeniable tone. bonus action to declare. required, 1 hour and 5 sp. conclave reliquary. catalyst item offense tech"
     },
     {
       "section": "Catalyst",
@@ -5303,10 +6757,16 @@
       "use": "Attacks; perk on hit.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item wardens gavel t2 ₡880000 1d10; on hit wis save or drop concentration heavy hammer that interrupts focus. attacks; perk on hit. required, 1 hour and 5 sp. o.m.n.i. vault issue."
+      "search": "catalyst item wardens gavel t2 ₡880000 1d10; on hit wis save or drop concentration heavy hammer that interrupts focus. attacks; perk on hit. required, 1 hour and 5 sp. o.m.n.i. vault issue. catalyst item defense offense tech"
     },
     {
       "section": "Catalyst",
@@ -5322,10 +6782,14 @@
       "use": "Free on declaration.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave vaults.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item lattice of second chances t2 ₡980000 treat any one d20 roll as 20, 1/session neck lattice rethreads a moment. free on declaration. required, 1 hour and 5 sp. conclave vaults."
+      "search": "catalyst item lattice of second chances t2 ₡980000 treat any one d20 roll as 20, 1/session neck lattice rethreads a moment. free on declaration. required, 1 hour and 5 sp. conclave vaults. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5341,10 +6805,16 @@
       "use": "Passive.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "O.M.N.I. black-book.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "consumable",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item phoenix charge, crown-grade t1 ₡1500000 on 0 hp, stand at 1 hp and gain +2 tc for 1 round, 1/session royal filament that refuses the end. passive. required, 1 hour and 5 sp. o.m.n.i. black-book."
+      "search": "catalyst item phoenix charge, crown-grade t1 ₡1500000 on 0 hp, stand at 1 hp and gain +2 tc for 1 round, 1/session royal filament that refuses the end. passive. required, 1 hour and 5 sp. o.m.n.i. black-book. catalyst item offense tech consumable"
     },
     {
       "section": "Catalyst",
@@ -5360,10 +6830,15 @@
       "use": "Standard attacks; passive penalty field.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Greyline masterworks.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "mobility",
+        "offense"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item echo-blade, major t1 ₡2700000 1d10; after-image imposes 2 to next attack vs you superior phase blade doubles the echo-trail. standard attacks; passive penalty field. required, 1 hour and 5 sp. greyline masterworks."
+      "search": "catalyst item echo-blade, major t1 ₡2700000 1d10; after-image imposes 2 to next attack vs you superior phase blade doubles the echo-trail. standard attacks; passive penalty field. required, 1 hour and 5 sp. greyline masterworks. catalyst item mobility offense"
     },
     {
       "section": "Catalyst",
@@ -5379,10 +6854,14 @@
       "use": "Passive.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave vault access.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item crown of perfect focus t1 ₡1800000 first concentration save each scene auto succeeds flawless circlet locks your center. passive. required, 1 hour and 5 sp. conclave vault access."
+      "search": "catalyst item crown of perfect focus t1 ₡1800000 first concentration save each scene auto succeeds flawless circlet locks your center. passive. required, 1 hour and 5 sp. conclave vault access. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5398,10 +6877,15 @@
       "use": "Action to trigger.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave warrant.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item starwarden beacon, major t1 ₡2500000 summon conclave escort extraction 1/session high-grade beacon broadcasts a covenant. action to trigger. required, 1 hour and 5 sp. conclave warrant."
+      "search": "catalyst item starwarden beacon, major t1 ₡2500000 summon conclave escort extraction 1/session high-grade beacon broadcasts a covenant. action to trigger. required, 1 hour and 5 sp. conclave warrant. catalyst item defense tech"
     },
     {
       "section": "Catalyst",
@@ -5417,10 +6901,14 @@
       "use": "Free when invoked.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "O.M.N.I. vault.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item time-slip marker, prime t1 ₡2200000 revert the last round for yourself only, 1/session chrono seal pins a personal loop. free when invoked. required, 1 hour and 5 sp. o.m.n.i. vault."
+      "search": "catalyst item time-slip marker, prime t1 ₡2200000 revert the last round for yourself only, 1/session chrono seal pins a personal loop. free when invoked. required, 1 hour and 5 sp. o.m.n.i. vault. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5436,10 +6924,15 @@
       "use": "Reaction on hit.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Greyline grandmaster.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item mirror-field buckler, royal t1 ₡1900000 +3 tc; reflect one ranged hit per encounter perfected buckler angles a flawless return. reaction on hit. required, 1 hour and 5 sp. greyline grandmaster."
+      "search": "catalyst item mirror-field buckler, royal t1 ₡1900000 +3 tc; reflect one ranged hit per encounter perfected buckler angles a flawless return. reaction on hit. required, 1 hour and 5 sp. greyline grandmaster. catalyst item offense tech"
     },
     {
       "section": "Catalyst",
@@ -5455,10 +6948,15 @@
       "use": "Reaction when they roll.",
       "attunement": "Required for both, 1 hour and 5 SP.",
       "source": "Conclave artisans.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "support",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item soul-bond engine t1 ₡2800000 choose an ally at attunement; give +1 to their roll 1/scene without los paired heartspring bridges intent. reaction when they roll. required for both, 1 hour and 5 sp. conclave artisans."
+      "search": "catalyst item soul-bond engine t1 ₡2800000 choose an ally at attunement; give +1 to their roll 1/scene without los paired heartspring bridges intent. reaction when they roll. required for both, 1 hour and 5 sp. conclave artisans. catalyst item support tech"
     },
     {
       "section": "Catalyst",
@@ -5474,10 +6972,14 @@
       "use": "Action to place.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "O.M.N.I. black-book.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item lawkeepers seal t1 ₡1600000 declare a 10 ft sanctuary zone; enemies have disadvantage for 1 round, 1/scene magisterial seal imposes a lawful hush. action to place. required, 1 hour and 5 sp. o.m.n.i. black-book."
+      "search": "catalyst item lawkeepers seal t1 ₡1600000 declare a 10 ft sanctuary zone; enemies have disadvantage for 1 round, 1/scene magisterial seal imposes a lawful hush. action to place. required, 1 hour and 5 sp. o.m.n.i. black-book. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5493,10 +6995,14 @@
       "use": "Bonus action to bank after success.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Reliquary dealers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item fate-spindle t1 ₡1300000 bank a d6 and spend it later this session hand-spindle stores the luck of motion. bonus action to bank after success. required, 1 hour and 5 sp. reliquary dealers."
+      "search": "catalyst item fate-spindle t1 ₡1300000 bank a d6 and spend it later this session hand-spindle stores the luck of motion. bonus action to bank after success. required, 1 hour and 5 sp. reliquary dealers. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5512,10 +7018,14 @@
       "use": "Bonus action.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave wardens.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item argent choir mantle t1 ₡2000000 allies within 10 ft gain +1 to saves for 2 rounds, 1/scene choir mantle projects a silver chorus. bonus action. required, 1 hour and 5 sp. conclave wardens."
+      "search": "catalyst item argent choir mantle t1 ₡2000000 allies within 10 ft gain +1 to saves for 2 rounds, 1/scene choir mantle projects a silver chorus. bonus action. required, 1 hour and 5 sp. conclave wardens. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5531,10 +7041,15 @@
       "use": "Bonus action during effect.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "O.M.N.I. vault issue.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "mobility",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item rift-singer boots t1 ₡1750000 teleport 30 ft as a bonus action once/round for 3 rounds, 1/session song-tuned boots step into the seam. bonus action during effect. required, 1 hour and 5 sp. o.m.n.i. vault issue."
+      "search": "catalyst item rift-singer boots t1 ₡1750000 teleport 30 ft as a bonus action once/round for 3 rounds, 1/session song-tuned boots step into the seam. bonus action during effect. required, 1 hour and 5 sp. o.m.n.i. vault issue. catalyst item mobility tech"
     },
     {
       "section": "Catalyst",
@@ -5550,10 +7065,15 @@
       "use": "Passive and free once/scene.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave vault access.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "control",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item crown of the unbroken t1 ₡3000000 cannot be stunned; end stun on self once/scene (free) adamant crown rejects interruption. passive and free once/scene. required, 1 hour and 5 sp. conclave vault access."
+      "search": "catalyst item crown of the unbroken t1 ₡3000000 cannot be stunned; end stun on self once/scene (free) adamant crown rejects interruption. passive and free once/scene. required, 1 hour and 5 sp. conclave vault access. catalyst item control tech"
     },
     {
       "section": "Catalyst",
@@ -5569,10 +7089,14 @@
       "use": "Reaction on seeing the effect.",
       "attunement": "Required, 1 hour and 5 SP. Max 3 active attunements.",
       "source": "Conclave reliquary only.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item chorus-shard keystone t0 ₡4500000 negate one entire aoe in line of sight, 1/session keystone crystal flattens a wave to silence. reaction on seeing the effect. required, 1 hour and 5 sp. max 3 active attunements. conclave reliquary only."
+      "search": "catalyst item chorus-shard keystone t0 ₡4500000 negate one entire aoe in line of sight, 1/session keystone crystal flattens a wave to silence. reaction on seeing the effect. required, 1 hour and 5 sp. max 3 active attunements. conclave reliquary only. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5588,10 +7112,13 @@
       "use": "Free at round start.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave oathkeepers.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item chronal favor, sovereign script t0 ₡6000000 act twice in one round, then become exhausted bound contract compels time to yield. free at round start. required, 1 hour and 5 sp. conclave oathkeepers."
+      "search": "catalyst item chronal favor, sovereign script t0 ₡6000000 act twice in one round, then become exhausted bound contract compels time to yield. free at round start. required, 1 hour and 5 sp. conclave oathkeepers. catalyst item"
     },
     {
       "section": "Catalyst",
@@ -5607,10 +7134,14 @@
       "use": "Bonus action to seal.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "O.M.N.I. black vault.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item void-seal capsule, grand t0 ₡4750000 untargetable for 1 round, 1/session absolute null field in a capsule. bonus action to seal. required, 1 hour and 5 sp. o.m.n.i. black vault."
+      "search": "catalyst item void-seal capsule, grand t0 ₡4750000 untargetable for 1 round, 1/session absolute null field in a capsule. bonus action to seal. required, 1 hour and 5 sp. o.m.n.i. black vault. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5626,10 +7157,16 @@
       "use": "Reaction when lethal damage occurs.",
       "attunement": "Required for bonded pair, 1 hour and 5 SP.",
       "source": "Conclave rite.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "offense",
+        "stealth",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item destiny bond locket, grand t0 ₡5500000 redirect one lethal hit to an echo so no one dies, 1/arc twin-soul locket ties a fate to a shadow. reaction when lethal damage occurs. required for bonded pair, 1 hour and 5 sp. conclave rite."
+      "search": "catalyst item destiny bond locket, grand t0 ₡5500000 redirect one lethal hit to an echo so no one dies, 1/arc twin-soul locket ties a fate to a shadow. reaction when lethal damage occurs. required for bonded pair, 1 hour and 5 sp. conclave rite. catalyst item stealth offense tech"
     },
     {
       "section": "Catalyst",
@@ -5645,10 +7182,14 @@
       "use": "Free on declaration.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Greyline grandmaster.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item perfect mirror die, master t0 ₡5000000 treat any roll as 20, 1/session flawless die that calls the perfect cast. free on declaration. required, 1 hour and 5 sp. greyline grandmaster."
+      "search": "catalyst item perfect mirror die, master t0 ₡5000000 treat any roll as 20, 1/session flawless die that calls the perfect cast. free on declaration. required, 1 hour and 5 sp. greyline grandmaster. catalyst item tech"
     },
     {
       "section": "Catalyst",
@@ -5664,10 +7205,15 @@
       "use": "Action to trigger.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave command.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "defense",
+        "item",
+        "tech"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item starwarden beacon, royal t0 ₡7500000 orbital extraction; cleanses 1 condition on extracted allies royal beacon summons the wardens above. action to trigger. required, 1 hour and 5 sp. conclave command."
+      "search": "catalyst item starwarden beacon, royal t0 ₡7500000 orbital extraction; cleanses 1 condition on extracted allies royal beacon summons the wardens above. action to trigger. required, 1 hour and 5 sp. conclave command. catalyst item defense tech"
     },
     {
       "section": "Catalyst",
@@ -5683,10 +7229,13 @@
       "use": "Free when another item is spent.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Conclave paradox cell.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item law of return, absolute t0 ₡9000000 one spent item refreshes instantly and ignores cooldowns paradox token pays tomorrows price today. free when another item is spent. required, 1 hour and 5 sp. conclave paradox cell."
+      "search": "catalyst item law of return, absolute t0 ₡9000000 one spent item refreshes instantly and ignores cooldowns paradox token pays tomorrows price today. free when another item is spent. required, 1 hour and 5 sp. conclave paradox cell. catalyst item"
     },
     {
       "section": "Catalyst",
@@ -5702,10 +7251,13 @@
       "use": "Free, narrative timing.",
       "attunement": "Required, 1 hour and 5 SP.",
       "source": "Story reward only.",
-      "classifications": [],
+      "classifications": [
+        "catalyst",
+        "item"
+      ],
       "tierRestrictions": [],
       "prerequisites": [],
-      "search": "catalyst item angels iou, supreme t0 ₡10000000 gm-approved miracle within reason, once bound promise from an unseen patron. free, narrative timing. required, 1 hour and 5 sp. story reward only."
+      "search": "catalyst item angels iou, supreme t0 ₡10000000 gm-approved miracle within reason, once bound promise from an unseen patron. free, narrative timing. required, 1 hour and 5 sp. story reward only. catalyst item"
     }
   ],
   "prices": [

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -10596,6 +10596,31 @@ function isCatalogPrerequisiteMet(prereq, playerState){
   return values.some(value => playerState.tags.has(value.normalized));
 }
 
+const GENERIC_CLASSIFICATION_TAGS = new Set([
+  'armor',
+  'catalyst',
+  'chemical',
+  'consumable',
+  'control',
+  'defense',
+  'gear',
+  'healing',
+  'item',
+  'magic',
+  'melee',
+  'mobility',
+  'offense',
+  'psionic',
+  'ranged',
+  'shield',
+  'stealth',
+  'support',
+  'tech',
+  'useful',
+  'utility',
+  'weapon',
+]);
+
 function isEntryAvailableToPlayer(entry, playerState){
   if (!entry || !playerState) return true;
   const playerTier = playerState.tierValue;
@@ -10610,8 +10635,11 @@ function isEntryAvailableToPlayer(entry, playerState){
     if (!tierOk) return false;
   }
   if (Array.isArray(entry.classifications) && entry.classifications.length) {
-    const classOk = entry.classifications.some(token => playerState.tags.has(token));
-    if (!classOk) return false;
+    const gatingTags = entry.classifications.filter(token => !GENERIC_CLASSIFICATION_TAGS.has(token));
+    if (gatingTags.length) {
+      const classOk = gatingTags.some(token => playerState.tags.has(token));
+      if (!classOk) return false;
+    }
   }
   if (Array.isArray(entry.prerequisites) && entry.prerequisites.length) {
     for (const prereq of entry.prerequisites) {


### PR DESCRIPTION
## Summary
- document the supported gear classification vocabulary
- derive and preserve descriptive classification tags when normalizing the catalog
- update the catalog data and front-end gating logic to consume the new tags safely

## Testing
- npm run build:catalog
- npm test *(fails: existing suite errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e624edee90832e9c385b8fd800c807