### PR TITLE
Parse weapon range separately

### DIFF
--- a/__tests__/weapon_range_parsing.test.js
+++ b/__tests__/weapon_range_parsing.test.js
@@ -1,0 +1,84 @@
+import { jest } from '@jest/globals';
+
+describe('weapon range parsing', () => {
+  test('catalog weapon cards extract range separately', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => '',
+      json: async () => ({}),
+      arrayBuffer: async () => new ArrayBuffer(0)
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const realGet = document.getElementById.bind(document);
+    const restoreGet = () => {
+      document.getElementById = realGet;
+    };
+
+    document.body.innerHTML = `
+      <div id="toast"></div>
+      <div id="weapons"></div>
+      <input id="credits" value="0" />
+      <div id="credits-total-pill"></div>
+    `;
+
+    document.getElementById = (id) => realGet(id) || {
+      innerHTML: '',
+      value: '',
+      style: { setProperty: () => {}, getPropertyValue: () => '' },
+      classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+      setAttribute: () => {},
+      getAttribute: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      appendChild: () => {},
+      contains: () => false,
+      add: () => {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      focus: () => {},
+      click: () => {},
+      textContent: '',
+      disabled: false,
+      checked: false,
+      hidden: false
+    };
+
+    if (!window.matchMedia) {
+      window.matchMedia = () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} });
+    }
+
+    try {
+      await jest.isolateModulesAsync(async () => {
+        const { buildCardInfo, extractWeaponDetails } = await import('../scripts/main.js');
+
+        const entry = {
+          rawType: 'Weapon',
+          type: 'Weapon',
+          name: 'Frost Cannon',
+          perk: 'Damage 2d6 cold; cone 15 ft.; Targets must succeed a DEX save',
+          tier: 'T2'
+        };
+
+        const { extras, range } = extractWeaponDetails(entry.perk);
+        expect(range).toBe('cone 15 ft');
+        expect(extras).not.toContain('cone 15 ft');
+
+        const info = buildCardInfo(entry);
+        expect(info.kind).toBe('weapon');
+        expect(info.data.range).toBe('cone 15 ft');
+        expect(info.data.damage).not.toMatch(/cone 15 ft/i);
+        expect(info.data.damage).toMatch(/Damage 2d6 cold/);
+      });
+    } finally {
+      restoreGet();
+      errorSpy.mockRestore();
+      if (originalFetch) {
+        global.fetch = originalFetch;
+      } else {
+        delete global.fetch;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- update weapon perk parsing to isolate range snippets from other modifiers
- populate weapon card data with a dedicated range field sourced from the parsed perk text
- add a regression test covering catalog weapon range population and adjust autosave scheduling constants ordering to avoid premature access during module load

## Testing
- npm test -- --runTestsByPath __tests__/weapon_range_parsing.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e62521e350832ea8b20cfcd3441f36