### PR TITLE
Allow calculateArmorBonus to handle penalties

### DIFF
--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -62,7 +62,7 @@ describe('calculateArmorBonus', () => {
     expect(calculateArmorBonus()).toBe(10);
   });
 
-  test('ignores negative armor bonuses', () => {
+  test('applies negative armor bonuses', () => {
     document.body.innerHTML = `
       <div data-kind="armor">
         <input type="checkbox" data-f="equipped" checked>
@@ -70,7 +70,23 @@ describe('calculateArmorBonus', () => {
         <select data-f="slot"><option>Head</option></select>
       </div>
     `;
-    expect(calculateArmorBonus()).toBe(0);
+    expect(calculateArmorBonus()).toBe(-5);
+  });
+
+  test('negative armor bonus lowers total TC', () => {
+    document.body.innerHTML = `
+      <div data-kind="armor">
+        <input type="checkbox" data-f="equipped" checked>
+        <input data-f="bonus" value="-2">
+        <select data-f="slot"><option>Body</option></select>
+      </div>
+    `;
+    const dexMod = mod(12); // +1
+    const armorBonus = calculateArmorBonus();
+    const totalTC = 10 + dexMod + armorBonus;
+
+    expect(armorBonus).toBe(-2);
+    expect(totalTC).toBe(9);
   });
 });
 

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -22,7 +22,9 @@ export function calculateArmorBonus(){
   qsa("[data-kind='armor']").forEach(card=>{
     const eq = qs("input[type='checkbox'][data-f='equipped']", card);
     const bonusEl = qs("input[data-f='bonus']", card);
-    const bonus = Math.max(0, num(bonusEl ? bonusEl.value : 0));
+    // Allow armor cards to apply penalties as well as bonuses. Missing values
+    // still default to zero so optional fields don't break the calculation.
+    const bonus = num(bonusEl ? bonusEl.value : 0);
     const slotEl = qs("select[data-f='slot']", card);
     const slot = slotEl ? slotEl.value : 'Body';
     if (eq && eq.checked){


### PR DESCRIPTION
## Summary
- update calculateArmorBonus to keep negative armor modifiers instead of clamping to zero
- document the change inline so optional inputs without values still default safely
- extend helper unit tests to cover negative armor cards and confirm TC decreases accordingly

## Testing
- npm test -- helpers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e6253cc568832e8c8c87853280aa9c