### PR TITLE
Fix weapon ability auto-sync for saved cards

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -9156,7 +9156,13 @@ function createCard(kind, pref = {}) {
   if (kind === 'weapon') {
     const rangeField = qs("[data-f='range']", card);
     const abilityField = qs("[data-f='attackAbility']", card);
-    const abilityShouldAutoSync = !attackAbilityWasProvided || !providedAttackAbilityRaw;
+    const normalizedProvidedAbility = providedAttackAbilityRaw
+      ? String(providedAttackAbilityRaw).trim().toLowerCase()
+      : '';
+    const inferredAbilityFromRange = inferWeaponAttackAbility({ range: pref.range });
+    const abilityShouldAutoSync = !attackAbilityWasProvided
+      || !normalizedProvidedAbility
+      || normalizedProvidedAbility === inferredAbilityFromRange;
     if (abilityField) {
       abilityField.dataset.autoSync = abilityShouldAutoSync ? 'true' : 'false';
       const markManualAbilitySelection = () => {


### PR DESCRIPTION
## Summary
- keep weapon attack ability auto-sync enabled when saved data matches the inferred range ability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e626bcb62c832e98341d8a846bb713