### PR TITLE
Fix welcome modal autosave initialization

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -11142,6 +11142,10 @@ function redo(){
   if(histIdx < history.length - 1){ histIdx++; deserialize(history[histIdx]); }
 }
 
+const CLOUD_AUTO_SAVE_INTERVAL_MS = 2 * 60 * 1000;
+let scheduledAutoSaveId = null;
+let scheduledAutoSaveInFlight = false;
+
 (function(){
   try{ localStorage.removeItem(AUTO_KEY); }catch{}
   if(forcedRefreshResume && forcedRefreshResume.data){
@@ -11165,10 +11169,6 @@ function redo(){
     });
   }
 })();
-
-const CLOUD_AUTO_SAVE_INTERVAL_MS = 2 * 60 * 1000;
-let scheduledAutoSaveId = null;
-let scheduledAutoSaveInFlight = false;
 
 async function performScheduledAutoSave(){
   if(scheduledAutoSaveInFlight) return;


### PR DESCRIPTION
## Summary
- Move the autosave timer declarations ahead of the bootstrapping IIFE so they are initialized before any cloud sync helpers run
- Prevent the scheduled autosave code from throwing a temporal dead zone error that halted main.js evaluation, restoring the welcome modal button handlers

## Testing
- npm test *(fails: existing suite errors about missing beginQueuedSyncFlush export and DM menu expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e624120a2c832e9dfec3227268dcf9