### PR TITLE
Display gear prices and sync credit totals

### DIFF
--- a/__tests__/character_events.test.js
+++ b/__tests__/character_events.test.js
@@ -22,6 +22,9 @@ describe('character events', () => {
       deleteCampaignLogEntry: jest.fn().mockResolvedValue(),
       fetchCampaignLogEntries: jest.fn().mockResolvedValue([]),
       subscribeCampaignLog: () => null,
+      beginQueuedSyncFlush: () => {},
+      getLastSyncStatus: () => 'idle',
+      subscribeSyncStatus: () => () => {},
     }));
 
     const { saveCharacter, deleteCharacter } = await import('../scripts/characters.js');

--- a/__tests__/credits_cloud.test.js
+++ b/__tests__/credits_cloud.test.js
@@ -48,6 +48,9 @@ describe('credits autosave to cloud', () => {
       deleteCampaignLogEntry: jest.fn().mockResolvedValue(),
       fetchCampaignLogEntries: jest.fn().mockResolvedValue([]),
       subscribeCampaignLog: () => null,
+      beginQueuedSyncFlush: () => {},
+      getLastSyncStatus: () => 'idle',
+      subscribeSyncStatus: () => () => {},
     }));
 
     global.toast = jest.fn();

--- a/__tests__/dm_login.test.js
+++ b/__tests__/dm_login.test.js
@@ -42,6 +42,9 @@ describe('dm login', () => {
       deleteCampaignLogEntry: jest.fn().mockResolvedValue(),
       fetchCampaignLogEntries: jest.fn().mockResolvedValue([]),
       subscribeCampaignLog: () => null,
+      beginQueuedSyncFlush: () => {},
+      getLastSyncStatus: () => 'idle',
+      subscribeSyncStatus: () => () => {},
     }));
     await import('../scripts/modal.js');
     await import('../scripts/dm.js');
@@ -109,6 +112,9 @@ describe('dm login', () => {
       deleteCampaignLogEntry: jest.fn().mockResolvedValue(),
       fetchCampaignLogEntries: jest.fn().mockResolvedValue([]),
       subscribeCampaignLog: () => null,
+      beginQueuedSyncFlush: () => {},
+      getLastSyncStatus: () => 'idle',
+      subscribeSyncStatus: () => () => {},
     }));
     await import('../scripts/modal.js');
     await import('../scripts/dm.js');
@@ -159,6 +165,9 @@ describe('dm login', () => {
       deleteCampaignLogEntry: jest.fn().mockResolvedValue(),
       fetchCampaignLogEntries: jest.fn().mockResolvedValue([]),
       subscribeCampaignLog: () => null,
+      beginQueuedSyncFlush: () => {},
+      getLastSyncStatus: () => 'idle',
+      subscribeSyncStatus: () => () => {},
     }));
 
     await import('../scripts/dm.js');

--- a/__tests__/mini_games_player_invite.test.js
+++ b/__tests__/mini_games_player_invite.test.js
@@ -162,6 +162,9 @@ async function initMainModule() {
     deleteCampaignLogEntry: async () => {},
     fetchCampaignLogEntries: async () => [],
     subscribeCampaignLog: () => () => {},
+    beginQueuedSyncFlush: () => {},
+    getLastSyncStatus: () => 'idle',
+    subscribeSyncStatus: () => () => {},
   }));
 
   jest.unstable_mockModule('../scripts/pin.js', () => ({

--- a/index.html
+++ b/index.html
@@ -763,6 +763,10 @@
           <span class="credits-currency" aria-hidden="true">₡</span>
           <span id="credits-total-pill" class="pill">0</span>
         </div>
+        <div class="credits-summary">
+          <span id="credits-gear-total" class="pill pill-sm">Equipped Gear: ₡0</span>
+          <span id="credits-gear-remaining" class="pill pill-sm">Remaining Credits: ₡0</span>
+        </div>
         <div class="inline">
           <label for="credits-amt" class="sr-only">Amount</label>
           <input id="credits-amt" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Amount"/>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1813,6 +1813,10 @@ progress::-moz-progress-bar{
 .sp-field #long-rest{width:100%;margin-top:8px;}
 .cap-field .cap-box{margin-top:8px;}
 .card{border:1px solid var(--line);border-radius:var(--radius);padding:var(--card-padding,8px);display:flex;flex-direction:column;gap:var(--card-gap,10px);transition:box-shadow .3s ease-in-out;background:color-mix(in srgb,var(--surface) 5%,transparent);background-color:color-mix(in srgb,var(--surface) 5%,transparent);-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);margin-left:auto;margin-right:auto;width:100%;max-width:var(--content-width);font-size:1.1rem}
+.credits-summary{display:flex;flex-wrap:wrap;gap:8px}
+.credits-summary .pill{font-size:var(--pill-font-size)}
+.gear-card-price{display:flex;justify-content:flex-end}
+.gear-card-price .pill{margin:0 0 4px auto}
 .card[hidden]{display:none !important}
 .gear-card .gear-card-title{margin:0}
 .gear-card .gear-card-action{align-self:flex-start}


### PR DESCRIPTION
## Summary
- surface gear prices on cards using catalog-provided display text or formatted cost chips
- total equipped gear prices to show alongside credits, including remaining or shortfall messaging
- extend storage mocks in unit tests for new sync helper exports

## Testing
- npm test *(fails: dm tools bootstrap > reveals toggle when logged in and syncs menu expansion)*

------
https://chatgpt.com/codex/tasks/task_e_68e621b8eb3c832eaea5bcf2bd7a18d2