### PR TITLE
Add SP options modal for stamina points

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,10 +375,10 @@
             <button
               type="button"
               class="card-caret"
-              id="sp-menu-toggle"
-              aria-haspopup="true"
+              id="sp-settings-toggle"
+              aria-haspopup="dialog"
               aria-expanded="false"
-              aria-controls="sp-menu"
+              aria-controls="modal-sp-settings"
               aria-label="Edit SP options"
               title="Edit SP options"
             >
@@ -391,8 +391,6 @@
             <progress id="sp-bar" max="5" value="5"></progress>
             <span id="sp-pill">5/5</span>
           </div>
-          <label for="sp-temp" class="sr-only">Temp SP</label>
-          <input id="sp-temp" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Temp SP"/>
         </div>
         <div class="sp-grid">
           <button class="btn-sm" data-sp="-1">-1 SP</button>
@@ -401,9 +399,6 @@
           <button class="btn-sm" data-sp="-4">-4 SP</button>
           <button class="btn-sm" data-sp="-5">-5 SP</button>
           <button id="sp-full" class="btn-sm">Reset SP</button>
-        </div>
-        <div id="sp-menu" class="card-menu" role="menu" hidden>
-          <button id="long-rest" class="card-menu__item" role="menuitem" type="button">Long Rest</button>
         </div>
       </fieldset>
       <fieldset class="card cap-field">
@@ -1217,6 +1212,26 @@
   </div>
 </div>
 
+
+<div class="overlay hidden" id="modal-sp-settings" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>SP Options</h3>
+    <div class="hp-settings__section">
+      <label for="sp-temp">Temporary SP</label>
+      <input id="sp-temp" data-view-allow type="number" inputmode="numeric" pattern="[0-9]*" placeholder="Temp SP"/>
+    </div>
+    <div class="actions hp-settings__actions">
+      <button id="long-rest" class="btn-sm" type="button">Long Rest</button>
+      <button id="sp-settings-save" class="btn-sm" type="button">Save</button>
+      <button class="btn-sm" data-close>Close</button>
+    </div>
+  </div>
+</div>
 
 <!-- LOG MODAL -->
 <div class="overlay hidden" id="modal-log" aria-hidden="true">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4173,8 +4173,8 @@ const elPowerMetricToggle = $('power-range-metric');
 const elPowerTextCompact = $('power-text-compact');
 const elPowerStylePrimary = $('power-style');
 const elPowerStyleSecondary = $('power-style-2');
-const elSPMenuToggle = $('sp-menu-toggle');
-const elSPMenu = $('sp-menu');
+const elSPSettingsToggle = $('sp-settings-toggle');
+const spSettingsOverlay = $('modal-sp-settings');
 
 let casterAbilityManuallySet = false;
 let lastCasterAbilitySuggestions = [];
@@ -4864,7 +4864,7 @@ function changeSP(delta){
 }
 qsa('[data-sp]').forEach(b=> b.addEventListener('click', ()=> changeSP(num(b.dataset.sp)||0) ));
 $('long-rest').addEventListener('click', ()=>{
-  closeSpMenu({ restoreFocus: true });
+  closeSpSettings();
   if(!confirm('Take a long rest?')) return;
   setHP(num(elHPBar.max));
   setSP(num(elSPBar.max));
@@ -4944,112 +4944,42 @@ if (hpRollSaveButton) {
 }
 qsa('#modal-hp-settings [data-close]').forEach(b=> b.addEventListener('click', closeHpSettings));
 
-function adjustCardMenuBounds(menu){
-  if (!menu || typeof menu.style === 'undefined') return;
-  menu.style.removeProperty('--card-menu-offset-x');
-  menu.style.removeProperty('--card-menu-max-height');
-  requestAnimationFrame(()=>{
-    if (typeof menu.hasAttribute === 'function' && menu.hasAttribute('hidden')) return;
-    if (typeof menu.getBoundingClientRect !== 'function') return;
-    const rect = menu.getBoundingClientRect();
-    const viewportWidth = Math.max(document.documentElement?.clientWidth || 0, window.innerWidth || 0);
-    const viewportHeight = Math.max(document.documentElement?.clientHeight || 0, window.innerHeight || 0);
-    if (viewportWidth) {
-      if (rect.right > viewportWidth - 12) {
-        const offset = rect.right - (viewportWidth - 12);
-        menu.style.setProperty('--card-menu-offset-x', `${Math.ceil(offset)}px`);
-      } else if (rect.left < 12) {
-        const offset = rect.left - 12;
-        menu.style.setProperty('--card-menu-offset-x', `${Math.floor(offset)}px`);
-      }
-    }
-    if (viewportHeight && rect.bottom > viewportHeight - 12) {
-      const available = Math.max(120, viewportHeight - rect.top - 12);
-      menu.style.setProperty('--card-menu-max-height', `${Math.floor(available)}px`);
-    }
+function setSpSettingsExpanded(expanded){
+  if (!elSPSettingsToggle) return;
+  elSPSettingsToggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+}
+function openSpSettings(){
+  show('modal-sp-settings');
+  setSpSettingsExpanded(true);
+  if (elSPTemp && typeof elSPTemp.focus === 'function') {
+    requestAnimationFrame(()=> elSPTemp.focus({ preventScroll: true }));
+  }
+}
+function closeSpSettings(){
+  hide('modal-sp-settings');
+  setSpSettingsExpanded(false);
+  if (elSPSettingsToggle && typeof elSPSettingsToggle.focus === 'function') {
+    requestAnimationFrame(()=> elSPSettingsToggle.focus({ preventScroll: true }));
+  }
+}
+if (elSPSettingsToggle) {
+  elSPSettingsToggle.addEventListener('click', openSpSettings);
+}
+if (typeof MutationObserver === 'function' && spSettingsOverlay instanceof Element) {
+  const observer = new MutationObserver(() => {
+    const expanded = !spSettingsOverlay.classList.contains('hidden');
+    setSpSettingsExpanded(expanded);
+  });
+  observer.observe(spSettingsOverlay, { attributes: true, attributeFilter: ['class'] });
+}
+const spSettingsSaveButton = $('sp-settings-save');
+if (spSettingsSaveButton) {
+  spSettingsSaveButton.addEventListener('click', ()=>{
+    updateDerived();
+    closeSpSettings();
   });
 }
-function isRealElement(node) {
-  if (!node) return false;
-  if (typeof Element !== 'undefined' && node instanceof Element) return true;
-  return typeof node === 'object'
-    && typeof node.removeAttribute === 'function'
-    && typeof node.setAttribute === 'function';
-}
-
-function openSpMenu(options = {}){
-  if (!isRealElement(elSPMenu) || !isRealElement(elSPMenuToggle)) return;
-  elSPMenu.removeAttribute('hidden');
-  elSPMenuToggle.setAttribute('aria-expanded', 'true');
-  adjustCardMenuBounds(elSPMenu);
-  if (options.focusFirst) {
-    requestAnimationFrame(()=>{
-      const first = typeof elSPMenu.querySelector === 'function'
-        ? elSPMenu.querySelector('button:not([disabled])')
-        : null;
-      if (first && typeof first.focus === 'function') {
-        first.focus({ preventScroll: true });
-      }
-    });
-  }
-}
-function closeSpMenu(options = {}){
-  if (!isRealElement(elSPMenu) || !isRealElement(elSPMenuToggle)) return;
-  const wasOpen = typeof elSPMenu.hasAttribute === 'function' ? !elSPMenu.hasAttribute('hidden') : true;
-  if (typeof elSPMenu.setAttribute === 'function' && typeof elSPMenu.hasAttribute === 'function' && !elSPMenu.hasAttribute('hidden')) {
-    elSPMenu.setAttribute('hidden', '');
-  }
-  if (typeof elSPMenuToggle.setAttribute === 'function') {
-    elSPMenuToggle.setAttribute('aria-expanded', 'false');
-  }
-  if (typeof elSPMenu.style !== 'undefined') {
-    elSPMenu.style.removeProperty('--card-menu-offset-x');
-    elSPMenu.style.removeProperty('--card-menu-max-height');
-  }
-  const shouldRestoreFocus = wasOpen && (
-    options.restoreFocus || (typeof elSPMenu.contains === 'function' && elSPMenu.contains(document.activeElement))
-  );
-  if (shouldRestoreFocus) {
-    requestAnimationFrame(()=>{
-      if (typeof elSPMenuToggle.focus === 'function') {
-        elSPMenuToggle.focus({ preventScroll: true });
-      }
-    });
-  }
-}
-if (isRealElement(elSPMenuToggle) && isRealElement(elSPMenu)) {
-  elSPMenuToggle.addEventListener('click', e => {
-    e.stopPropagation();
-    const isHidden = typeof elSPMenu.hasAttribute === 'function' ? elSPMenu.hasAttribute('hidden') : false;
-    if (isHidden) {
-      openSpMenu({ focusFirst: e.detail === 0 });
-    } else {
-      closeSpMenu();
-    }
-  });
-  elSPMenu.addEventListener('click', e => e.stopPropagation());
-  document.addEventListener('click', e => {
-    const containsTarget = typeof elSPMenu.contains === 'function' && elSPMenu.contains(e.target);
-    if (!containsTarget && e.target !== elSPMenuToggle) {
-      closeSpMenu();
-    }
-  });
-  document.addEventListener('keydown', e => {
-    const isHidden = typeof elSPMenu.hasAttribute === 'function' ? elSPMenu.hasAttribute('hidden') : false;
-    if (e.key === 'Escape' && !isHidden) {
-      e.stopPropagation();
-      closeSpMenu({ restoreFocus: true });
-    }
-  });
-  const handleSpMenuViewportChange = ()=>{
-    const isHidden = typeof elSPMenu.hasAttribute === 'function' ? elSPMenu.hasAttribute('hidden') : false;
-    if (!isHidden) {
-      adjustCardMenuBounds(elSPMenu);
-    }
-  };
-  window.addEventListener('resize', handleSpMenuViewportChange);
-  window.addEventListener('orientationchange', handleSpMenuViewportChange);
-}
+qsa('#modal-sp-settings [data-close]').forEach(b=> b.addEventListener('click', closeSpSettings));
 
 /* ========= Dice/Coin + Logs ========= */
 function safeParse(key){


### PR DESCRIPTION
## Summary
- replace the SP quick menu with a modal dialog that mirrors the HP options experience
- move the temporary SP field into the new modal alongside Long Rest and Save controls
- update client-side logic to open/close the modal and wire the Long Rest flow to it

## Testing
- Manually verified in browser

------
https://chatgpt.com/codex/tasks/task_e_68e624b2ac34832e98ea2e9e3eb6d3b1