### PR TITLE
Limit long rest checkbox reset to combat controls

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4917,8 +4917,14 @@ $('long-rest').addEventListener('click', ()=>{
   setSP(num(elSPBar.max));
   elHPTemp.value='';
   if (elSPTemp) elSPTemp.value='';
-  // clear all checkbox states on the page
-  qsa('input[type="checkbox"]').forEach(cb=>{
+  // clear combat-related checkbox states only
+  const combatCheckboxes = [
+    ...qsa('#death-saves input[type="checkbox"]'),
+    ...qsa('#statuses input[type="checkbox"]'),
+    ...qsa('#ongoing-effects input[type="checkbox"]'),
+  ];
+  if (elCAPCheck) combatCheckboxes.push(elCAPCheck);
+  combatCheckboxes.forEach(cb => {
     cb.checked = false;
     cb.removeAttribute('checked');
   });


### PR DESCRIPTION
## Summary
- narrow the long rest checkbox reset to the combat tab by clearing only status, death save, and cinematic action point toggles
- leave proficiency and other non-combat checkboxes untouched when a long rest is triggered

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6310221b8832eaa64c4a68d5137fc