### PR TITLE
Animate initiative roll result

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4359,7 +4359,12 @@ if (elPowerSaveAbility) {
 
 refreshCasterAbilitySuggestion({ force: true });
 
-if (elInitiativeRollBtn) {
+if (elInitiativeRollBtn && elInitiativeRollResult) {
+  const initiativeOutcomeClasses = ['initiative-roll--crit-high', 'initiative-roll--crit-low'];
+  const resetInitiativeAnimation = () => {
+    elInitiativeRollResult.classList.remove('initiative-roll--active');
+  };
+
   elInitiativeRollBtn.addEventListener('click', () => {
     const dexMod = mod(elDex.value);
     const wisMod = addWisToInitiative ? mod(elWis.value) : 0;
@@ -4371,7 +4376,32 @@ if (elInitiativeRollBtn) {
       base += wisMod;
       baseBonuses.push({ label: 'WIS mod', value: wisMod, includeZero: true });
     }
-    rollWithBonus('Initiative', base, elInitiativeRollResult, { type: 'initiative', baseBonuses });
+    let rollDetails = null;
+    rollWithBonus('Initiative', base, elInitiativeRollResult, {
+      type: 'initiative',
+      baseBonuses,
+      onRoll: details => {
+        rollDetails = details;
+      },
+    });
+
+    elInitiativeRollResult.classList.remove('initiative-roll--active', ...initiativeOutcomeClasses);
+
+    if (rollDetails) {
+      if (rollDetails.roll === rollDetails.sides) {
+        elInitiativeRollResult.classList.add('initiative-roll--crit-high');
+      } else if (rollDetails.roll === 1) {
+        elInitiativeRollResult.classList.add('initiative-roll--crit-low');
+      }
+    }
+
+    if (!animationsEnabled) {
+      return;
+    }
+
+    void elInitiativeRollResult.offsetWidth;
+    elInitiativeRollResult.classList.add('initiative-roll--active');
+    elInitiativeRollResult.addEventListener('animationend', resetInitiativeAnimation, { once: true });
   });
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -1689,6 +1689,12 @@ progress::-moz-progress-bar{
   60%{transform:scale(1) rotate(360deg);opacity:1;}
   100%{transform:scale(0.5) rotate(540deg);opacity:0;}
 }
+@keyframes initiativeGlow{
+  0%{box-shadow:0 0 0 0 color-mix(in srgb,var(--initiative-glow-color, var(--accent)) 60%, transparent);transform:translateZ(0) scale(1);}
+  40%{box-shadow:0 0 0 12px color-mix(in srgb,var(--initiative-glow-color, var(--accent)) 10%, transparent);transform:translateZ(0) scale(1.05);}
+  60%{box-shadow:0 0 0 8px color-mix(in srgb,var(--initiative-glow-color, var(--accent)) 18%, transparent);transform:translateZ(0) scale(1.02);}
+  100%{box-shadow:0 0 0 0 color-mix(in srgb,var(--initiative-glow-color, var(--accent)) 0%, transparent);transform:translateZ(0) scale(1);}
+}
 #load-animation{
   position:fixed;
   inset:0;
@@ -2765,3 +2771,7 @@ body.is-view-mode .power-editor__content .power-card__body{display:flex}
 .roll-tools__panel .pill.result{margin-bottom:2px;font-size:var(--roll-tools-pill-font-size);min-height:var(--roll-tools-pill-height);padding:clamp(3px,1.2vw,6px) clamp(8px,2.4vw,12px)}
 .roll-tools__initiative{margin-top:calc(var(--roll-tools-gap)*.6);padding-top:calc(var(--roll-tools-gap)*.8);border-top:1px solid var(--line);display:flex;flex-direction:column;gap:calc(var(--roll-tools-gap)*.6)}
 .roll-tools__initiative label{margin:0;font-size:var(--roll-tools-heading-size);color:var(--muted);text-transform:uppercase;letter-spacing:.06em}
+#initiative-roll-result{--initiative-glow-color:var(--accent);transition:color .3s ease, border-color .3s ease;}
+#initiative-roll-result.initiative-roll--active{animation:initiativeGlow .9s cubic-bezier(.33,1,.68,1);}
+#initiative-roll-result.initiative-roll--crit-high{--initiative-glow-color:var(--success);color:var(--success);border-color:color-mix(in srgb,var(--success) 60%, var(--surface-2) 40%);}
+#initiative-roll-result.initiative-roll--crit-low{--initiative-glow-color:var(--error);color:var(--error);border-color:color-mix(in srgb,var(--error) 60%, var(--surface-2) 40%);}


### PR DESCRIPTION
## Summary
- add an initiative-specific pulse animation and styling hooks for critical highs and lows
- trigger the initiative animation from the roll button and clear it after the animation completes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e631d048c8832ebea5d50befea2298