### PR TITLE
Replace edit icons with attribution pencil image

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,7 +362,9 @@
               aria-label="Edit HP options"
               title="Edit HP options"
             >
-              <span class="btn-icon" aria-hidden="true">✎</span>
+              <span class="btn-icon" aria-hidden="true">
+                <img class="btn-icon__img" src="images/attribution-pencil (1).png" alt=""/>
+              </span>
             </button>
           </span>
         </legend>
@@ -396,7 +398,9 @@
               aria-label="Edit SP options"
               title="Edit SP options"
             >
-              <span class="btn-icon" aria-hidden="true">✎</span>
+              <span class="btn-icon" aria-hidden="true">
+                <img class="btn-icon__img" src="images/attribution-pencil (1).png" alt=""/>
+              </span>
             </button>
           </span>
         </legend>
@@ -523,7 +527,9 @@
           data-view-label="Ability Scores"
           aria-describedby="card-abilities-title"
         >
-          <span class="btn-icon" aria-hidden="true">✎</span>
+          <span class="btn-icon" aria-hidden="true">
+            <img class="btn-icon__img" src="images/attribution-pencil (1).png" alt=""/>
+          </span>
           <span class="btn-label card-edit-toggle__label sr-only">Edit</span>
         </button>
       </h2>
@@ -674,7 +680,9 @@
           data-view-label="Character and Story"
           aria-describedby="card-story-title"
         >
-          <span class="btn-icon" aria-hidden="true">✎</span>
+          <span class="btn-icon" aria-hidden="true">
+            <img class="btn-icon__img" src="images/attribution-pencil (1).png" alt=""/>
+          </span>
           <span class="btn-label card-edit-toggle__label sr-only">Edit</span>
         </button>
       </h2>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1294,6 +1294,13 @@ button:focus-visible,
   margin-inline-end:clamp(4px,1.2vw,8px);
 }
 
+.btn-icon__img{
+  width:1em;
+  height:1em;
+  display:block;
+  object-fit:contain;
+}
+
 button .btn-label{display:inline-flex;align-items:center}
 
 .inline{display:flex;align-items:center;gap:var(--control-gap);flex-wrap:wrap}


### PR DESCRIPTION
## Summary
- swap the HP, SP, Ability Scores, and Character and Story edit buttons to use the attribution pencil icon image
- add styling for the new image-based icon so it aligns with existing button layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e63578f110832eb43c3f74f3228bef