### PR TITLE
Add cached audio cues for status animations

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5534,11 +5534,137 @@ function playDamageAnimation(amount){
   });
 }
 
+const AUDIO_CUE_SETTINGS = {
+  down: {
+    frequency: 110,
+    type: 'sawtooth',
+    duration: 0.55,
+    volume: 0.3,
+    attack: 0.02,
+    release: 0.25,
+    partials: [
+      { ratio: 1, amplitude: 1 },
+      { ratio: 0.5, amplitude: 0.6 },
+    ],
+  },
+  death: {
+    frequency: 70,
+    type: 'square',
+    duration: 0.85,
+    volume: 0.28,
+    attack: 0.01,
+    release: 0.35,
+    partials: [
+      { ratio: 1, amplitude: 1 },
+      { ratio: 2, amplitude: 0.45 },
+    ],
+  },
+  heal: {
+    frequency: 660,
+    type: 'sine',
+    duration: 0.7,
+    volume: 0.22,
+    attack: 0.015,
+    release: 0.3,
+    partials: [
+      { ratio: 1, amplitude: 1 },
+      { ratio: 1.5, amplitude: 0.55 },
+      { ratio: 2, amplitude: 0.3 },
+    ],
+  },
+};
+
+let audioContext;
+const audioCueCache = new Map();
+
+function ensureAudioContext(){
+  if(typeof window === 'undefined') return null;
+  const Ctx = window.AudioContext || window.webkitAudioContext;
+  if(!Ctx) return null;
+  if(!audioContext){
+    audioContext = new Ctx();
+  }
+  if(audioContext?.state === 'suspended'){
+    audioContext.resume?.().catch(()=>{});
+  }
+  return audioContext;
+}
+
+function renderWaveSample(type, freq, t){
+  const phase = 2 * Math.PI * freq * t;
+  switch(type){
+    case 'square':
+      return Math.sign(Math.sin(phase)) || 0;
+    case 'triangle':
+      return 2 * Math.asin(Math.sin(phase)) / Math.PI;
+    case 'sawtooth':
+      return 2 * (freq * t - Math.floor(0.5 + freq * t));
+    default:
+      return Math.sin(phase);
+  }
+}
+
+function buildAudioBuffer(name){
+  const ctx = ensureAudioContext();
+  if(!ctx) return null;
+  const config = AUDIO_CUE_SETTINGS[name];
+  if(!config) return null;
+  const {
+    duration = 0.4,
+    frequency = 440,
+    type = 'sine',
+    volume = 0.2,
+    attack = 0.01,
+    release = 0.1,
+    partials,
+  } = config;
+  const sampleRate = ctx.sampleRate;
+  const totalSamples = Math.max(1, Math.floor(sampleRate * duration));
+  const buffer = ctx.createBuffer(1, totalSamples, sampleRate);
+  const data = buffer.getChannelData(0);
+  const voices = (partials && partials.length) ? partials : [{ ratio: 1, amplitude: 1 }];
+  const normalization = voices.reduce((sum, part)=>sum + Math.abs(part.amplitude ?? 1), 0) || 1;
+
+  for(let i=0;i<totalSamples;i++){
+    const t = i / sampleRate;
+    let envelope = 1;
+    if(attack > 0 && t < attack){
+      envelope = t / attack;
+    }else if(release > 0 && t > duration - release){
+      envelope = Math.max((duration - t) / release, 0);
+    }
+    let sample = 0;
+    for(const part of voices){
+      const ratio = part.ratio ?? 1;
+      const amplitude = part.amplitude ?? 1;
+      sample += amplitude * renderWaveSample(type, frequency * ratio, t);
+    }
+    data[i] = (sample / normalization) * envelope * volume;
+  }
+
+  audioCueCache.set(name, buffer);
+  return buffer;
+}
+
+function playStatusCue(name){
+  const ctx = ensureAudioContext();
+  if(!ctx) return;
+  const buffer = audioCueCache.get(name) ?? buildAudioBuffer(name);
+  if(!buffer) return;
+  const source = ctx.createBufferSource();
+  source.buffer = buffer;
+  const gain = ctx.createGain();
+  gain.gain.value = 1;
+  source.connect(gain).connect(ctx.destination);
+  source.start();
+}
+
 function playDownAnimation(){
   if(!animationsEnabled) return Promise.resolve();
   const anim = $('down-animation');
   if(!anim) return Promise.resolve();
   anim.hidden=false;
+  playStatusCue('down');
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{
@@ -5556,6 +5682,7 @@ function playDeathAnimation(){
   const anim = $('death-animation');
   if(!anim) return Promise.resolve();
   anim.hidden=false;
+  playStatusCue('death');
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{
@@ -5574,6 +5701,7 @@ function playHealAnimation(amount){
   if(!anim) return Promise.resolve();
   anim.textContent=`+${amount}`;
   anim.hidden=false;
+  playStatusCue('heal');
   return new Promise(res=>{
     anim.classList.add('show');
     const done=()=>{


### PR DESCRIPTION
## Summary
- add a lightweight audio cue helper that prebuilds synthesized tones for status animations
- trigger unique down, death, and heal cues when their animations begin
- cache rendered audio buffers so repeated animations avoid playback latency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e653f14dc4832e9a6bfa981d30f30c