### PR TITLE
Add save confirmation cue before success toast

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5603,6 +5603,19 @@ function playSaveAnimation(){
   });
 }
 
+function cueSuccessfulSave(){
+  try {
+    const cue = playSaveAnimation();
+    if (cue && typeof cue.catch === 'function') {
+      cue.catch(err => console.error('Save confirmation cue failed', err));
+    }
+    return cue;
+  } catch (err) {
+    console.error('Save confirmation cue failed', err);
+    return Promise.resolve();
+  }
+}
+
 function playCoinAnimation(result){
   if(!animationsEnabled) return Promise.resolve();
   const anim=$('coin-animation');
@@ -11532,8 +11545,11 @@ $('btn-save').addEventListener('click', async () => {
       await saveCharacter(data, target);
     }
     markAutoSaveSynced(data, serialized);
+    cueSuccessfulSave();
     toast('Save successful', 'success');
-    playSaveAnimation();
+  } catch (e) {
+    console.error('Save failed', e);
+    toast('Save failed', 'error');
   } finally {
     btn.classList.remove('loading'); btn.disabled = false;
   }
@@ -11551,6 +11567,7 @@ if (heroInput) {
       try {
         const data = serialize();
         await saveCharacter(data, name);
+        cueSuccessfulSave();
         markAutoSaveSynced(data);
       } catch (e) {
         console.error('Autosave failed', e);


### PR DESCRIPTION
## Summary
- add a reusable `cueSuccessfulSave` helper to trigger the save animation confirmation cue
- invoke the cue before the success toast in the manual save flow and add error handling for failed saves
- reuse the cue during automatic hero creation saves so the experience stays consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e653fb3698832e957e4efa5a7515c6