### PR TITLE
Handle suspended audio context before playing tones

### DIFF
--- a/__tests__/app_comprehensive_integration.test.js
+++ b/__tests__/app_comprehensive_integration.test.js
@@ -127,6 +127,24 @@ function installCoreMocks() {
     }
   }
 
+  function createSynchronousThenable(){
+    const chain = {
+      then(onFulfilled, onRejected){
+        try{
+          onFulfilled?.();
+        }catch(error){
+          onRejected?.(error);
+        }
+        return chain;
+      },
+      catch(onRejected){
+        onRejected?.();
+        return chain;
+      },
+    };
+    return chain;
+  }
+
   class AudioContextMock {
     constructor() {
       this.state = 'running';
@@ -137,7 +155,7 @@ function installCoreMocks() {
     }
     resume() {
       this.state = 'running';
-      return Promise.resolve();
+      return createSynchronousThenable();
     }
     createOscillator() {
       return new OscillatorNodeMock();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2375,9 +2375,17 @@ document.addEventListener('visibilitychange', () => {
     closeAudioContext();
   }
 });
-function playTone(type){
+async function playTone(type){
   try{
     if(!audioCtx) audioCtx = new (window.AudioContext||window.webkitAudioContext)();
+    if(!audioCtx) return;
+    if(audioCtx.state === 'suspended'){
+      try{
+        await audioCtx.resume();
+      }catch(e){
+        /* noop */
+      }
+    }
     const osc = audioCtx.createOscillator();
     const gain = audioCtx.createGain();
     const now = audioCtx.currentTime;


### PR DESCRIPTION
## Summary
- resume the audio context in playTone when suspended before creating oscillator nodes
- make the integration test audio context mock expose a synchronous promise chain for resume

## Testing
- npm test -- app_comprehensive_integration

------
https://chatgpt.com/codex/tasks/task_e_68e6571e66f4832e98dacc7ffdfb7dbe