### PR TITLE
Enhance toast audio patterns

### DIFF
--- a/__tests__/toast_audio.test.js
+++ b/__tests__/toast_audio.test.js
@@ -1,0 +1,137 @@
+import { getToastTonePattern, mapToastToneKey, normalizeToastToneType, playToastToneForType } from '../scripts/toast-audio.js';
+
+function createMockAudioContext() {
+  const oscillatorCalls = [];
+  const gainCalls = [];
+
+  class FrequencyParam {
+    constructor() {
+      this.events = [];
+      this.value = 0;
+    }
+    setValueAtTime(value, time) {
+      this.events.push({ value, time });
+      this.value = value;
+    }
+  }
+
+  class GainParam {
+    constructor() {
+      this.cancelledAt = [];
+      this.events = [];
+      this.value = 0;
+    }
+    cancelScheduledValues(time) {
+      this.cancelledAt.push(time);
+    }
+    setValueAtTime(value, time) {
+      this.events.push({ type: 'set', value, time });
+      this.value = value;
+    }
+    linearRampToValueAtTime(value, time) {
+      this.events.push({ type: 'ramp', value, time });
+      this.value = value;
+    }
+  }
+
+  class GainNodeMock {
+    constructor() {
+      this.gain = new GainParam();
+      this.connections = [];
+    }
+    connect(node) {
+      this.connections.push(node);
+    }
+  }
+
+  class OscillatorNodeMock {
+    constructor() {
+      this.frequency = new FrequencyParam();
+      this.connections = [];
+      this.started = [];
+      this.stopped = [];
+      this.type = '';
+    }
+    connect(node) {
+      this.connections.push(node);
+    }
+    start(time) {
+      this.started.push(time);
+    }
+    stop(time) {
+      this.stopped.push(time);
+    }
+  }
+
+  return {
+    currentTime: 1,
+    destination: { id: 'dest', connections: [] },
+    createOscillator() {
+      const osc = new OscillatorNodeMock();
+      oscillatorCalls.push(osc);
+      return osc;
+    },
+    createGain() {
+      const gain = new GainNodeMock();
+      gainCalls.push(gain);
+      return gain;
+    },
+    oscillators: oscillatorCalls,
+    gains: gainCalls,
+  };
+}
+
+describe('toast audio mapping', () => {
+  test('normalizes toast types safely', () => {
+    expect(normalizeToastToneType('  SUCCESS  ')).toBe('success');
+    expect(normalizeToastToneType(null)).toBe('');
+    expect(mapToastToneKey('custom-warning')).toBe('warning');
+    expect(mapToastToneKey('unknown-type')).toBe('default');
+  });
+
+  test('info toasts schedule a single mellow tone', () => {
+    const ctx = createMockAudioContext();
+    playToastToneForType(ctx, 'INFO');
+    const osc = ctx.oscillators[0];
+    expect(osc.frequency.events).toEqual([{ value: 587.33, time: 1 }]);
+  });
+
+  test('success toasts play an ascending triad', () => {
+    const ctx = createMockAudioContext();
+    playToastToneForType(ctx, 'success');
+    const events = ctx.oscillators[0].frequency.events;
+    expect(events).toHaveLength(3);
+    expect(events.map(evt => evt.value)).toEqual([784, 1046.5, 1318.5]);
+    expect(events.map(evt => Number(evt.time.toFixed(2)))).toEqual([1, 1.14, 1.3]);
+  });
+
+  test('warning toasts pulse between mid tones', () => {
+    const ctx = createMockAudioContext();
+    playToastToneForType(ctx, 'warning');
+    const events = ctx.oscillators[0].frequency.events;
+    expect(events.map(evt => evt.value)).toEqual([784, 659.25, 784]);
+    expect(events.map(evt => Number(evt.time.toFixed(2)))).toEqual([1, 1.12, 1.24]);
+  });
+
+  test('error toasts descend sharply', () => {
+    const ctx = createMockAudioContext();
+    playToastToneForType(ctx, 'error');
+    const events = ctx.oscillators[0].frequency.events;
+    expect(events.map(evt => ({ value: evt.value, time: Number(evt.time.toFixed(2)) }))).toEqual([
+      { value: 392, time: 1 },
+      { value: 261.63, time: 1.18 },
+    ]);
+  });
+
+  test('pattern lookup returns copies for external use', () => {
+    const pattern = getToastTonePattern('success');
+    expect(pattern).toEqual([
+      { frequency: 784, duration: 0.14 },
+      { frequency: 1046.5, duration: 0.16 },
+      { frequency: 1318.5, duration: 0.18 },
+    ]);
+    pattern[0].frequency = 0;
+    const nextPattern = getToastTonePattern('success');
+    expect(nextPattern[0].frequency).toBe(784);
+  });
+});

--- a/scripts/toast-audio.js
+++ b/scripts/toast-audio.js
@@ -1,0 +1,149 @@
+const TOAST_TONE_PATTERNS = Object.freeze({
+  success: Object.freeze([
+    Object.freeze({ frequency: 784, duration: 0.14 }),
+    Object.freeze({ frequency: 1046.5, duration: 0.16 }),
+    Object.freeze({ frequency: 1318.5, duration: 0.18 }),
+  ]),
+  warning: Object.freeze([
+    Object.freeze({ frequency: 784, duration: 0.12 }),
+    Object.freeze({ frequency: 659.25, duration: 0.12 }),
+    Object.freeze({ frequency: 784, duration: 0.16 }),
+  ]),
+  error: Object.freeze([
+    Object.freeze({ frequency: 392, duration: 0.18 }),
+    Object.freeze({ frequency: 261.63, duration: 0.22 }),
+  ]),
+  info: Object.freeze([
+    Object.freeze({ frequency: 587.33, duration: 0.22 }),
+  ]),
+  default: Object.freeze([
+    Object.freeze({ frequency: 523.25, duration: 0.2 }),
+  ]),
+});
+
+const TYPE_KEYWORDS = [
+  { key: 'success', patterns: ['success', 'confirm', 'positive', 'pass', 'ok'] },
+  { key: 'warning', patterns: ['warn', 'caution', 'alert'] },
+  { key: 'error', patterns: ['error', 'fail', 'danger', 'critical', 'invalid'] },
+  { key: 'info', patterns: ['info', 'notice', 'hint', 'status'] },
+];
+
+export function normalizeToastToneType(type) {
+  if (typeof type !== 'string') return '';
+  return type.trim().toLowerCase();
+}
+
+export function mapToastToneKey(type) {
+  const normalized = normalizeToastToneType(type);
+  if (normalized && TOAST_TONE_PATTERNS[normalized]) {
+    return normalized;
+  }
+  if (normalized) {
+    const alias = TYPE_KEYWORDS.find(entry =>
+      entry.patterns.some(keyword => normalized.includes(keyword))
+    );
+    if (alias) {
+      return alias.key;
+    }
+  }
+  return 'default';
+}
+
+export function getToastTonePattern(type) {
+  const key = mapToastToneKey(type);
+  const pattern = TOAST_TONE_PATTERNS[key] || TOAST_TONE_PATTERNS.default;
+  return pattern.map(segment => ({
+    frequency: segment.frequency,
+    duration: segment.duration,
+  }));
+}
+
+export function playToastToneForType(audioCtx, type) {
+  if (!audioCtx || typeof audioCtx.createOscillator !== 'function' || typeof audioCtx.createGain !== 'function') {
+    return false;
+  }
+  const pattern = getToastTonePattern(type);
+  if (!pattern.length) {
+    return false;
+  }
+
+  const oscillator = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  if (!oscillator || !gain || typeof oscillator.connect !== 'function' || typeof gain.connect !== 'function') {
+    return false;
+  }
+
+  const now = typeof audioCtx.currentTime === 'number' ? audioCtx.currentTime : 0;
+  const rampUpDuration = 0.015;
+  const releaseDuration = 0.06;
+  const maxGain = 0.12;
+
+  oscillator.type = 'sine';
+  oscillator.connect(gain);
+  if (audioCtx.destination) {
+    gain.connect(audioCtx.destination);
+  }
+
+  const gainParam = gain.gain;
+  if (gainParam) {
+    if (typeof gainParam.cancelScheduledValues === 'function') {
+      gainParam.cancelScheduledValues(now);
+    }
+    if (typeof gainParam.setValueAtTime === 'function') {
+      gainParam.setValueAtTime(0, now);
+      if (typeof gainParam.linearRampToValueAtTime === 'function') {
+        gainParam.linearRampToValueAtTime(maxGain, now + rampUpDuration);
+      } else {
+        gainParam.setValueAtTime(maxGain, now + rampUpDuration);
+      }
+    } else {
+      gainParam.value = maxGain;
+    }
+  }
+
+  const frequencyParam = oscillator.frequency;
+  const canScheduleFrequency = frequencyParam && typeof frequencyParam.setValueAtTime === 'function';
+  let segmentStart = now;
+  let totalDuration = 0;
+  for (const segment of pattern) {
+    const frequency = Number(segment?.frequency);
+    const duration = Number(segment?.duration);
+    if (!Number.isFinite(frequency) || !Number.isFinite(duration) || duration <= 0) {
+      continue;
+    }
+    if (canScheduleFrequency) {
+      frequencyParam.setValueAtTime(frequency, segmentStart);
+    } else if (frequencyParam) {
+      frequencyParam.value = frequency;
+    }
+    segmentStart += duration;
+    totalDuration += duration;
+  }
+
+  if (totalDuration <= 0) {
+    totalDuration = 0.18;
+  }
+
+  const sustainEnd = now + totalDuration;
+  const stopTime = sustainEnd + releaseDuration;
+
+  if (gainParam && typeof gainParam.setValueAtTime === 'function') {
+    gainParam.setValueAtTime(maxGain, sustainEnd);
+    if (typeof gainParam.linearRampToValueAtTime === 'function') {
+      gainParam.linearRampToValueAtTime(0, stopTime);
+    } else {
+      gainParam.setValueAtTime(0, stopTime);
+    }
+  }
+
+  if (typeof oscillator.start === 'function') {
+    oscillator.start(now);
+  }
+  if (typeof oscillator.stop === 'function') {
+    oscillator.stop(stopTime);
+  }
+
+  return true;
+}
+
+export { TOAST_TONE_PATTERNS };


### PR DESCRIPTION
## Summary
- introduce a toast audio helper with normalized tone mapping and distinct multi-tone patterns
- update toast playback to feed normalized toast types into the shared tone scheduler
- add unit coverage verifying each toast category produces the expected tone sequence

## Testing
- npm test -- toast_audio

------
https://chatgpt.com/codex/tasks/task_e_68e6572b98ec832e874834288191ce7f