### PR TITLE
Add audio cues for dice and coin interactions

### DIFF
--- a/__tests__/roll_audio.test.js
+++ b/__tests__/roll_audio.test.js
@@ -1,0 +1,160 @@
+import { jest } from '@jest/globals';
+
+function createStubElement() {
+  return {
+    innerHTML: '',
+    value: '',
+    style: { setProperty: () => {}, getPropertyValue: () => '' },
+    classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+    setAttribute: () => {},
+    getAttribute: () => null,
+    add: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    appendChild: () => {},
+    contains: () => false,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    focus: () => {},
+    click: () => {},
+    textContent: '',
+    disabled: false,
+    checked: false,
+    hidden: false,
+    dataset: {},
+  };
+}
+
+describe('roll and coin audio cues', () => {
+  let audioContextMock;
+  let sourceNode;
+  let gainNode;
+  let originalGetElementById;
+  let originalMatchMedia;
+  let originalFetch;
+  let originalConfirm;
+  let originalAudioContext;
+  let originalWebkitAudioContext;
+
+  beforeEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+    sessionStorage.clear();
+
+    document.body.innerHTML = `
+      <div id="dice-tools">
+        <input id="dice-sides" value="20" />
+        <input id="dice-count" value="1" />
+        <span id="dice-out"></span>
+        <ul id="dice-breakdown"></ul>
+        <div id="damage-animation"></div>
+        <button id="roll-dice" type="button"></button>
+        <button id="dm-roll" type="button"></button>
+        <button id="flip" type="button"></button>
+        <span id="flip-out"></span>
+        <div id="coin-animation"></div>
+      </div>
+      <div id="log-action"></div>
+      <div id="full-log-action"></div>
+      <div id="toast"></div>
+    `;
+
+    originalGetElementById = document.getElementById;
+    const realGet = document.getElementById.bind(document);
+    document.getElementById = (id) => realGet(id) || createStubElement();
+
+    originalMatchMedia = window.matchMedia;
+    window.matchMedia = jest.fn().mockReturnValue({
+      matches: true,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    });
+
+    originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => '',
+      arrayBuffer: async () => new ArrayBuffer(0),
+    });
+    originalConfirm = window.confirm;
+    window.confirm = jest.fn(() => true);
+
+    gainNode = {
+      gain: { value: 0 },
+      connect: jest.fn(() => ({ connect: jest.fn() })),
+    };
+    sourceNode = {
+      connect: jest.fn(() => gainNode),
+      start: jest.fn(),
+    };
+    audioContextMock = {
+      sampleRate: 48000,
+      createBuffer: jest.fn((channels, length) => ({
+        getChannelData: jest.fn(() => new Float32Array(length)),
+      })),
+      createBufferSource: jest.fn(() => sourceNode),
+      createGain: jest.fn(() => gainNode),
+      resume: jest.fn().mockResolvedValue(),
+      destination: {},
+    };
+    originalAudioContext = window.AudioContext;
+    originalWebkitAudioContext = window.webkitAudioContext;
+    window.AudioContext = jest.fn(() => audioContextMock);
+    window.webkitAudioContext = undefined;
+  });
+
+  afterEach(() => {
+    document.getElementById = originalGetElementById;
+    window.matchMedia = originalMatchMedia;
+    global.fetch = originalFetch;
+    window.confirm = originalConfirm;
+    window.AudioContext = originalAudioContext;
+    window.webkitAudioContext = originalWebkitAudioContext;
+  });
+
+  async function loadMain() {
+    const module = await import('../scripts/main.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    return module;
+  }
+
+  test('triggers audio helper when rolling dice', async () => {
+    await loadMain();
+    const rollButton = document.getElementById('roll-dice');
+    window.AudioContext.mockClear();
+    audioContextMock.createBufferSource.mockClear();
+
+    rollButton.click();
+
+    expect(window.AudioContext).toHaveBeenCalled();
+    expect(audioContextMock.createBufferSource).toHaveBeenCalled();
+  });
+
+  test('triggers audio helper on dm-roll button when distinct', async () => {
+    await loadMain();
+    const dmRollButton = document.getElementById('dm-roll');
+    window.AudioContext.mockClear();
+    audioContextMock.createBufferSource.mockClear();
+
+    dmRollButton.click();
+
+    expect(window.AudioContext).toHaveBeenCalled();
+    expect(audioContextMock.createBufferSource).toHaveBeenCalled();
+  });
+
+  test('triggers audio helper on coin flip', async () => {
+    await loadMain();
+    const coinButton = document.getElementById('flip');
+    window.AudioContext.mockClear();
+    audioContextMock.createBufferSource.mockClear();
+
+    coinButton.click();
+
+    expect(window.AudioContext).toHaveBeenCalled();
+    expect(audioContextMock.createBufferSource).toHaveBeenCalled();
+  });
+});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5487,42 +5487,56 @@ function rollWithBonus(name, bonus, out, opts = {}){
 }
 renderLogs();
 renderFullLogs();
-$('roll-dice').addEventListener('click', ()=>{
-  const s = num($('dice-sides').value), c=num($('dice-count').value)||1;
-  const out = $('dice-out');
-  const breakdown = $('dice-breakdown');
-  out.classList.remove('rolling');
-  const rolls = Array.from({length:c}, ()=> 1+Math.floor(Math.random()*s));
-  const sum = rolls.reduce((a,b)=>a+b,0);
-  out.textContent = sum;
-  void out.offsetWidth; out.classList.add('rolling');
-  if (breakdown) {
-    breakdown.textContent = '';
-    if (c > 1) {
-      const fragment = document.createDocumentFragment();
-      rolls.forEach((roll, index) => {
-        const item = document.createElement('li');
-        item.textContent = String(roll);
-        item.setAttribute('aria-label', `Roll ${index + 1}: ${roll}`);
-        fragment.appendChild(item);
-      });
-      breakdown.appendChild(fragment);
-      breakdown.hidden = false;
-    } else {
-      breakdown.hidden = true;
+const rollDiceButton = $('roll-dice');
+if (rollDiceButton) {
+  rollDiceButton.addEventListener('click', ()=>{
+    const s = num($('dice-sides').value), c=num($('dice-count').value)||1;
+    const out = $('dice-out');
+    const breakdown = $('dice-breakdown');
+    out.classList.remove('rolling');
+    const rolls = Array.from({length:c}, ()=> 1+Math.floor(Math.random()*s));
+    const sum = rolls.reduce((a,b)=>a+b,0);
+    out.textContent = sum;
+    void out.offsetWidth; out.classList.add('rolling');
+    if (breakdown) {
+      breakdown.textContent = '';
+      if (c > 1) {
+        const fragment = document.createDocumentFragment();
+        rolls.forEach((roll, index) => {
+          const item = document.createElement('li');
+          item.textContent = String(roll);
+          item.setAttribute('aria-label', `Roll ${index + 1}: ${roll}`);
+          fragment.appendChild(item);
+        });
+        breakdown.appendChild(fragment);
+        breakdown.hidden = false;
+      } else {
+        breakdown.hidden = true;
+      }
     }
-  }
-  playDamageAnimation(sum);
-  logAction(`${c}×d${s}: ${rolls.join(', ')} = ${sum}`);
-  window.dmNotify?.(`Rolled ${c}d${s}: ${rolls.join(', ')} = ${sum}`);
-});
-$('flip').addEventListener('click', ()=>{
-  const v = Math.random()<.5 ? 'Heads' : 'Tails';
-  $('flip-out').textContent = v;
-  playCoinAnimation(v);
-  logAction(`Coin flip: ${v}`);
-  window.dmNotify?.(`Coin flip: ${v}`);
-});
+    playDamageAnimation(sum);
+    playStatusCue('dm-roll');
+    logAction(`${c}×d${s}: ${rolls.join(', ')} = ${sum}`);
+    window.dmNotify?.(`Rolled ${c}d${s}: ${rolls.join(', ')} = ${sum}`);
+  });
+}
+const coinFlipButton = $('flip');
+if (coinFlipButton) {
+  coinFlipButton.addEventListener('click', ()=>{
+    const v = Math.random()<.5 ? 'Heads' : 'Tails';
+    $('flip-out').textContent = v;
+    playCoinAnimation(v);
+    playStatusCue('coin-flip');
+    logAction(`Coin flip: ${v}`);
+    window.dmNotify?.(`Coin flip: ${v}`);
+  });
+}
+const dmRollButton = $('dm-roll');
+if (dmRollButton && dmRollButton !== rollDiceButton) {
+  dmRollButton.addEventListener('click', ()=>{
+    playStatusCue('dm-roll');
+  });
+}
 
 function playDamageAnimation(amount){
   if(!animationsEnabled) return Promise.resolve();
@@ -5565,6 +5579,32 @@ const AUDIO_CUE_SETTINGS = {
     partials: [
       { ratio: 1, amplitude: 1 },
       { ratio: 2, amplitude: 0.45 },
+    ],
+  },
+  'dm-roll': {
+    frequency: 320,
+    type: 'triangle',
+    duration: 0.45,
+    volume: 0.28,
+    attack: 0.01,
+    release: 0.22,
+    partials: [
+      { ratio: 1, amplitude: 1 },
+      { ratio: 1.5, amplitude: 0.5 },
+      { ratio: 2, amplitude: 0.25 },
+    ],
+  },
+  'coin-flip': {
+    frequency: 920,
+    type: 'sine',
+    duration: 0.35,
+    volume: 0.26,
+    attack: 0.008,
+    release: 0.18,
+    partials: [
+      { ratio: 1, amplitude: 1 },
+      { ratio: 2, amplitude: 0.35 },
+      { ratio: 3, amplitude: 0.18 },
     ],
   },
   heal: {


### PR DESCRIPTION
## Summary
- trigger the shared status audio helper when the dice roll, optional dm-roll, and coin flip controls are used
- define new "dm-roll" and "coin-flip" cue configurations so the sounds are distinctive
- add focused Jest coverage that asserts the audio helper runs for the roll and flip buttons

## Testing
- npm test -- roll_audio

------
https://chatgpt.com/codex/tasks/task_e_68e65737e524832ea8acfe418d6365a3