### PR TITLE
Add staggered animation for menu actions

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3235,12 +3235,21 @@ if (btnMenu && menuActions) {
     }
   };
 
+  const resetMenuButtonDelays = () => {
+    const buttons = menuActions.querySelectorAll('button');
+    buttons.forEach(btn => {
+      btn.style.removeProperty('--menu-item-index');
+      btn.style.removeProperty('animation-delay');
+    });
+  };
+
   const hideMenu = (options = {}) => {
     const immediate = options === true || options.immediate === true;
     if (!isMenuOpen && menuActions.hidden && !menuActions.classList.contains('show')) {
       return;
     }
     isMenuOpen = false;
+    resetMenuButtonDelays();
     const onTransitionEnd = event => {
       if (event.target === menuActions) finalizeHide();
     };
@@ -3263,6 +3272,15 @@ if (btnMenu && menuActions) {
     menuActions.hidden = false;
     const shouldFocusFirst = document.activeElement === btnMenu;
     requestAnimationFrame(() => {
+      const buttons = Array.from(menuActions.querySelectorAll('button')).filter(btn => {
+        if (btn.hidden) return false;
+        if (btn.getAttribute('aria-hidden') === 'true') return false;
+        const display = window.getComputedStyle(btn).display;
+        return display !== 'none';
+      });
+      buttons.forEach((btn, index) => {
+        btn.style.setProperty('--menu-item-index', index);
+      });
       menuActions.classList.add('show');
       if (shouldFocusFirst) {
         const firstFocusable = menuActions.querySelector('button, [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])');

--- a/styles/main.css
+++ b/styles/main.css
@@ -97,11 +97,16 @@ header::before{content:none}
 .actions{display:flex;gap:var(--control-gap);flex-wrap:wrap}
 .actions.actions--center{justify-content:center}
 .dropdown{position:relative;display:flex;align-items:center;justify-content:flex-end;flex:0 0 auto;justify-self:end;grid-area:menu;gap:clamp(8px,2vw,14px)}
-.menu{position:absolute;top:calc(100% + 4px);right:0;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50;opacity:0;transform:translateY(-8px) scale(.99);visibility:hidden;transition:opacity .24s cubic-bezier(.22,1,.36,1),transform .24s cubic-bezier(.22,1,.36,1);pointer-events:none;transform-origin:top right;will-change:opacity,transform}
+.menu{position:absolute;top:calc(100% + 4px);right:0;display:flex;flex-direction:column;background:var(--surface-2);border:1px solid var(--accent);border-radius:var(--radius);box-shadow:var(--shadow);z-index:50;opacity:0;transform:translateY(-8px) scale(.99);visibility:hidden;transition:opacity .24s cubic-bezier(.22,1,.36,1),transform .24s cubic-bezier(.22,1,.36,1);pointer-events:none;transform-origin:top right;will-change:opacity,transform;--menu-item-stagger:80ms}
 .menu.show{opacity:1;transform:translateY(0) scale(1);visibility:visible;pointer-events:auto}
-.menu button{background:transparent;color:var(--text);border:none;padding:clamp(6px,2.2vw,10px) clamp(10px,3.6vw,14px);text-align:left;font-weight:400;min-height:auto;white-space:nowrap}
+.menu button{background:transparent;color:var(--text);border:none;padding:clamp(6px,2.2vw,10px) clamp(10px,3.6vw,14px);text-align:left;font-weight:400;min-height:auto;white-space:nowrap;--menu-item-index:0;animation:menuItemDrop .3s cubic-bezier(.22,1,.36,1);animation-delay:calc(var(--menu-item-index, 0) * var(--menu-item-stagger, 80ms));animation-fill-mode:both;animation-play-state:paused}
+.menu.show button{animation-play-state:running}
 .menu button:hover{background:var(--accent);color:var(--text-on-accent)}
 .menu .btn-sm{justify-content:flex-start}
+
+@keyframes menuItemDrop{0%{opacity:0;transform:translateY(-6px)}to{opacity:1;transform:translateY(0)}}
+
+@media (prefers-reduced-motion:reduce){.menu button{animation:none!important;animation-delay:0s!important}}
 @media(max-width:600px){
   .actions{justify-content:center}
 }


### PR DESCRIPTION
## Summary
- add a keyframed menu item drop animation with CSS variable-based staggering and reduced-motion safeguards
- assign sequential indices to visible menu buttons so the stagger timing matches their order and clear inline styles when hiding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e673947e9c832eb1279d65e0f9b364