### PR TITLE
Add shard whirl animation to draw workflow

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1943,45 +1943,106 @@ progress::-moz-progress-bar{
   70%{transform:translateY(10px) scale(1) rotate(10deg);opacity:1;}
   100%{transform:translateY(30px) scale(0.5) rotate(20deg);opacity:0;}
 }
-#draw-lightning{
-  position:fixed;
-  inset:0;
-  pointer-events:none;
-  z-index:3500;
-}
-#draw-lightning .bolt{
-  position:absolute;
-  width:20px;
-  height:80px;
-  background:#fff;
-  clip-path:polygon(35% 0,65% 0,55% 35%,100% 35%,30% 100%,45% 60%,0 60%);
-  filter:drop-shadow(0 0 6px #fff);
-  opacity:0;
-  animation:boltStrike .6s ease-in-out forwards;
-}
-@keyframes boltStrike{
-  0%{opacity:0;transform:scale(.8);}
-  10%{opacity:1;transform:scale(1);}
-  100%{opacity:0;transform:scale(1);}
-}
+#draw-lightning,
 #draw-flash{
   position:fixed;
   inset:0;
-  background:#fff;
   pointer-events:none;
   opacity:0;
-  z-index:4000;
+  transition:opacity .18s ease-in-out;
+  z-index:3500;
 }
-#draw-flash.show{
-  animation:drawFlash 1s ease-in-out forwards;
+#draw-lightning[hidden],
+#draw-flash[hidden]{
+  display:none !important;
 }
-@keyframes drawFlash{
-  0%{opacity:0;}
-  25%{opacity:.8;}
-  50%{opacity:0;}
-  75%{opacity:.8;}
-  90%{opacity:1;}
-  100%{opacity:0;}
+#draw-lightning{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  z-index:3600;
+  filter:drop-shadow(0 0 24px rgba(59,130,246,.55));
+}
+#draw-lightning .shard-field{
+  position:relative;
+  width:min(500px,80vw);
+  height:min(500px,80vw);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  isolation:isolate;
+}
+#draw-lightning .shard-field::before{
+  content:"";
+  width:min(140px,28vw);
+  height:min(140px,28vw);
+  border-radius:50%;
+  background:radial-gradient(circle,rgba(255,255,255,.75) 0%,rgba(96,165,250,.55) 50%,rgba(59,130,246,0) 80%);
+  opacity:.9;
+  box-shadow:0 0 32px rgba(59,130,246,.45),0 0 64px rgba(59,130,246,.35);
+}
+#draw-lightning .shard{
+  --start-angle:0deg;
+  --orbit-radius:160px;
+  --shard-delay:0ms;
+  --shard-duration:1400ms;
+  position:absolute;
+  top:50%;
+  left:50%;
+  width:min(48px,9.5vw);
+  height:min(120px,22vw);
+  margin:-60px 0 0 -24px;
+  background:linear-gradient(180deg,rgba(255,255,255,.95) 0%,rgba(125,211,252,.88) 45%,rgba(59,130,246,.35) 80%,rgba(59,130,246,0) 100%);
+  clip-path:polygon(46% 0,60% 28%,96% 44%,70% 52%,92% 100%,44% 70%,14% 82%,32% 46%,4% 34%,28% 22%);
+  mix-blend-mode:screen;
+  opacity:0;
+  transform-origin:center;
+  animation:shardWhirl var(--shard-duration) cubic-bezier(.22,1,.36,1) var(--shard-delay) forwards;
+  animation-play-state:paused;
+  will-change:transform,opacity;
+}
+#draw-lightning.is-active{opacity:1;}
+#draw-lightning.is-active .shard{animation-play-state:running;}
+#draw-lightning .shard:nth-child(odd){filter:drop-shadow(0 0 18px rgba(191,219,254,.9));}
+#draw-lightning .shard:nth-child(even){filter:drop-shadow(0 0 22px rgba(125,211,252,.7));}
+
+#draw-flash{
+  background:radial-gradient(circle at center,rgba(255,255,255,.85) 0%,rgba(191,219,254,.6) 28%,rgba(59,130,246,.35) 60%,rgba(14,17,23,.8) 100%);
+  mix-blend-mode:screen;
+  z-index:3500;
+}
+#draw-flash::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(circle at center,rgba(255,255,255,.65) 0%,rgba(59,130,246,.35) 45%,rgba(59,130,246,0) 70%);
+}
+#draw-flash.is-active{animation:shardFlash 1.4s ease-in-out forwards;opacity:1;}
+
+@keyframes shardWhirl{
+  0%{
+    opacity:0;
+    transform:translate(-50%,-50%) rotate(var(--start-angle)) translateX(var(--orbit-radius)) scale(.55);
+  }
+  20%{
+    opacity:1;
+  }
+  68%{
+    opacity:1;
+    transform:translate(-50%,-50%) rotate(calc(var(--start-angle) + 240deg)) translateX(calc(var(--orbit-radius) * .42)) scale(.88);
+  }
+  100%{
+    opacity:0;
+    transform:translate(-50%,-50%) rotate(calc(var(--start-angle) + 360deg)) translateX(0px) scale(.35);
+  }
+}
+
+@keyframes shardFlash{
+  0%{opacity:0;transform:scale(1.05);}
+  25%{opacity:.92;transform:scale(1);}
+  55%{opacity:.65;transform:scale(1.03);}
+  80%{opacity:.85;transform:scale(1.01);}
+  100%{opacity:0;transform:scale(1.08);}
 }
 .sp-grid{display:grid;width:100%;grid-template-columns:repeat(auto-fit,minmax(90px,1fr));gap:8px;}
 .sp-grid .btn-sm{width:100%;}


### PR DESCRIPTION
## Summary
- restyle the draw flash/lightning overlays with shardWhirl-driven orbiting shards and hide them by default
- add a shard whirl controller in `shard-of-many-fates.js` that drives the animation and reuse it for reveal effects
- start the whirl when a draw is confirmed so result handling waits on the animation and cleans up even on cancellation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67d9dde70832e9af2e49cd7cc9728