### PR TITLE
Add campaign log editing UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1313,6 +1313,24 @@
   </div>
 </div>
 
+<div class="overlay hidden" id="modal-campaign-edit" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Edit Campaign Entry</h3>
+    <div id="campaign-edit-meta" class="campaign-edit-meta" aria-live="polite"></div>
+    <label for="campaign-edit-text" class="sr-only">Campaign log entry text</label>
+    <textarea id="campaign-edit-text" data-view-allow rows="3"></textarea>
+    <div class="actions">
+      <button id="campaign-edit-save" class="btn-sm" type="button">Save Changes</button>
+      <button class="btn-sm" type="button" data-close>Cancel</button>
+    </div>
+  </div>
+</div>
+
 <div class="overlay hidden" id="modal-campaign-backlog" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
     <button class="x" data-close aria-label="Close">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2371,6 +2371,19 @@ function applyDeleteIcons(root=document){
   qsa('button[data-del], button[data-act="del"]', root).forEach(applyDeleteIcon);
 }
 
+function applyEditIcon(btn){
+  if(!btn) return;
+  btn.innerHTML = ICON_EDIT;
+  if(!btn.getAttribute('aria-label')){
+    btn.setAttribute('aria-label','Edit');
+  }
+  Object.assign(btn.style, DELETE_ICON_STYLE);
+}
+
+function applyEditIcons(root=document){
+  qsa('button[data-act="edit"]', root).forEach(applyEditIcon);
+}
+
 async function applyLockIcon(btn){
   if(!btn) return;
   const name = btn.dataset.lock;
@@ -5770,8 +5783,9 @@ function renderCampaignCollection(entries, targetId, emptyMessage){
   container.innerHTML = entries
     .slice()
     .reverse()
-    .map(entry=>`<div class="catalog-item" data-entry-id="${entry.id}"><div>${fmt(entry.t)} ${entry.name}</div><div>${entry.text}</div><div><button class="btn-sm" data-entry-id="${entry.id}" aria-label="Delete entry"></button></div></div>`)
+    .map(entry=>`<div class="catalog-item" data-entry-id="${entry.id}"><div>${fmt(entry.t)} ${entry.name}</div><div>${entry.text}</div><div class="catalog-item__controls"><button class="btn-sm" type="button" data-entry-id="${entry.id}" data-act="edit" aria-label="Edit entry"></button><button class="btn-sm" type="button" data-entry-id="${entry.id}" data-act="del" aria-label="Delete entry"></button></div></div>`)
     .join('');
+  applyEditIcons(container);
   applyDeleteIcons(container);
 }
 
@@ -5872,6 +5886,28 @@ function queueCampaignLogEntry(text, options = {}){
   })();
   return entry;
 }
+
+function updateCampaignLogEntry(id, text, options = {}){
+  if(typeof id !== 'string' || !id) return null;
+  const existing = campaignLogEntries.find(entry => entry.id === id);
+  if(!existing) return null;
+  const normalizedText = typeof text === 'string' ? text : '';
+  const updated = { ...existing, text: normalizedText };
+  mergeCampaignEntry(updated);
+  if(options.sync === false) return updated;
+  (async()=>{
+    try{
+      const saved = await appendCampaignLogEntry(updated);
+      if(saved) mergeCampaignEntry(saved);
+    }catch(err){
+      console.error('Failed to sync campaign log entry edit', err);
+      try{ toast('Failed to sync campaign log entry edit', 'error'); }catch{}
+    }
+  })();
+  return updated;
+}
+
+window.updateCampaignLogEntry = updateCampaignLogEntry;
 
 updateCampaignLogViews();
 const CONTENT_UPDATE_EVENT = 'cc:content-updated';
@@ -6784,11 +6820,57 @@ $('roll-death-save')?.addEventListener('click', ()=>{
   }
   checkDeathProgress();
 });
-async function handleCampaignLogDelete(e){
+let activeCampaignEditEntryId = null;
+
+function resetCampaignLogEditor(){
+  activeCampaignEditEntryId = null;
+  const field = $('campaign-edit-text');
+  if(field){
+    field.value = '';
+  }
+  const meta = $('campaign-edit-meta');
+  if(meta){
+    meta.textContent = '';
+  }
+}
+
+function openCampaignLogEditor(id){
+  const entry = campaignLogEntries.find(item => item.id === id);
+  if(!entry) return;
+  activeCampaignEditEntryId = id;
+  const field = $('campaign-edit-text');
+  if(field){
+    field.value = entry.text;
+  }
+  const meta = $('campaign-edit-meta');
+  if(meta){
+    meta.textContent = `${fmt(entry.t)} ${entry.name}`;
+  }
+  show('modal-campaign-edit');
+  if(typeof requestAnimationFrame === 'function'){
+    requestAnimationFrame(()=>{
+      const textarea = $('campaign-edit-text');
+      if(!textarea) return;
+      textarea.focus();
+      const end = textarea.value.length;
+      try{ textarea.setSelectionRange(end, end); }catch{}
+    });
+  }else if(field){
+    field.focus();
+  }
+}
+
+async function handleCampaignLogClick(e){
   const btn = e.target.closest('button[data-entry-id]');
   if(!btn) return;
   const id = btn.dataset.entryId;
   if(!id) return;
+  const action = btn.dataset.act || 'del';
+  if(action === 'edit'){
+    openCampaignLogEditor(id);
+    return;
+  }
+  if(action !== 'del') return;
   if(!confirm('Delete this entry?')) return;
   const removed = removeCampaignEntry(id);
   if(!removed) return;
@@ -6825,12 +6907,55 @@ if (btnCampaignAdd) {
 
 const campaignLogContainer = $('campaign-log');
 if(campaignLogContainer){
-  campaignLogContainer.addEventListener('click', handleCampaignLogDelete);
+  campaignLogContainer.addEventListener('click', handleCampaignLogClick);
 }
 
 const campaignBacklogContainer = $('campaign-backlog');
 if(campaignBacklogContainer){
-  campaignBacklogContainer.addEventListener('click', handleCampaignLogDelete);
+  campaignBacklogContainer.addEventListener('click', handleCampaignLogClick);
+}
+
+const campaignEditSave = $('campaign-edit-save');
+if(campaignEditSave){
+  campaignEditSave.addEventListener('click', ()=>{
+    if(!activeCampaignEditEntryId) return;
+    const field = $('campaign-edit-text');
+    if(!field) return;
+    const text = field.value.trim();
+    if(!text){
+      try{ toast('Campaign log text is required', 'error'); }catch{}
+      return;
+    }
+    const current = campaignLogEntries.find(entry => entry.id === activeCampaignEditEntryId);
+    if(!current){
+      hide('modal-campaign-edit');
+      resetCampaignLogEditor();
+      return;
+    }
+    if(current.text === text){
+      hide('modal-campaign-edit');
+      resetCampaignLogEditor();
+      return;
+    }
+    updateCampaignLogEntry(activeCampaignEditEntryId, text);
+    pushHistory();
+    try{ toast('Campaign log entry updated', 'success'); }catch{}
+    hide('modal-campaign-edit');
+    resetCampaignLogEditor();
+  });
+}
+
+qsa('#modal-campaign-edit [data-close]').forEach(btn=>{
+  btn.addEventListener('click', resetCampaignLogEditor);
+});
+
+const campaignEditOverlay = $('modal-campaign-edit');
+if(campaignEditOverlay){
+  campaignEditOverlay.addEventListener('click', event=>{
+    if(event.target === campaignEditOverlay){
+      resetCampaignLogEditor();
+    }
+  }, { capture: true });
 }
 
 const btnCampaignBacklog = $('campaign-view-backlog');
@@ -12640,6 +12765,7 @@ setupPerkSelect('power-style','power-style-perks', POWER_STYLE_PERKS);
 setupPerkSelect('origin','origin-perks', ORIGIN_PERKS);
 setupFactionRepTracker(handlePerkEffects, pushHistory);
 updateDerived();
+applyEditIcons();
 applyDeleteIcons();
 applyLockIcons();
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- add inline edit controls to each campaign log entry and reuse icon styling
- introduce a dedicated edit modal with local state management and expose update helpers for syncing edits
- ensure campaign log views re-render with edit actions while keeping existing dialogs open

## Testing
- npm test -- --watch=false *(fails: existing jsdom/browser-related errors in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e67fdff0f0832e97ecd45738c175ab