### PR TITLE
Add credits ledger tracking and modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,7 @@
         <button id="btn-load" class="btn-sm">Load / Save</button>
         <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
         <button id="btn-log" class="btn-sm">Action Log</button>
+        <button id="btn-credits-ledger" class="btn-sm">Credits Ledger</button>
         <button id="btn-campaign" class="btn-sm">Campaign Log</button>
         <button id="btn-rules" class="btn-sm">Rules</button>
         <button id="btn-help" class="btn-sm">Help</button>
@@ -813,6 +814,16 @@
           </select>
           <button id="credits-submit" class="btn-sm" type="button">Apply</button>
         </div>
+        <div class="credits-reason">
+          <label for="credits-reason" class="sr-only">Reason</label>
+          <input
+            id="credits-reason"
+            data-view-allow
+            type="text"
+            placeholder="Reason (e.g., mission payout, equipment purchase)"
+            autocomplete="off"
+          />
+        </div>
         <input id="credits" type="hidden" value="0"/>
       </div>
       <div class="card card-wide">
@@ -1290,6 +1301,25 @@
     <h3>Action Log</h3>
     <div id="log-action" class="catalog"></div>
     <div class="actions"><button id="log-full" class="btn-sm">Full Log</button><button class="btn-sm" data-close>Close</button></div>
+  </div>
+</div>
+
+
+<div class="overlay hidden" id="modal-credits-ledger" aria-hidden="true">
+  <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
+    <button class="x" data-close aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+    <h3>Credits Ledger</h3>
+    <div class="credits-ledger__filters" role="group" aria-label="Filter credits ledger entries">
+      <button class="btn-sm" type="button" data-ledger-filter="all" aria-pressed="true">All</button>
+      <button class="btn-sm" type="button" data-ledger-filter="gain" aria-pressed="false">Gains</button>
+      <button class="btn-sm" type="button" data-ledger-filter="spend" aria-pressed="false">Spends</button>
+    </div>
+    <div id="credits-ledger-list" class="catalog" aria-live="polite"></div>
+    <div class="actions"><button class="btn-sm" data-close>Close</button></div>
   </div>
 </div>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4850,6 +4850,7 @@ const elCredits = $('credits');
 const elCreditsPill = $('credits-total-pill');
 const elCreditsGearTotal = $('credits-gear-total');
 const elCreditsGearRemaining = $('credits-gear-remaining');
+const elCreditsReason = $('credits-reason');
 
 if (elPowerStylePrimary) {
   elPowerStylePrimary.addEventListener('change', () => {
@@ -5348,6 +5349,76 @@ function formatCreditsValue(value) {
   return safe < 0 ? `-${formatted}` : formatted;
 }
 
+const CREDITS_LEDGER_STORAGE_KEY = 'credits-ledger';
+const CREDITS_LEDGER_MAX_ENTRIES = 200;
+let creditsLedgerEntries = [];
+
+function loadCreditsLedgerEntries() {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const stored = localStorage.getItem(CREDITS_LEDGER_STORAGE_KEY);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map(entry => {
+      const amount = Number(entry?.amount);
+      const balance = Number(entry?.balance);
+      const ts = Number(entry?.ts);
+      const rawReason = typeof entry?.reason === 'string' ? entry.reason.trim() : '';
+      return {
+        amount: Number.isFinite(amount) ? amount : 0,
+        balance: Number.isFinite(balance) ? balance : 0,
+        reason: rawReason || 'Adjustment',
+        ts: Number.isFinite(ts) ? ts : Date.now(),
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+function persistCreditsLedgerEntries(entries) {
+  creditsLedgerEntries = entries.slice(-CREDITS_LEDGER_MAX_ENTRIES);
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(CREDITS_LEDGER_STORAGE_KEY, JSON.stringify(creditsLedgerEntries));
+  } catch {}
+}
+
+function getCreditsLedgerEntries() {
+  return creditsLedgerEntries.slice();
+}
+
+function recordCreditsLedgerEntry(entry) {
+  const amount = Number(entry?.amount);
+  const balance = Number(entry?.balance);
+  const ts = Number(entry?.ts);
+  const normalized = {
+    amount: Number.isFinite(amount) ? amount : 0,
+    balance: Number.isFinite(balance) ? balance : 0,
+    reason:
+      typeof entry?.reason === 'string' && entry.reason.trim()
+        ? entry.reason.trim()
+        : amount > 0
+          ? 'Credits gained'
+          : 'Credits spent',
+    ts: Number.isFinite(ts) ? ts : Date.now(),
+  };
+  const next = getCreditsLedgerEntries();
+  next.push(normalized);
+  persistCreditsLedgerEntries(next);
+  if (typeof document !== 'undefined' && typeof document.dispatchEvent === 'function') {
+    try {
+      document.dispatchEvent(new CustomEvent('credits-ledger-updated', { detail: normalized }));
+    } catch {}
+  }
+}
+
+creditsLedgerEntries = loadCreditsLedgerEntries();
+if (creditsLedgerEntries.length > CREDITS_LEDGER_MAX_ENTRIES) {
+  persistCreditsLedgerEntries(creditsLedgerEntries);
+}
+
 function calculateEquippedGearTotal() {
   const gearLists = ['weapons', 'armors', 'items'];
   let total = 0;
@@ -5389,7 +5460,7 @@ function updateCreditsDisplay(){
   updateCreditsGearSummary();
 }
 
-function setCredits(v){
+function setCredits(v, options = {}){
   const prev = num(elCredits.value)||0;
   const total = Math.max(0, v);
   elCredits.value = total;
@@ -5399,6 +5470,17 @@ function setCredits(v){
     const actionKey = diff > 0 ? 'credits-gain' : 'credits-spend';
     playActionCue(actionKey);
     window.dmNotify?.(`Credits ${diff>0?'gained':'spent'} ${Math.abs(diff)} (now ${total})`);
+    const providedReason = typeof options === 'object' && options !== null ? options.reason : undefined;
+    const entryReason = typeof providedReason === 'string' && providedReason.trim()
+      ? providedReason.trim()
+      : diff > 0
+        ? 'Credits gained'
+        : 'Credits spent';
+    recordCreditsLedgerEntry({
+      amount: diff,
+      balance: total,
+      reason: entryReason,
+    });
     pushHistory();
     const name = currentCharacter();
     if (name) {
@@ -5422,11 +5504,20 @@ function notifyInsufficientCredits(message = "You don't have enough Credits for 
 }
 
 $('credits-submit').addEventListener('click', ()=>{
-  const amt = num($('credits-amt').value)||0;
+  const amtField = $('credits-amt');
+  const amt = num(amtField?.value)||0;
   if(!amt) return;
   const mode = $('credits-mode').value;
-  setCredits(num(elCredits.value) + (mode==='add'? amt : -amt));
-  $('credits-amt').value='';
+  const delta = mode==='add'? amt : -amt;
+  const current = num(elCredits.value) || 0;
+  const providedReason = elCreditsReason && typeof elCreditsReason.value === 'string'
+    ? elCreditsReason.value.trim()
+    : '';
+  const defaultReason = mode==='add' ? 'Manual credit gain' : 'Manual credit spend';
+  const reason = providedReason || defaultReason;
+  setCredits(current + delta, { reason });
+  if (amtField) amtField.value='';
+  if (elCreditsReason) elCreditsReason.value='';
 });
 
 
@@ -6851,6 +6942,72 @@ const btnLogFull = $('log-full');
 if (btnLogFull) {
   btnLogFull.addEventListener('click', ()=>{ renderFullLogs(); hide('modal-log'); show('modal-log-full'); });
 }
+const creditsLedgerList = $('credits-ledger-list');
+const creditsLedgerFilterButtons = Array.from(qsa('[data-ledger-filter]'));
+let creditsLedgerFilter = 'all';
+
+function setCreditsLedgerFilter(filter) {
+  const normalized = filter === 'gain' || filter === 'spend' ? filter : 'all';
+  creditsLedgerFilter = normalized;
+  creditsLedgerFilterButtons.forEach(btn => {
+    const target = btn?.dataset?.ledgerFilter || 'all';
+    btn.setAttribute('aria-pressed', target === normalized ? 'true' : 'false');
+  });
+  renderCreditsLedger();
+}
+
+function renderCreditsLedger() {
+  if (!creditsLedgerList) return;
+  const entries = (() => {
+    const all = getCreditsLedgerEntries();
+    if (creditsLedgerFilter === 'gain') return all.filter(entry => entry.amount > 0);
+    if (creditsLedgerFilter === 'spend') return all.filter(entry => entry.amount < 0);
+    return all;
+  })()
+    .slice()
+    .reverse();
+  if (!entries.length) {
+    creditsLedgerList.innerHTML = '<p class="credits-ledger__empty">No ledger entries yet.</p>';
+    return;
+  }
+  const html = entries
+    .map(entry => {
+      const amountDisplay = entry.amount > 0
+        ? `+${formatCreditsValue(entry.amount)}`
+        : formatCreditsValue(entry.amount);
+      const balanceDisplay = formatCreditsValue(entry.balance);
+      const reasonText = escapeHtml(entry.reason || 'Adjustment');
+      const ts = Number(entry.ts);
+      const timestampLabel = Number.isFinite(ts) ? new Date(ts).toLocaleString() : '';
+      const timestampHtml = timestampLabel
+        ? `<div class="small credits-ledger__timestamp">${escapeHtml(timestampLabel)}</div>`
+        : '';
+      const typeClass = entry.amount >= 0 ? 'credits-ledger__entry--gain' : 'credits-ledger__entry--spend';
+      return `<div class="catalog-item credits-ledger__entry ${typeClass}"><div class="credits-ledger__line"><span class="credits-ledger__amount">${escapeHtml(amountDisplay)}</span><span class="credits-ledger__balance">Balance: ${escapeHtml(balanceDisplay)}</span></div><div class="small">${reasonText}</div>${timestampHtml}</div>`;
+    })
+    .join('');
+  creditsLedgerList.innerHTML = html;
+}
+
+creditsLedgerFilterButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const target = btn?.dataset?.ledgerFilter || 'all';
+    setCreditsLedgerFilter(target);
+  });
+});
+
+const btnCreditsLedger = $('btn-credits-ledger');
+if (btnCreditsLedger) {
+  btnCreditsLedger.addEventListener('click', () => {
+    setCreditsLedgerFilter('all');
+    show('modal-credits-ledger');
+  });
+}
+
+document.addEventListener('credits-ledger-updated', () => {
+  renderCreditsLedger();
+});
+
 const btnCampaign = $('btn-campaign');
 if (btnCampaign) {
   btnCampaign.addEventListener('click', ()=>{ updateCampaignLogViews(); show('modal-campaign'); });
@@ -11171,21 +11328,24 @@ function addEntryToSheet(entry, { toastMessage = 'Added to sheet', cardInfoOverr
   });
   const formattedPrice = hasPrice ? formatPrice(priceValue) : '';
   const isManualCard = !!(pending && pending.isConnected);
+  const entryName = info?.data?.name || entry?.name || 'item';
   let creditsDeducted = false;
   if (hasPrice && !isManualCard && typeof setCredits === 'function' && elCredits) {
     let shouldDeduct = false;
     if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
-      const entryName = info?.data?.name || entry?.name || 'this item';
-      shouldDeduct = window.confirm(`Subtract ${formattedPrice} from Credits for ${entryName}?`);
+      const confirmName = entryName || 'this item';
+      shouldDeduct = window.confirm(`Subtract ${formattedPrice} from Credits for ${confirmName}?`);
     }
     if (shouldDeduct) {
       const available = num(elCredits.value) || 0;
       if (available < priceValue) {
         notifyInsufficientCredits(`You don't have enough Credits to spend ${formattedPrice}.`);
       } else {
-        setCredits(available - priceValue);
+        const ledgerReason = formattedPrice
+          ? `Purchased ${entryName} for ${formattedPrice}`
+          : `Purchased ${entryName}`;
+        setCredits(available - priceValue, { reason: ledgerReason });
         creditsDeducted = true;
-        const entryName = info?.data?.name || entry?.name || 'item';
         try {
           logAction(`Credits spent automatically: ${formattedPrice} on ${entryName}.`);
         } catch {}

--- a/styles/main.css
+++ b/styles/main.css
@@ -2058,6 +2058,17 @@ progress::-moz-progress-bar{
 .catalog-item:last-child{border-bottom:none}
 .catalog-item.active{background:var(--accent);color:var(--text-on-accent)}
 .catalog-item.active .pill{border-color:var(--text-on-accent);color:var(--text-on-accent)}
+.credits-reason{margin-top:10px}
+.credits-reason input{width:100%}
+.credits-ledger__filters{display:flex;flex-wrap:wrap;gap:8px;justify-content:center;margin-bottom:12px}
+.credits-ledger__filters .btn-sm[aria-pressed="true"]{background:var(--accent);color:var(--text-on-accent)}
+.catalog-item.credits-ledger__entry{display:flex;flex-direction:column;align-items:flex-start;gap:4px}
+.credits-ledger__line{display:flex;justify-content:space-between;gap:12px;width:100%;font-weight:600}
+.credits-ledger__amount,.credits-ledger__balance{font-variant-numeric:tabular-nums}
+.credits-ledger__entry--gain .credits-ledger__amount{color:var(--success)}
+.credits-ledger__entry--spend .credits-ledger__amount{color:var(--error)}
+.credits-ledger__timestamp{color:var(--muted)}
+.credits-ledger__empty{text-align:center;padding:16px 8px;color:var(--muted)}
 #recover-list .recover-group{margin-bottom:16px}
 #recover-list .recover-group:last-child{margin-bottom:0}
 #recover-list .recover-group h4{margin:8px 4px;font-size:1rem;font-weight:600;color:var(--muted)}


### PR DESCRIPTION
## Summary
- persist detailed credits ledger entries (amount, reason, balance, timestamp) in localStorage when the balance changes
- add a Credits Ledger modal with gain/spend filters plus styling and menu access, and expose a manual adjustment reason input
- provide descriptive reasons for automatic catalog deductions and manual adjustments when updating credits

## Testing
- npm test *(fails: existing jsdom DOM/mocking errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e67fbdcf2c832ebca1649cfd73e5ce