### PR TITLE
Add cloud sync management panel

### DIFF
--- a/__tests__/mini_games_player_invite.test.js
+++ b/__tests__/mini_games_player_invite.test.js
@@ -165,6 +165,11 @@ async function initMainModule() {
     beginQueuedSyncFlush: () => {},
     getLastSyncStatus: () => 'idle',
     subscribeSyncStatus: () => () => {},
+    listQueuedCloudSaves: async () => [],
+    clearQueuedCloudSaves: async () => {},
+    deleteQueuedCloudSave: async () => {},
+    flushQueuedCloudSaves: async () => {},
+    getLastSyncTimestamp: () => null,
   }));
 
   jest.unstable_mockModule('../scripts/pin.js', () => ({

--- a/index.html
+++ b/index.html
@@ -155,18 +155,21 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15m-15 5.25h15m-15 5.25h15"/>
         </svg>
       </button>
-      <span
+      <button
         id="cloud-sync-status"
         class="sync-status-indicator"
         data-status="online"
-        role="status"
+        type="button"
         aria-live="polite"
+        aria-haspopup="dialog"
+        aria-expanded="false"
+        aria-controls="cloud-sync-panel"
         aria-label="Cloud sync status: Online"
         title="Online"
       >
         <span class="sync-status-indicator__light" aria-hidden="true"></span>
         <span class="sr-only" data-sync-status-label>Online</span>
-      </span>
+      </button>
       <div id="menu-actions" class="menu" hidden>
         <button id="btn-load" class="btn-sm">Load / Save</button>
         <button id="btn-enc" class="btn-sm" aria-label="Encounter / Initiative" title="Encounter / Initiative">Encounter / Initiative</button>
@@ -264,6 +267,46 @@
       </span>
       <div class="news-ticker__track news-ticker__track--m24n" data-m24n-ticker-track>
         <span class="news-ticker__text news-ticker__text--m24n" data-m24n-ticker-text>Loading MN24/7 feed…</span>
+      </div>
+    </div>
+  </div>
+  <div
+    id="cloud-sync-panel"
+    class="sync-panel"
+    role="dialog"
+    aria-modal="false"
+    aria-labelledby="cloud-sync-panel-title"
+    hidden
+  >
+    <div class="sync-panel__header">
+      <h2 id="cloud-sync-panel-title">Cloud sync</h2>
+      <button type="button" class="btn-sm" data-sync-panel-close>Close</button>
+    </div>
+    <div class="sync-panel__body">
+      <div class="sync-panel__status" data-sync-panel-status-container>
+        <p class="sync-panel__status-line">
+          <strong>Status:</strong>
+          <span data-sync-panel-status>Online</span>
+        </p>
+        <p class="sync-panel__last-sync">
+          <strong>Last sync:</strong>
+          <span data-sync-panel-last-sync>Never</span>
+        </p>
+      </div>
+      <div class="sync-panel__actions">
+        <button type="button" class="btn-sm" data-sync-panel-sync>Sync now</button>
+        <button type="button" class="btn-sm" data-sync-panel-clear-queue>Clear queue</button>
+        <button type="button" class="btn-sm" data-sync-panel-clear-errors>Clear issues</button>
+      </div>
+      <div class="sync-panel__section">
+        <h3 id="cloud-sync-panel-queue-title">Queued saves</h3>
+        <p class="sync-panel__empty" data-sync-panel-queue-empty>All changes are synced.</p>
+        <ul class="sync-panel__list" aria-labelledby="cloud-sync-panel-queue-title" data-sync-panel-queue></ul>
+      </div>
+      <div class="sync-panel__section">
+        <h3 id="cloud-sync-panel-errors-title">Sync issues</h3>
+        <p class="sync-panel__empty" data-sync-panel-errors-empty hidden>No sync issues logged.</p>
+        <ul class="sync-panel__list" aria-labelledby="cloud-sync-panel-errors-title" data-sync-panel-errors></ul>
       </div>
     </div>
   </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -110,6 +110,123 @@ header::before{content:none}
 @media(max-width:600px){
   .actions{justify-content:center}
 }
+.sync-panel{
+  position:absolute;
+  top:calc(100% + 12px);
+  right:calc(clamp(16px, 5vw, 32px) + env(safe-area-inset-right, 0px));
+  width:min(360px, calc(100vw - 32px));
+  display:flex;
+  flex-direction:column;
+  gap:clamp(12px,3vw,18px);
+  padding:clamp(12px,3vw,18px);
+  background:var(--surface-2);
+  border:1px solid var(--accent);
+  border-radius:var(--radius);
+  box-shadow:var(--shadow);
+  z-index:80;
+  color:var(--text);
+}
+.sync-panel[hidden]{
+  display:none;
+}
+.sync-panel__header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:clamp(8px,2.4vw,12px);
+}
+.sync-panel__header h2{
+  margin:0;
+  font-size:clamp(1.1rem,3.2vw,1.35rem);
+}
+.sync-panel__body{
+  display:flex;
+  flex-direction:column;
+  gap:clamp(10px,2.6vw,14px);
+}
+.sync-panel__status-line,
+.sync-panel__last-sync{
+  margin:0;
+  font-size:clamp(.85rem,2.4vw,1rem);
+  display:flex;
+  gap:6px;
+  align-items:center;
+}
+.sync-panel__last-sync time,
+.sync-panel__status span{word-break:break-word;}
+.sync-panel__actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:clamp(6px,2.2vw,10px);
+}
+.sync-panel__section{
+  display:flex;
+  flex-direction:column;
+  gap:clamp(6px,2vw,10px);
+}
+.sync-panel__section h3{
+  margin:0;
+  font-size:clamp(1rem,2.8vw,1.15rem);
+}
+.sync-panel__empty{
+  margin:0;
+  font-size:clamp(.8rem,2.4vw,.95rem);
+  color:var(--muted);
+}
+.sync-panel__list{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+  flex-direction:column;
+  gap:clamp(6px,2vw,10px);
+}
+.sync-panel__item{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:clamp(6px,2vw,10px);
+  background:color-mix(in srgb,var(--surface) 80%, transparent 20%);
+  border:1px solid color-mix(in srgb,var(--accent) 50%, transparent);
+  border-radius:calc(var(--radius) - 2px);
+  padding:clamp(8px,2.6vw,12px);
+}
+.sync-panel__item-details{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  font-size:clamp(.78rem,2.2vw,.95rem);
+}
+.sync-panel__item-title{
+  font-weight:600;
+  word-break:break-word;
+}
+.sync-panel__item-meta{
+  color:var(--muted);
+  font-size:clamp(.7rem,2vw,.85rem);
+}
+.sync-panel__item-actions{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.sync-panel__item-actions .btn-sm{
+  padding:clamp(4px,1.8vw,8px) clamp(6px,2.6vw,10px);
+  font-size:clamp(.65rem,2vw,.85rem);
+}
+.sync-panel__error{
+  border-color:color-mix(in srgb,var(--error) 45%, transparent);
+  background:color-mix(in srgb,var(--error) 18%, transparent);
+}
+.sync-panel__error .sync-panel__item-title{color:var(--error);}
+.sync-panel__timestamp{font-variant-numeric:tabular-nums;}
+
+@media(max-width:600px){
+  .sync-panel{
+    right:calc(clamp(12px, 4vw, 20px) + env(safe-area-inset-right, 0px));
+    width:calc(100vw - clamp(24px, 10vw, 40px));
+  }
+}
 .icon,.tab{padding:clamp(2px,1vw,4px);height:calc(var(--icon-size)*1.05);min-height:calc(var(--icon-size)*1.2);border-radius:var(--radius);background:var(--surface-2);border:1px solid var(--accent);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;transition:var(--transition);cursor:pointer;touch-action:manipulation}
 .icon{width:calc(var(--icon-size)*1.8)}
 .tab{
@@ -216,6 +333,8 @@ a:hover,a:focus{color:var(--accent-2);text-decoration:underline}
   transition:background .3s ease,border-color .3s ease,box-shadow .3s ease;
   min-width:calc(var(--sync-indicator-size) + clamp(6px,1.4vw,10px));
   min-height:calc(var(--sync-indicator-size) + clamp(6px,1.4vw,10px));
+  cursor:pointer;
+  touch-action:manipulation;
 }
 
 .sync-status-indicator__light{


### PR DESCRIPTION
## Summary
- replace the cloud sync status badge with a button that opens a new detail popover showing status, last sync time, queue contents, and error log controls
- extend storage helpers and the service worker to expose queued save management, last-sync tracking, and sync event broadcasts used by the panel
- style the new popover, update mocks for storage in tests, and surface manual sync actions with retry and clear options

## Testing
- `npm test -- --watchAll=false` *(fails: jsdom environment lacks full DOM APIs and service worker network mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68e67f36acdc832ea926303680c8e772